### PR TITLE
Replace s3_input with s3_data parameter

### DIFF
--- a/introduction_to_applying_machine_learning/xgboost_direct_marketing/xgboost_direct_marketing_sagemaker.ipynb
+++ b/introduction_to_applying_machine_learning/xgboost_direct_marketing/xgboost_direct_marketing_sagemaker.ipynb
@@ -420,8 +420,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s3_input_train = sagemaker.s3_input(s3_prefix='s3://{}/{}/train'.format(bucket, prefix), content_type='libsvm')\n",
-    "s3_input_validation = sagemaker.s3_input(s3_prefix='s3://{}/{}/validation/'.format(bucket, prefix), content_type='libsvm')"
+    "s3_input_train = sagemaker.s3_input(s3_data='s3://{}/{}/train'.format(bucket, prefix), content_type='libsvm')\n",
+    "s3_input_validation = sagemaker.s3_input(s3_data='s3://{}/{}/validation/'.format(bucket, prefix), content_type='libsvm')"
    ]
   },
   {


### PR DESCRIPTION
Help on class s3_input in module sagemaker.session:

class s3_input(builtins.object)
 |  Amazon SageMaker channel configurations for S3 data sources.
 |  
 |  Attributes:
 |      config (dict[str, dict]): A SageMaker ``DataSource`` referencing a SageMaker ``S3DataSource``.
 |  
 |  Methods defined here:
 |  
 |  __init__(self, s3_data, distribution='FullyReplicated', compression=None, content_type=None, record_wrapping=None, s3_data_type='S3Prefix')
 |      Create a definition for input data used by an SageMaker training job.
 |      
 |      See AWS documentation on the ``CreateTrainingJob`` API for more details on the parameters.
 |      
 |      Args:
 |          s3_data (str): Defines the location of s3 data to train on.
 |          distribution (str): Valid values: 'FullyReplicated', 'ShardedByS3Key'
 |              (default: 'FullyReplicated').
 |          compression (str): Valid values: 'Gzip', 'Bzip2', 'Lzop' (default: None).
 |          content_type (str): MIME type of the input data (default: None).
 |          record_wrapping (str): Valid values: 'RecordIO' (default: None).
 |          s3_data_type (str): Value values: 'S3Prefix', 'ManifestFile'. If 'S3Prefix', ``s3_data`` defines
 |              a prefix of s3 objects to train on. All objects with s3 keys beginning with ``s3_data`` will
 |              be used to train. If 'ManifestFile', then ``s3_data`` defines a single s3 manifest file, listing
 |              each s3 object to train on. The Manifest file format is described in the SageMaker API documentation:
 |              https://aws.amazon.com/sagemaker/latest/dg/API_S3DataSource.html
 |