### PR TITLE
adding notebooks for data conversion and encryption

### DIFF
--- a/advanced_functionality/README.md
+++ b/advanced_functionality/README.md
@@ -8,3 +8,6 @@ Example Notebooks include:
 - *kmeans_bring_your_own_model*: How to use Amazon SageMaker Algorithms containers to bring a pre-trained model to a realtime hosted endpoint without ever needing to think about REST APIs.
 - *r_bring_your_own*: How to containerize an R algorithm using Docker and plumber for hosting so that it can be used in Amazon SageMaker's managed training and realtime hosting.
 - *xgboost_bring_your_own_model*: How to use Amazon SageMaker Algorithms containers to bring a pre-trained model to a realtime hosted endpoint without ever needing to think about REST APIs.
+- *handling_kms_encrypted_data.ipynb*: How to use Server Side KMS encrypted data with Amazon SageMaker training works. The IAM role used for S3 access needs to have permissions to encrypt and decrypt data with the KMS key.
+- *parquet_to_recordio_protobuf.ipynb*: How to convert Parquet data format into the recordIO-protobuf format that many SageMaker algorithms consume. 
+- *working_with_redshift_data.ipynb*: Demonstrates how to copy data from Redshift to S3 and vice-versa. 

--- a/advanced_functionality/handling_kms_encrypted_data/handling_kms_encrypted_data.ipynb
+++ b/advanced_functionality/handling_kms_encrypted_data/handling_kms_encrypted_data.ipynb
@@ -1,0 +1,549 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SageMaker and AWS KMS–Managed Keys\n",
+    "_**Handling KMS encrypted data with SageMaker model training and encrypting the generated model artifacts**_\n",
+    "\n",
+    "---\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Contents\n",
+    "\n",
+    "1. [Background](#Background)\n",
+    "1. [Setup](#Setup)\n",
+    "1. [Optionally, upload encrypted data files for training](#Optionally,-upload-encrypted-data-files-for-training)\n",
+    "1. [Training the XGBoost model](#Training-the-XGBoost-model)\n",
+    "1. [Set up hosting for the model](#Set-up-hosting-for-the-model)\n",
+    "1. [Validate the model for use](#Validate-the-model-for-use)\n",
+    "\n",
+    "---\n",
+    "## Background\n",
+    "\n",
+    "AWS Key Management Service ([AWS KMS](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html)) enables \n",
+    "Server-side encryption to protect your data at rest. Amazon SageMaker training works with KMS encrypted data if the IAM role used for S3 access has permissions to encrypt and decrypt data with the KMS key. Further, a KMS key can also be used to encrypt the model artifacts at rest using Amazon S3 server-side encryption. In this notebook, we demonstrate SageMaker training with KMS encrypted data. \n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Setup\n",
+    "\n",
+    "### General Setup\n",
+    "Let's start by specifying:\n",
+    "* AWS region.\n",
+    "* The IAM role arn used to give learning and hosting access to your data. See the documentation for how to specify these.\n",
+    "* The S3 bucket that you want to use for training and model data.\n",
+    "\n",
+    "### KMS key setup\n",
+    "1. Use an existing KMS key from AWS IAM console or create one ([learn more](http://docs.aws.amazon.com/kms/latest/developerguide/create-keys.html)).\n",
+    "2. Allow the IAM role used for SageMaker to encrypt and decrypt data with this key from within applications and when using AWS services integrated with KMS ([learn more](http://docs.aws.amazon.com/console/kms/key-users)).\n",
+    "\n",
+    "We use the `key-id` from the KMS key ARN `arn:aws:kms:region:acct-id:key/key-id`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "isConfigCell": true
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "\n",
+    "import os\n",
+    "import io\n",
+    "import boto3\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import re\n",
+    "\n",
+    "region = boto3.Session().region_name\n",
+    "\n",
+    "assumed_role = boto3.client('sts').get_caller_identity()['Arn']\n",
+    "role = re.sub(r'^(.+)sts::(\\d+):assumed-role/(.+?)/.*$', r'\\1iam::\\2:role/\\3', assumed_role)\n",
+    "\n",
+    "kms_key_id = '<bring your own key-id>'\n",
+    "\n",
+    "bucket='<s3 bucket>' # put your s3 bucket name here, and create s3 bucket\n",
+    "prefix = 'sagemarker/kms-new'\n",
+    "# customize to your bucket where you have stored the data\n",
+    "bucket_path = 'https://s3-{}.amazonaws.com/{}'.format(region,bucket)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Optionally, upload encrypted data files for training\n",
+    "\n",
+    "To demonstrate SageMaker training with KMS encrypted data, we first upload a toy dataset that has Server Side Encryption with customer provided key.\n",
+    "\n",
+    "### Data ingestion\n",
+    "\n",
+    "We, first, read the dataset from an existing repository into memory. This processing could be done *in situ* by Amazon Athena, Apache Spark in Amazon EMR, Amazon Redshift, etc., assuming the dataset is present in the appropriate location. Then, the next step would be to transfer the data to S3 for use in training. For small datasets, such as the one used below, reading into memory isn't onerous, though it would be for larger datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!conda install -y -c conda-forge scikit-learn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.datasets import load_boston\n",
+    "boston = load_boston()\n",
+    "X = boston['data']\n",
+    "y = boston['target']\n",
+    "feature_names = boston['feature_names']\n",
+    "data = pd.DataFrame(X, columns=feature_names)\n",
+    "target = pd.DataFrame(y, columns={'MEDV'})\n",
+    "data['MEDV'] = y\n",
+    "local_file_name = 'boston.csv'\n",
+    "data.to_csv(local_file_name, header=False, index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Data preprocessing\n",
+    "\n",
+    "Now that we have the dataset, we need to split it into *train*, *validation*, and *test* datasets which we can use to evaluate the accuracy of the machine learning algorithm. We randomly split the dataset into 60% training, 20% validation and 20% test. Note that SageMaker Xgboost, expects the label column to be the first one in the datasets. So, we'll move the median value column (`MEDV`) from the last to the first position within the `write_file` method below. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.model_selection import train_test_split\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.4, random_state=1)\n",
+    "X_test, X_val, y_test, y_val = train_test_split(X_test, y_test, test_size=0.5, random_state=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def write_file(X, y, fname):\n",
+    "    feature_names = boston['feature_names']\n",
+    "    data = pd.DataFrame(X, columns=feature_names)\n",
+    "    target = pd.DataFrame(y, columns={'MEDV'})\n",
+    "    data['MEDV'] = y\n",
+    "    # bring this column to the front before writing the files\n",
+    "    cols = data.columns.tolist()\n",
+    "    cols = cols[-1:] + cols[:-1]\n",
+    "    data = data[cols]\n",
+    "    data.to_csv(fname, header=False, index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_file = 'train.csv'\n",
+    "validation_file = 'val.csv'\n",
+    "test_file = 'test.csv'\n",
+    "write_file(X_train, y_train, train_file)\n",
+    "write_file(X_val, y_val, validation_file)\n",
+    "write_file(X_test, y_test, test_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Data upload to S3 with Server Side Encryption"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3 = boto3.client('s3')\n",
+    "\n",
+    "data_train = open(train_file, 'rb')\n",
+    "key_train = '{}/train/{}'.format(prefix,train_file)\n",
+    "\n",
+    "\n",
+    "print(\"Put object...\")\n",
+    "s3.put_object(Bucket=bucket,\n",
+    "              Key=key_train,\n",
+    "              Body=data_train,\n",
+    "              ServerSideEncryption='aws:kms',\n",
+    "              SSEKMSKeyId=kms_key_id)\n",
+    "print(\"Done uploading the training dataset\")\n",
+    "\n",
+    "data_validation = open(validation_file, 'rb')\n",
+    "key_validation = '{}/validation/{}'.format(prefix,validation_file)\n",
+    "\n",
+    "print(\"Put object...\")\n",
+    "s3.put_object(Bucket=bucket,\n",
+    "              Key=key_validation,\n",
+    "              Body=data_validation,\n",
+    "              ServerSideEncryption='aws:kms',\n",
+    "              SSEKMSKeyId=kms_key_id)\n",
+    "\n",
+    "print(\"Done uploading the validation dataset\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Training the SageMaker XGBoost model\n",
+    "\n",
+    "Now that we have our data in S3, we can begin training. We'll use Amazon SageMaker XGboost algorithm as an example to demonstrate model training. Note that nothing needs to be changed in the way you'd call the training algorithm. The only requirement for training to succeed is that the IAM role (`role`) used for S3 access has permissions to encrypt and decrypt data with the KMS key (`kms_key_id`). You can set these permissions using the instructions [here](http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-users). If the permissions aren't set, you'll get the `Data download failed` error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "containers = {'us-west-2': '433757028032.dkr.ecr.us-west-2.amazonaws.com/xgboost:latest',\n",
+    "              'us-east-1': '811284229777.dkr.ecr.us-east-1.amazonaws.com/xgboost:latest',\n",
+    "              'us-east-2': '825641698319.dkr.ecr.us-east-1.amazonaws.com/xgboost:latest',\n",
+    "              'eu-west-1': '685385470294.dkr.ecr.us-east-1.amazonaws.com/xgboost:latest'}\n",
+    "container = containers[boto3.Session().region_name]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "from time import gmtime, strftime\n",
+    "import time\n",
+    "\n",
+    "job_name = 'xgboost-single-regression' + strftime(\"%Y-%m-%d-%H-%M-%S\", gmtime())\n",
+    "print(\"Training job\", job_name)\n",
+    "\n",
+    "create_training_params = \\\n",
+    "{\n",
+    "    \"AlgorithmSpecification\": {\n",
+    "        \"TrainingImage\": container,\n",
+    "        \"TrainingInputMode\": \"File\"\n",
+    "    },\n",
+    "    \"RoleArn\": role,\n",
+    "    \"OutputDataConfig\": {\n",
+    "        \"S3OutputPath\": bucket_path + \"/\"+ prefix + \"/output\"\n",
+    "    },\n",
+    "    \"ResourceConfig\": {\n",
+    "        \"InstanceCount\": 1,\n",
+    "        \"InstanceType\": \"ml.m4.4xlarge\",\n",
+    "        \"VolumeSizeInGB\": 5\n",
+    "    },\n",
+    "    \"TrainingJobName\": job_name,\n",
+    "    \"HyperParameters\": {\n",
+    "        \"max_depth\":\"5\",\n",
+    "        \"eta\":\"0.2\",\n",
+    "        \"gamma\":\"4\",\n",
+    "        \"min_child_weight\":\"6\",\n",
+    "        \"subsample\":\"0.7\",\n",
+    "        \"silent\":\"0\",\n",
+    "        \"objective\":\"reg:linear\",\n",
+    "        \"num_round\":\"5\"\n",
+    "    },\n",
+    "    \"StoppingCondition\": {\n",
+    "        \"MaxRuntimeInSeconds\": 86400\n",
+    "    },\n",
+    "    \"InputDataConfig\": [\n",
+    "        {\n",
+    "            \"ChannelName\": \"train\",\n",
+    "            \"DataSource\": {\n",
+    "                \"S3DataSource\": {\n",
+    "                    \"S3DataType\": \"S3Prefix\",\n",
+    "                    \"S3Uri\": bucket_path + \"/\"+ prefix + '/train',\n",
+    "                    \"S3DataDistributionType\": \"FullyReplicated\"\n",
+    "                }\n",
+    "            },\n",
+    "            \"ContentType\": \"libsvm\",\n",
+    "            \"CompressionType\": \"None\"\n",
+    "        },\n",
+    "        {\n",
+    "            \"ChannelName\": \"validation\",\n",
+    "            \"DataSource\": {\n",
+    "                \"S3DataSource\": {\n",
+    "                    \"S3DataType\": \"S3Prefix\",\n",
+    "                    \"S3Uri\": bucket_path + \"/\"+ prefix + '/validation',\n",
+    "                    \"S3DataDistributionType\": \"FullyReplicated\"\n",
+    "                }\n",
+    "            },\n",
+    "            \"ContentType\": \"csv\",\n",
+    "            \"CompressionType\": \"None\"\n",
+    "        }\n",
+    "    ]\n",
+    "}\n",
+    "\n",
+    "client = boto3.client('sagemaker')\n",
+    "client.create_training_job(**create_training_params)\n",
+    "\n",
+    "status = client.describe_training_job(TrainingJobName=job_name)['TrainingJobStatus']\n",
+    "print(status)\n",
+    "while status !='Completed' and status!='Failed':\n",
+    "    time.sleep(60)\n",
+    "    status = client.describe_training_job(TrainingJobName=job_name)['TrainingJobStatus']\n",
+    "    print(status)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up hosting for the model\n",
+    "In order to set up hosting, we have to import the model from training to hosting. \n",
+    "\n",
+    "### Import model into hosting\n",
+    "\n",
+    "Register the model with hosting. This allows the flexibility of importing models trained elsewhere."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "import boto3\n",
+    "from time import gmtime, strftime\n",
+    "\n",
+    "model_name=job_name + '-model'\n",
+    "print(model_name)\n",
+    "\n",
+    "info = client.describe_training_job(TrainingJobName=job_name)\n",
+    "model_data = info['ModelArtifacts']['S3ModelArtifacts']\n",
+    "print(model_data)\n",
+    "\n",
+    "primary_container = {\n",
+    "    'Image': container,\n",
+    "    'ModelDataUrl': model_data\n",
+    "}\n",
+    "\n",
+    "create_model_response = client.create_model(\n",
+    "    ModelName = model_name,\n",
+    "    ExecutionRoleArn = role,\n",
+    "    PrimaryContainer = primary_container)\n",
+    "\n",
+    "print(create_model_response['ModelArn'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create endpoint configuration\n",
+    "\n",
+    "SageMaker supports configuring REST endpoints in hosting with multiple models, e.g. for A/B testing purposes. In order to support this, customers create an endpoint configuration, that describes the distribution of traffic across the models, whether split, shadowed, or sampled in some way. In addition, the endpoint configuration describes the instance type required for model deployment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from time import gmtime, strftime\n",
+    "\n",
+    "endpoint_config_name = 'XGBoostEndpointConfig-' + strftime(\"%Y-%m-%d-%H-%M-%S\", gmtime())\n",
+    "print(endpoint_config_name)\n",
+    "create_endpoint_config_response = client.create_endpoint_config(\n",
+    "    EndpointConfigName = endpoint_config_name,\n",
+    "    ProductionVariants=[{\n",
+    "        'InstanceType':'ml.m4.xlarge',\n",
+    "        'InitialVariantWeight':1,\n",
+    "        'InitialInstanceCount':1,\n",
+    "        'ModelName':model_name,\n",
+    "        'VariantName':'AllTraffic'}])\n",
+    "\n",
+    "print(\"Endpoint Config Arn: \" + create_endpoint_config_response['EndpointConfigArn'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create endpoint\n",
+    "Lastly, create the endpoint that serves up the model, through specifying the name and configuration defined above. The end result is an endpoint that can be validated and incorporated into production applications. This takes 9-11 minutes to complete."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "import time\n",
+    "\n",
+    "endpoint_name = 'XGBoostEndpoint-new-' + strftime(\"%Y-%m-%d-%H-%M-%S\", gmtime())\n",
+    "print(endpoint_name)\n",
+    "create_endpoint_response = client.create_endpoint(\n",
+    "    EndpointName=endpoint_name,\n",
+    "    EndpointConfigName=endpoint_config_name)\n",
+    "print(create_endpoint_response['EndpointArn'])\n",
+    "\n",
+    "resp = client.describe_endpoint(EndpointName=endpoint_name)\n",
+    "status = resp['EndpointStatus']\n",
+    "print(\"Status: \" + status)\n",
+    "\n",
+    "while status=='Creating':\n",
+    "    time.sleep(60)\n",
+    "    resp = client.describe_endpoint(EndpointName=endpoint_name)\n",
+    "    status = resp['EndpointStatus']\n",
+    "    print(\"Status: \" + status)\n",
+    "\n",
+    "print(\"Arn: \" + resp['EndpointArn'])\n",
+    "print(\"Status: \" + status)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Validate the model for use\n",
+    "Finally, you can now validate the model for use. They can obtain the endpoint from the client library using the result from previous operations, and generate classifications from the trained model using that endpoint.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "runtime_client = boto3.client('sagemaker-runtime')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import math\n",
+    "def do_predict(data, endpoint_name, content_type):\n",
+    "    payload = ''.join(data)\n",
+    "    response = runtime_client.invoke_endpoint(EndpointName=endpoint_name, \n",
+    "                                   ContentType=content_type, \n",
+    "                                   Body=payload)\n",
+    "    result = response['Body'].read()\n",
+    "    result = result.decode(\"utf-8\")\n",
+    "    result = result.split(',')\n",
+    "    return result\n",
+    "\n",
+    "def batch_predict(data, batch_size, endpoint_name, content_type):\n",
+    "    items = len(data)\n",
+    "    arrs = []\n",
+    "    \n",
+    "    for offset in range(0, items, batch_size):\n",
+    "        if offset+batch_size < items:\n",
+    "            results = do_predict(data[offset:(offset+batch_size)], endpoint_name, content_type)\n",
+    "            arrs.extend(results)\n",
+    "        else:\n",
+    "            arrs.extend(do_predict(data[offset:items], endpoint_name, content_type))\n",
+    "        sys.stdout.write('.')\n",
+    "    return(arrs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following helps us calculate the Median Absolute Percent Error (MdAPE) on the batch dataset. Note that the intent of this example is not to produce the most accurate regressor but to demonstrate how to handle KMS encrypted data with SageMaker. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "import json\n",
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "with open('test.csv') as f:\n",
+    "    lines = f.readlines()\n",
+    "\n",
+    "#remove the labels\n",
+    "labels = [line.split(',')[0] for line in lines]\n",
+    "features = [line.split(',')[1:] for line in lines]\n",
+    "\n",
+    "features_str = [','.join(row) for row in features]\n",
+    "preds = batch_predict(features_str, 100, endpoint_name, 'text/csv')\n",
+    "print('\\n Median Absolute Percent Error (MdAPE) = ', np.median(np.abs(np.asarray(labels, dtype=float) - np.asarray(preds, dtype=float)) / np.asarray(labels, dtype=float)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### (Optional) Delete the Endpoint\n",
+    "\n",
+    "If you're ready to be done with this notebook, please uncomment the delete_endpoint line in the cell below and then run it.  This will remove the hosted endpoint you created and avoid any charges from a stray instance being left on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.delete_endpoint(EndpointName=endpoint_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Environment (conda_python3)",
+   "language": "python",
+   "name": "conda_python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
+  },
+  "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/advanced_functionality/parquet_to_recordio_protobuf/parquet_to_recordio_protobuf.ipynb
+++ b/advanced_functionality/parquet_to_recordio_protobuf/parquet_to_recordio_protobuf.ipynb
@@ -1,0 +1,379 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Converting the Parquet data format to recordIO-wrapped protobuf\n",
+    "\n",
+    "---\n",
+    "\n",
+    "---\n",
+    "## Contents\n",
+    "\n",
+    "1. [Introduction](#Introduction)\n",
+    "1. [Optional data ingestion](#Optional-data-ingestion)\n",
+    "    1. [Download the data](#Download-the-data)\n",
+    "    1. [Convert into Parquet format](#Convert-into-Parquet-format)\n",
+    "1. [Data conversion](#Data-conversion)\n",
+    "    1. [Convert to recordIO protobuf format](#Convert-to-recordIO-protobuf-format)\n",
+    "    1. [Upload to S3](#Upload-to-S3)\n",
+    "1. [Training the linear model](#Training-the-linear-model)\n",
+    "\n",
+    "\n",
+    "## Introduction\n",
+    "In this notebook we illustrate how to convert a Parquet data format into the recordIO-protobuf format that many SageMaker algorithms consume. For the demonstration, first we'll convert the publicly available MNIST dataset into the Parquet format. Subsequently, it is converted into the recordIO-protobuf format and uploaded to S3 for consumption by the linear learner algorithm. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "isConfigCell": true
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import io\n",
+    "import re\n",
+    "import boto3\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import time\n",
+    "\n",
+    "assumed_role = boto3.client('sts').get_caller_identity()['Arn']\n",
+    "role = re.sub(r'^(.+)sts::(\\d+):assumed-role/(.+?)/.*$', r'\\1iam::\\2:role/\\3', assumed_role)\n",
+    "\n",
+    "bucket = '<S3 bucket>'\n",
+    "prefix = 'sagemaker/parquet'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!conda install -y -c conda-forge fastparquet scikit-learn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Optional data ingestion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Download the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "import pickle, gzip, numpy, urllib.request, json\n",
+    "\n",
+    "# Load the dataset\n",
+    "urllib.request.urlretrieve(\"http://deeplearning.net/data/mnist/mnist.pkl.gz\", \"mnist.pkl.gz\")\n",
+    "with gzip.open('mnist.pkl.gz', 'rb') as f:\n",
+    "    train_set, valid_set, test_set = pickle.load(f, encoding='latin1')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastparquet import write\n",
+    "from fastparquet import ParquetFile\n",
+    "\n",
+    "def save_as_parquet_file(dataset, filename, label_col):\n",
+    "    X = dataset[0]\n",
+    "    y = dataset[1]\n",
+    "    data = pd.DataFrame(X)\n",
+    "    data[label_col] = y\n",
+    "    data.columns = data.columns.astype(str) #Parquet expexts the column names to be strings\n",
+    "    write(filename, data)\n",
+    "    \n",
+    "def read_parquet_file(filename):\n",
+    "    pf = ParquetFile(filename)\n",
+    "    return pf.to_pandas()\n",
+    "\n",
+    "def features_and_target(df, label_col):\n",
+    "    X = df.loc[:, df.columns != label_col].values\n",
+    "    y = df[label_col].values\n",
+    "    return [X, y]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Convert into Parquet format"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trainFile = 'train.parquet'\n",
+    "validFile = 'valid.parquet'\n",
+    "testFile = 'test.parquet'\n",
+    "label_col = 'target'\n",
+    "\n",
+    "save_as_parquet_file(train_set, trainFile, label_col)\n",
+    "save_as_parquet_file(valid_set, validFile, label_col)\n",
+    "save_as_parquet_file(test_set, testFile, label_col)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data conversion\n",
+    "\n",
+    "Since algorithms have particular input and output requirements, converting the dataset is also part of the process that a data scientist goes through prior to initiating training. E.g., the Amazon SageMaker implementation of Linear Learner takes recordIO-wrapped protobuf. Most of the conversion effort is handled by the Amazon SageMaker Python SDK, imported as `sagemaker` below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dfTrain = read_parquet_file(trainFile)\n",
+    "dfValid = read_parquet_file(validFile)\n",
+    "dfTest = read_parquet_file(testFile)\n",
+    "\n",
+    "train_X, train_y = features_and_target(dfTrain, label_col)\n",
+    "valid_X, valid_y = features_and_target(dfValid, label_col)\n",
+    "test_X, test_y = features_and_target(dfTest, label_col)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Convert to recordIO protobuf format"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import io\n",
+    "import numpy as np\n",
+    "import sagemaker.amazon.common as smac\n",
+    "\n",
+    "trainVectors = np.array([t.tolist() for t in train_X]).astype('float32')\n",
+    "trainLabels = np.where(np.array([t.tolist() for t in train_y]) == 0, 1, 0).astype('float32')\n",
+    "\n",
+    "bufTrain = io.BytesIO()\n",
+    "smac.write_numpy_to_dense_tensor(bufTrain, trainVectors, trainLabels)\n",
+    "bufTrain.seek(0)\n",
+    "\n",
+    "\n",
+    "validVectors = np.array([t.tolist() for t in valid_X]).astype('float32')\n",
+    "validLabels = np.where(np.array([t.tolist() for t in valid_y]) == 0, 1, 0).astype('float32')\n",
+    "\n",
+    "bufValid = io.BytesIO()\n",
+    "smac.write_numpy_to_dense_tensor(bufValid, validVectors, validLabels)\n",
+    "bufValid.seek(0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Upload to S3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "import os\n",
+    "\n",
+    "key = 'recordio-pb-data'\n",
+    "boto3.resource('s3').Bucket(bucket).Object(os.path.join(prefix, 'train', key)).upload_fileobj(bufTrain)\n",
+    "s3_train_data = 's3://{}/{}/train/{}'.format(bucket, prefix, key)\n",
+    "print('uploaded training data location: {}'.format(s3_train_data))\n",
+    "\n",
+    "boto3.resource('s3').Bucket(bucket).Object(os.path.join(prefix, 'validation', key)).upload_fileobj(bufValid)\n",
+    "s3_validation_data = 's3://{}/{}/validation/{}'.format(bucket, prefix, key)\n",
+    "print('uploaded validation data location: {}'.format(s3_validation_data))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Training the linear model\n",
+    "\n",
+    "Once we have the data preprocessed and available in the correct format for training, the next step is to actually train the model using the data. Since this data is relatively small, it isn't meant to show off the performance of the Linear Learner training algorithm, although we have tested it on multi-terabyte datasets.\n",
+    "\n",
+    "This example takes four to six minutes to complete. Majority of the time is spent provisioning hardware and loading the algorithm container since the dataset is small.\n",
+    "\n",
+    "First, let's specify our containers.  Since we want this notebook to run in all 4 of Amazon SageMaker's regions, we'll create a small lookup.  More details on algorithm containers can be found in [AWS documentation](https://docs-aws.amazon.com/sagemaker/latest/dg/im-algo-docker-registry-paths.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "containers = {'us-west-2': '174872318107.dkr.ecr.us-west-2.amazonaws.com/linear-learner:latest',\n",
+    "              'us-east-1': '382416733822.dkr.ecr.us-east-1.amazonaws.com/linear-learner:latest',\n",
+    "              'us-east-2': '404615174143.dkr.ecr.us-east-2.amazonaws.com/linear-learner:latest',\n",
+    "              'eu-west-1': '438346466558.dkr.ecr.eu-west-1.amazonaws.com/linear-learner:latest'}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linear_job = 'linear-' + time.strftime(\"%Y-%m-%d-%H-%M-%S\", time.gmtime())\n",
+    "\n",
+    "print(\"Job name is:\", linear_job)\n",
+    "\n",
+    "linear_training_params = {\n",
+    "    \"RoleArn\": role,\n",
+    "    \"TrainingJobName\": linear_job,\n",
+    "    \"AlgorithmSpecification\": {\n",
+    "        \"TrainingImage\": containers[boto3.Session().region_name],\n",
+    "        \"TrainingInputMode\": \"File\"\n",
+    "    },\n",
+    "    \"ResourceConfig\": {\n",
+    "        \"InstanceCount\": 1,\n",
+    "        \"InstanceType\": \"ml.c4.2xlarge\",\n",
+    "        \"VolumeSizeInGB\": 10\n",
+    "    },\n",
+    "    \"InputDataConfig\": [\n",
+    "        {\n",
+    "            \"ChannelName\": \"train\",\n",
+    "            \"DataSource\": {\n",
+    "                \"S3DataSource\": {\n",
+    "                    \"S3DataType\": \"S3Prefix\",\n",
+    "                    \"S3Uri\": \"s3://{}/{}/train/\".format(bucket, prefix),\n",
+    "                    \"S3DataDistributionType\": \"FullyReplicated\"\n",
+    "                }\n",
+    "            },\n",
+    "            \"CompressionType\": \"None\",\n",
+    "            \"RecordWrapperType\": \"None\"\n",
+    "        },\n",
+    "        {\n",
+    "            \"ChannelName\": \"validation\",\n",
+    "            \"DataSource\": {\n",
+    "                \"S3DataSource\": {\n",
+    "                    \"S3DataType\": \"S3Prefix\",\n",
+    "                    \"S3Uri\": \"s3://{}/{}/validation/\".format(bucket, prefix),\n",
+    "                    \"S3DataDistributionType\": \"FullyReplicated\"\n",
+    "                }\n",
+    "            },\n",
+    "            \"CompressionType\": \"None\",\n",
+    "            \"RecordWrapperType\": \"None\"\n",
+    "        }\n",
+    "\n",
+    "    ],\n",
+    "    \"OutputDataConfig\": {\n",
+    "        \"S3OutputPath\": \"s3://{}/{}/\".format(bucket, prefix)\n",
+    "    },\n",
+    "    \"HyperParameters\": {\n",
+    "        \"feature_dim\": \"784\",\n",
+    "        \"mini_batch_size\": \"200\",\n",
+    "        \"predictor_type\": \"binary_classifier\",\n",
+    "        \"epochs\": \"10\",\n",
+    "        \"num_models\": \"32\",\n",
+    "        \"loss\": \"absolute_loss\"\n",
+    "    },\n",
+    "    \"StoppingCondition\": {\n",
+    "        \"MaxRuntimeInSeconds\": 60 * 60\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's kick off our training job in SageMaker's distributed, managed training, using the parameters we just created. Because training is managed (AWS handles spinning up and spinning down hardware), we don't have to wait for our job to finish to continue, but for this case, let's setup a while loop so we can monitor the status of our training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "\n",
+    "sm = boto3.Session().client('sagemaker')\n",
+    "sm.create_training_job(**linear_training_params)\n",
+    "\n",
+    "status = sm.describe_training_job(TrainingJobName=linear_job)['TrainingJobStatus']\n",
+    "print(status)\n",
+    "sm.get_waiter('TrainingJob_Created').wait(TrainingJobName=linear_job)\n",
+    "if status == 'Failed':\n",
+    "    message = sm.describe_training_job(TrainingJobName=linear_job)['FailureReason']\n",
+    "    print('Training failed with the following error: {}'.format(message))\n",
+    "    raise Exception('Training job failed')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sm.describe_training_job(TrainingJobName=linear_job)['TrainingJobStatus']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Environment (conda_python3)",
+   "language": "python",
+   "name": "conda_python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
+  },
+  "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/advanced_functionality/working_with_redshift_data/redshift_creds_template.json.nogit
+++ b/advanced_functionality/working_with_redshift_data/redshift_creds_template.json.nogit
@@ -1,0 +1,7 @@
+{
+    "host_name": "<hostname>",
+    "port_num": "<portnum>",
+    "db_name": "<db_name>",
+    "username": "<username>",
+    "password": "<password>"
+}

--- a/advanced_functionality/working_with_redshift_data/working_with_redshift_data.ipynb
+++ b/advanced_functionality/working_with_redshift_data/working_with_redshift_data.ipynb
@@ -1,0 +1,231 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Copying data from Redshift to S3 and back\n",
+    "\n",
+    "---\n",
+    "\n",
+    "---\n",
+    "## Contents\n",
+    "\n",
+    "1. [Introduction](#Introduction)\n",
+    "1. [Reading from Redshift](#Reading-from-Redshift)\n",
+    "1. [Upload to S3](#Upload-to-S3)\n",
+    "1. [Writing back to Redshift](#Writing-back-to-Redshift)\n",
+    "\n",
+    "\n",
+    "\n",
+    "## Introduction\n",
+    "In this notebook we illustrate how to copy data from Redshift to S3 and vice-versa. We have a Redshift cluster within the same VPC, and have preloaded it with data from the [iris data set](https://archive.ics.uci.edu/ml/datasets/iris). Let's start by installing `psycopg2`, a PostgreSQL database adapter for the Python, adding a few imports and specifying a few configs. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!conda install -y -c anaconda psycopg2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "isConfigCell": true
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import boto3\n",
+    "import pandas as pd\n",
+    "import json\n",
+    "import psycopg2\n",
+    "import sqlalchemy as sa\n",
+    "\n",
+    "region = boto3.Session().region_name\n",
+    "\n",
+    "bucket='<S3 bucket>' # put your s3 bucket name here, and create s3 bucket\n",
+    "prefix = 'sagemarker/redshift'\n",
+    "# customize to your bucket where you have stored the data\n",
+    "\n",
+    "credfile = 'redshift_creds_template.json.nogit'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reading from Redshift\n",
+    "We store the information needed to connect to Redshift in a credentials file. See the file `redshift_creds_template.json.nogit` for an example. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "isConfigCell": true
+   },
+   "outputs": [],
+   "source": [
+    "# Read credentials to a dictionary\n",
+    "with open(credfile) as fh:\n",
+    "    creds = json.loads(fh.read())\n",
+    "\n",
+    "# Sample query for testing\n",
+    "query = 'select * from public.irisdata;'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We create a connection to redshift using our credentials, and use this to query Redshift and store the result in a pandas DataFrame, which we then save."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Reading from Redshift...\")\n",
+    "\n",
+    "def get_conn(creds): \n",
+    "    conn = psycopg2.connect(dbname=creds['db_name'], \n",
+    "                            user=creds['username'], \n",
+    "                            password=creds['password'],\n",
+    "                            port=creds['port_num'],\n",
+    "                            host=creds['host_name'])\n",
+    "    return conn\n",
+    "\n",
+    "def get_df(creds, query):\n",
+    "    with get_conn(creds) as conn:\n",
+    "        with conn.cursor() as cur:\n",
+    "            cur.execute(query)\n",
+    "            result_set = cur.fetchall()\n",
+    "            colnames = [desc.name for desc in cur.description]\n",
+    "            df = pd.DataFrame.from_records(result_set, columns=colnames)\n",
+    "    return df\n",
+    "\n",
+    "df = get_df(creds, query)\n",
+    "\n",
+    "print(\"Saving file\")\n",
+    "localFile = 'iris.csv'\n",
+    "df.to_csv(localFile, index=False)\n",
+    "\n",
+    "print(\"Done\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Upload to S3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Writing to S3...\")\n",
+    "\n",
+    "fObj = open(localFile, 'rb')\n",
+    "boto3.Session().resource('s3').Bucket(bucket).Object(os.path.join(prefix, localFile)).upload_fileobj(fObj)\n",
+    "print(\"Done\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Writing back to Redshift\n",
+    "\n",
+    "We now demonstrate the reverse process of copying data from S3 to Redshift. We copy back the same data but in an actual application the data would be the output of an algorithm on Sagemaker."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Reading from S3...\")\n",
+    "# key unchanged for demo purposes - change key to read from output data\n",
+    "key = os.path.join(prefix, localFile)\n",
+    "\n",
+    "s3 = boto3.resource('s3')\n",
+    "outfile = 'iris2.csv'\n",
+    "s3.Bucket(bucket).download_file(key, outfile)\n",
+    "df2 = pd.read_csv(outfile)\n",
+    "print(\"Done\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Writing to Redshift...\")\n",
+    "\n",
+    "connection_str = 'postgresql+psycopg2://' + \\\n",
+    "                  creds['username'] + ':' + \\\n",
+    "                  creds['password'] + '@' + \\\n",
+    "                  creds['host_name'] + ':' + \\\n",
+    "                  creds['port_num'] + '/' + \\\n",
+    "                  creds['db_name'];\n",
+    "                    \n",
+    "df2.to_sql('irisdata_v2', connection_str, schema='public', index=False)\n",
+    "print(\"Done\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We read the copied data in Redshift - success!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.options.display.max_rows = 2\n",
+    "conn = get_conn(creds)\n",
+    "query = 'select * from irisdata3'\n",
+    "df = pd.read_sql_query(query, conn)\n",
+    "df"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Environment (conda_python3)",
+   "language": "python",
+   "name": "conda_python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
+  },
+  "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/advanced_functionality/xgboost_bring_your_own_model/README.md
+++ b/advanced_functionality/xgboost_bring_your_own_model/README.md
@@ -1,2 +1,2 @@
 ### Bring Your Own Model (XGboost)
-`sagemaker-xgboost-bring-your-own-model.ipynb` shows how to train and Xgboost model in scikit-learn and then inject it into Amazon SageMaker's first party XGboost container for scoring. This addresses the use case where a customer has already trained their model outside of Amazon SageMaker, but wishes to host it for predictions within Amazon SageMaker.
+`xgboost_bring_your_own_model.ipynb` shows how to train an Xgboost model in scikit-learn and then inject it into Amazon SageMaker's first party XGboost container for scoring. This addresses the usecase where a customer has already trained their model outside of Amazon SageMaker, but wishes to host it for predictions within Amazon SageMaker.


### PR DESCRIPTION
- *handling_kms_encrypted_data.ipynb*: How to use Server Side KMS encrypted data with Amazon SageMaker training works. The IAM role used for S3 access needs to have permissions to encrypt and decrypt data with the KMS key.
- *parquet_to_recordio_protobuf.ipynb*: How to convert Parquet data format into the recordIO-protobuf format that many SageMaker algorithms consume.
- *working_with_redshift_data.ipynb*: Demonstrates how to copy data from Redshift to S3 and vice-versa.