### PR TITLE
Correct indent

### DIFF
--- a/reinforcement_learning/rl_roboschool_ray/common/sagemaker_rl/tf_serving_utils.py
+++ b/reinforcement_learning/rl_roboschool_ray/common/sagemaker_rl/tf_serving_utils.py
@@ -15,8 +15,8 @@ def change_permissions_recursive(path, mode):
     for root, dirs, files in os.walk(path, topdown=False):
         for dir in [os.path.join(root, d) for d in dirs]:
             os.chmod(dir, mode)
-    for file in [os.path.join(root, f) for f in files]:
-        os.chmod(file, mode)
+        for file in [os.path.join(root, f) for f in files]:
+            os.chmod(file, mode)
 
 
 def export_tf_serving(agent, output_dir):


### PR DESCRIPTION
*Description of changes:*
I correct a wrong indent, which sets incorrect permission on files and may have troubles in local mode. The permissions are actually changed here:
https://github.com/awslabs/amazon-sagemaker-examples/blob/1ce01d276b705dbc547573a852d280a4eb3dbcc0/reinforcement_learning/rl_roboschool_ray/common/sagemaker_rl/ray_launcher.py#L210-L212

BTW, as [README.md](https://github.com/awslabs/amazon-sagemaker-examples/blob/2b9b8711770fca9e320837b0b536d09fd30377fa/reinforcement_learning/rl_roboschool_ray/common/sagemaker_rl/README.md)  in [./common/sagemaker_rl](https://github.com/awslabs/amazon-sagemaker-examples/tree/2b9b8711770fca9e320837b0b536d09fd30377fa/reinforcement_learning/rl_roboschool_ray/common/sagemaker_rl) says these files are to be moved to a container image, do we still need these files?