### PR TITLE
Install R Kernel in the environment where Jupyter sits

### DIFF
--- a/advanced_functionality/install_r_kernel/install_r_kernel.ipynb
+++ b/advanced_functionality/install_r_kernel/install_r_kernel.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!conda install -y -c r r-essentials"
+    "!conda install --yes --name JupyterSystemEnv --channel r r-essentials"
    ]
   },
   {
@@ -27,11 +27,10 @@
   }
  ],
  "metadata": {
-  "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.",
   "kernelspec": {
-   "display_name": "Environment (conda_jupytersystemenv)",
+   "display_name": "conda_python3",
    "language": "python",
-   "name": "conda_jupytersystemenv"
+   "name": "conda_python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -43,8 +42,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
-  }
+   "version": "3.6.2"
+  },
+  "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },
  "nbformat": 4,
  "nbformat_minor": 2


### PR DESCRIPTION
Jupyter runs in a "pristine" Conda environment which isn't affected by changes in the root environment.  As a result, modifications to Jupyter (kernels, extensions, etc.) must be installed there too.

This updates the install_r_notebook to use the JupyterSystemEnv environment when installing R.