### PR TITLE
Minor LDA parameter adjustment

### DIFF
--- a/scientific_details_of_algorithms/lda_topic_modeling/LDA-Science.ipynb
+++ b/scientific_details_of_algorithms/lda_topic_modeling/LDA-Science.ipynb
@@ -1146,11 +1146,11 @@
    "source": [
     "N = 6\n",
     "\n",
-    "good_idx = (l1_errors < 0.1)\n",
+    "good_idx = (l1_errors < 0.05)\n",
     "good_documents = payload_documents[good_idx][:N]\n",
     "good_topic_mixtures = inferred_topic_mixtures[good_idx][:N]\n",
     "\n",
-    "poor_idx = (l1_errors > 0.4)\n",
+    "poor_idx = (l1_errors > 0.3)\n",
     "poor_documents = payload_documents[poor_idx][:N]\n",
     "poor_topic_mixtures = inferred_topic_mixtures[poor_idx][:N]"
    ]


### PR DESCRIPTION
In some random examples there aren't enough "bad" inference output. We readjust
the error bounds on plotting example documents.