### PR TITLE
Use absolute paths for custom code files for AWS docs examples

### DIFF
--- a/sagemaker-python-sdk/mxnet_mnist/mxnet_mnist.ipynb
+++ b/sagemaker-python-sdk/mxnet_mnist/mxnet_mnist.ipynb
@@ -42,7 +42,7 @@
    "source": [
     "from sagemaker.mxnet import MXNet\n",
     "\n",
-    "mnist_estimator = MXNet(entry_point='mnist.py',\n",
+    "mnist_estimator = MXNet(entry_point='/home/ec2-user/sample-notebooks/sagemaker-python-sdk/mxnet_mnist/mnist.py',\n",
     "                        role=role,\n",
     "                        output_path=model_artifacts_location,\n",
     "                        code_location=custom_code_upload_location,\n",
@@ -115,7 +115,7 @@
    "outputs": [],
    "source": [
     "from IPython.display import HTML\n",
-    "HTML(open(\"input.html\").read())"
+    "HTML(open(\"/home/ec2-user/sample-notebooks/sagemaker-python-sdk/mxnet_mnist/input.html\").read())"
    ]
   },
   {

--- a/sagemaker-python-sdk/tensorflow_iris_dnn_classifier_using_estimators/tensorflow_iris_dnn_classifier_using_estimators.ipynb
+++ b/sagemaker-python-sdk/tensorflow_iris_dnn_classifier_using_estimators/tensorflow_iris_dnn_classifier_using_estimators.ipynb
@@ -286,7 +286,7 @@
    "source": [
     "from sagemaker.tensorflow import TensorFlow\n",
     "\n",
-    "iris_estimator = TensorFlow(entry_point='iris_dnn_classifier.py',\n",
+    "iris_estimator = TensorFlow(entry_point='/home/ec2-user/sample-notebooks/sagemaker-python-sdk/tensorflow_iris_dnn_classifier_using_estimators/iris_dnn_classifier.py',\n",
     "                            role=role,\n",
     "                            output_path=model_artifacts_location,\n",
     "                            code_location=custom_code_upload_location,\n",


### PR DESCRIPTION
We want the user to be able to copy and paste the code from the AWS docs into a new notebook and have it work, and we don't want to require them to create the notebook in a certain directory. So we need to use absolute paths.