### PR TITLE
Enable S3 Endpoint URL configuration

### DIFF
--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/evaluation_worker.py
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/evaluation_worker.py
@@ -145,6 +145,10 @@ def main():
                         type=str,
                         nargs='+',
                         default=rospy.get_param("MODEL_S3_PREFIX", ["sagemaker"]))
+    parser.add_argument('--s3_endpoint_url',
+                        help='(string) S3 endpoint URL',
+                        type=str,
+                        default=rospy.get_param("S3_ENDPOINT_URL", None))                        
     parser.add_argument('--aws_region',
                         help='(string) AWS region',
                         type=str,
@@ -190,7 +194,7 @@ def main():
     args = parser.parse_args()
     arg_s3_bucket = args.s3_bucket
     arg_s3_prefix = args.s3_prefix
-    logger.info("S3 bucket: %s \n S3 prefix: %s", arg_s3_bucket, arg_s3_prefix)
+    logger.info("S3 bucket: %s \n S3 prefix: %s \n S3 endpoint URL: %s", args.s3_bucket, args.s3_prefix, args.s3_endpoint_url)
 
     metrics_s3_buckets = rospy.get_param('METRICS_S3_BUCKET')
     metrics_s3_object_keys = rospy.get_param('METRICS_S3_OBJECT_KEY')
@@ -250,6 +254,7 @@ def main():
         model_metadata = ModelMetadata(bucket=arg_s3_bucket[agent_index],
                                        s3_key=get_s3_key(arg_s3_prefix[agent_index], MODEL_METADATA_S3_POSTFIX),
                                        region_name=args.aws_region,
+                                       s3_endpoint_url=args.s3_endpoint_url,
                                        local_path=MODEL_METADATA_LOCAL_PATH_FORMAT.format(agent_name))
         _, _, version = model_metadata.get_model_metadata_info()
 
@@ -257,6 +262,7 @@ def main():
         checkpoint = Checkpoint(bucket=arg_s3_bucket[agent_index],
                                 s3_prefix=arg_s3_prefix[agent_index],
                                 region_name=args.aws_region,
+                                s3_endpoint_url=args.s3_endpoint_url,
                                 agent_name=agent_name,
                                 checkpoint_dir=args.local_model_directory)
         # make coach checkpoint compatible
@@ -298,6 +304,7 @@ def main():
 
         metrics_s3_config = {MetricsS3Keys.METRICS_BUCKET.value: metrics_s3_buckets[agent_index],
                              MetricsS3Keys.METRICS_KEY.value: metrics_s3_object_keys[agent_index],
+                             MetricsS3Keys.ENDPOINT_URL.value: rospy.get_param('S3_ENDPOINT_URL', None),
                              # Replaced rospy.get_param('AWS_REGION') to be equal to the argument being passed
                              # or default argument set
                              MetricsS3Keys.REGION.value: args.aws_region}
@@ -309,6 +316,7 @@ def main():
                               bucket=simtrace_s3_bucket[agent_index],
                               s3_prefix=simtrace_s3_object_prefix[agent_index],
                               region_name=aws_region,
+                              s3_endpoint_url=args.s3_endpoint_url,
                               local_path=SIMTRACE_EVAL_LOCAL_PATH_FORMAT.format(agent_name)))
         if mp4_s3_bucket:
             simtrace_video_s3_writers.extend([
@@ -316,16 +324,19 @@ def main():
                               bucket=mp4_s3_bucket[agent_index],
                               s3_prefix=mp4_s3_object_prefix[agent_index],
                               region_name=aws_region,
+                              s3_endpoint_url=args.s3_endpoint_url,
                               local_path=CAMERA_PIP_MP4_LOCAL_PATH_FORMAT.format(agent_name)),
                 SimtraceVideo(upload_type=SimtraceVideoNames.DEGREE45.value,
                               bucket=mp4_s3_bucket[agent_index],
                               s3_prefix=mp4_s3_object_prefix[agent_index],
                               region_name=aws_region,
+                              s3_endpoint_url=args.s3_endpoint_url,
                               local_path=CAMERA_45DEGREE_LOCAL_PATH_FORMAT.format(agent_name)),
                 SimtraceVideo(upload_type=SimtraceVideoNames.TOPVIEW.value,
                               bucket=mp4_s3_bucket[agent_index],
                               s3_prefix=mp4_s3_object_prefix[agent_index],
                               region_name=aws_region,
+                              s3_endpoint_url=args.s3_endpoint_url,
                               local_path=CAMERA_TOPVIEW_LOCAL_PATH_FORMAT.format(agent_name))])
 
         run_phase_subject = RunPhaseSubject()

--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/metrics/constants.py
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/metrics/constants.py
@@ -12,6 +12,7 @@ class MetricsS3Keys(Enum):
     REGION = 'aws_region'
     METRICS_BUCKET = 'metrics_bucket'
     METRICS_KEY = 'metrics_key'
+    ENDPOINT_URL = 'endpoint_url'
 
 class EvalMetricsKeys(Enum):
     '''The shared metric key for eval metrics'''

--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/metrics/s3_metrics.py
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/metrics/s3_metrics.py
@@ -70,7 +70,8 @@ class TrainingMetrics(MetricsInterface, ObserverInterface, AbstractTracker):
         self._deepracer_checkpoint_json = deepracer_checkpoint_json
         self._s3_metrics = Metrics(bucket=s3_dict_metrics[MetricsS3Keys.METRICS_BUCKET.value],
                                    s3_key=s3_dict_metrics[MetricsS3Keys.METRICS_KEY.value],
-                                   region_name=s3_dict_metrics[MetricsS3Keys.REGION.value])
+                                   region_name=s3_dict_metrics[MetricsS3Keys.REGION.value],
+                                   s3_endpoint_url=s3_dict_metrics[MetricsS3Keys.ENDPOINT_URL.value])
         self._start_time_ = time.time()
         self._episode_ = 0
         self._episode_reward_ = 0.0
@@ -239,7 +240,8 @@ class EvalMetrics(MetricsInterface, AbstractTracker):
         self._agent_name_ = agent_name
         self._s3_metrics = Metrics(bucket=s3_dict_metrics[MetricsS3Keys.METRICS_BUCKET.value],
                                    s3_key=s3_dict_metrics[MetricsS3Keys.METRICS_KEY.value],
-                                   region_name=s3_dict_metrics[MetricsS3Keys.REGION.value])
+                                   region_name=s3_dict_metrics[MetricsS3Keys.REGION.value],
+                                   s3_endpoint_url=s3_dict_metrics[MetricsS3Keys.ENDPOINT_URL.value])
         self._is_continuous = is_continuous
         self._start_time_ = time.time()
         self._number_of_trials_ = 0

--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/checkpoint.py
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/checkpoint.py
@@ -36,6 +36,7 @@ class Checkpoint():
     RlCoachSyncFile, TensorflowModel to handle all checkpoint related logic
     '''
     def __init__(self, bucket, s3_prefix, region_name="us-east-1",
+                 s3_endpoint_url=None,
                  agent_name='agent', checkpoint_dir="./checkpoint",
                  max_retry_attempts=5, backoff_time_sec=1.0):
         '''This class is a placeholder for RLCoachCheckpoint, DeepracerCheckpointJson,
@@ -64,6 +65,7 @@ class Checkpoint():
         self._rl_coach_checkpoint = RLCoachCheckpoint(bucket=bucket,
                                                       s3_prefix=s3_prefix,
                                                       region_name=region_name,
+                                                      s3_endpoint_url=s3_endpoint_url,
                                                       local_dir=os.path.join(checkpoint_dir,
                                                                              agent_name),
                                                       max_retry_attempts=max_retry_attempts,
@@ -76,6 +78,7 @@ class Checkpoint():
             DeepracerCheckpointJson(bucket=bucket,
                                     s3_prefix=s3_prefix,
                                     region_name=region_name,
+                                    s3_endpoint_url=s3_endpoint_url,
                                     local_dir=os.path.join(checkpoint_dir, agent_name),
                                     max_retry_attempts=0,
                                     backoff_time_sec=backoff_time_sec)
@@ -85,6 +88,7 @@ class Checkpoint():
                                                   bucket=bucket,
                                                   s3_prefix=s3_prefix,
                                                   region_name=region_name,
+                                                  s3_endpoint_url=s3_endpoint_url,
                                                   local_dir=os.path.join(checkpoint_dir,
                                                                          agent_name),
                                                   max_retry_attempts=max_retry_attempts,
@@ -95,6 +99,7 @@ class Checkpoint():
                                               bucket=bucket,
                                               s3_prefix=s3_prefix,
                                               region_name=region_name,
+                                              s3_endpoint_url=s3_endpoint_url,
                                               local_dir=checkpoint_dir,
                                               max_retry_attempts=max_retry_attempts,
                                               backoff_time_sec=backoff_time_sec)
@@ -104,6 +109,7 @@ class Checkpoint():
                                                bucket=bucket,
                                                s3_prefix=s3_prefix,
                                                region_name=region_name,
+                                               s3_endpoint_url=s3_endpoint_url,
                                                local_dir=os.path.join(checkpoint_dir,
                                                                       agent_name),
                                                max_retry_attempts=max_retry_attempts,
@@ -113,6 +119,7 @@ class Checkpoint():
         self._tensorflow_model = TensorflowModel(bucket=bucket,
                                                  s3_prefix=s3_prefix,
                                                  region_name=region_name,
+                                                 s3_endpoint_url=s3_endpoint_url,
                                                  local_dir=os.path.join(checkpoint_dir,
                                                                         agent_name),
                                                  max_retry_attempts=max_retry_attempts,

--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/checkpoint_files/deepracer_checkpoint_json.py
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/checkpoint_files/deepracer_checkpoint_json.py
@@ -23,6 +23,7 @@ class DeepracerCheckpointJson():
     '''This class is for deepracer checkpoint json file upload and download
     '''
     def __init__(self, bucket, s3_prefix, region_name='us-east-1',
+                 s3_endpoint_url=None,
                  local_dir='.checkpoint/agent',
                  max_retry_attempts=0, backoff_time_sec=1.0):
         '''This class is for deepracer checkpoint json file upload and download
@@ -50,6 +51,7 @@ class DeepracerCheckpointJson():
         self._local_path = os.path.normpath(
             DEEPRACER_CHECKPOINT_LOCAL_PATH_FORMAT.format(local_dir))
         self._s3_client = S3Client(region_name,
+                                   s3_endpoint_url,
                                    max_retry_attempts,
                                    backoff_time_sec)
 

--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/checkpoint_files/rl_coach_checkpoint.py
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/checkpoint_files/rl_coach_checkpoint.py
@@ -28,6 +28,7 @@ class RLCoachCheckpoint():
     '''This class is for RL coach checkpoint file
     '''
     def __init__(self, bucket, s3_prefix, region_name='us-east-1',
+                 s3_endpoint_url=None,
                  local_dir='./checkpoint/agent',
                  max_retry_attempts=5, backoff_time_sec=1.0):
         '''This class is for RL coach checkpoint file
@@ -68,6 +69,7 @@ class RLCoachCheckpoint():
         self._coach_checkpoint_state_file = CheckpointStateFile(
             os.path.dirname(self._local_path))
         self._s3_client = S3Client(region_name,
+                                   s3_endpoint_url,
                                    max_retry_attempts,
                                    backoff_time_sec)
 

--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/checkpoint_files/rl_coach_sync_file.py
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/checkpoint_files/rl_coach_sync_file.py
@@ -22,6 +22,7 @@ class RlCoachSyncFile():
     '''This class is for rl coach sync file: .finished, .lock, and .ready
     '''
     def __init__(self, syncfile_type, bucket, s3_prefix, region_name="us-east-1",
+                 s3_endpoint_url=None,
                  local_dir='./checkpoint',
                  max_retry_attempts=5, backoff_time_sec=1.0):
         '''This class is for rl coach sync file: .finished, .lock, and .ready
@@ -51,6 +52,7 @@ class RlCoachSyncFile():
         self._local_path = os.path.normpath(
             SYNC_FILES_LOCAL_PATH_FORMAT_DICT[syncfile_type].format(local_dir))
         self._s3_client = S3Client(region_name,
+                                   s3_endpoint_url,
                                    max_retry_attempts,
                                    backoff_time_sec)
 

--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/checkpoint_files/tensorflow_model.py
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/checkpoint_files/tensorflow_model.py
@@ -34,6 +34,7 @@ class TensorflowModel():
     '''This class is for tensorflow model upload and download
     '''
     def __init__(self, bucket, s3_prefix, region_name='us-east-1',
+                 s3_endpoint_url=None,
                  local_dir='./checkpoint/agent',
                  max_retry_attempts=5, backoff_time_sec=1.0):
         '''This class is for tensorflow model upload and download
@@ -59,6 +60,7 @@ class TensorflowModel():
                                                          CHECKPOINT_POSTFIX_DIR))
         self._delete_queue = queue.Queue()
         self._s3_client = S3Client(region_name,
+                                   s3_endpoint_url,
                                    max_retry_attempts,
                                    backoff_time_sec)
 

--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/hyperparameters.py
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/hyperparameters.py
@@ -18,6 +18,7 @@ class Hyperparameters():
     '''hyperparameters download and upload
     '''
     def __init__(self, bucket, s3_key, region_name="us-east-1",
+                 s3_endpoint_url=None,
                  local_path="./custom_files/agent/hyperparameters.json",
                  max_retry_attempts=5, backoff_time_sec=1.0):
         '''Hyperparameters upload, download, and parse
@@ -42,7 +43,8 @@ class Hyperparameters():
         self._s3_key = s3_key.replace('s3://{}/'.format(self._bucket), '')
         self._local_path = local_path
         self._hyperparameters = None
-        self._s3_client = S3Client(region_name,
+        self._s3_client = S3Client(region_name, 
+                                   s3_endpoint_url,
                                    max_retry_attempts,
                                    backoff_time_sec)
 

--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/ip_config.py
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/ip_config.py
@@ -26,6 +26,7 @@ class IpConfig():
     '''ip upload, download, and parse
     '''
     def __init__(self, bucket, s3_prefix, region_name='us-east-1',
+                 s3_endpoint_url=None,
                  local_path="./custom_files/agent/ip.json",
                  max_retry_attempts=5, backoff_time_sec=1.0):
         '''ip upload, download, and parse
@@ -53,6 +54,7 @@ class IpConfig():
             IP_ADDRESS_POSTFIX))
         self._local_path = local_path
         self._s3_client = S3Client(region_name,
+                                   s3_endpoint_url,
                                    max_retry_attempts,
                                    backoff_time_sec)
         self._ip_file = None

--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/metrics.py
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/metrics.py
@@ -14,7 +14,7 @@ class Metrics():
     '''metrics upload
     '''
     def __init__(self, bucket, s3_key, region_name='us-east-1',
-                 max_retry_attempts=5, backoff_time_sec=1.0):
+                 max_retry_attempts=5, backoff_time_sec=1.0, s3_endpoint_url=None):
         '''metrics upload
 
         Args:
@@ -32,6 +32,7 @@ class Metrics():
         self._bucket = bucket
         self._s3_key = s3_key
         self._s3_client = S3Client(region_name,
+                                   s3_endpoint_url,
                                    max_retry_attempts,
                                    backoff_time_sec)
 

--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/model_metadata.py
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/model_metadata.py
@@ -18,6 +18,7 @@ class ModelMetadata():
     '''model metadata file upload, download, and parse
     '''
     def __init__(self, bucket, s3_key, region_name="us-east-1",
+                 s3_endpoint_url=None,
                  local_path="./custom_files/agent/model_metadata.json",
                  max_retry_attempts=5, backoff_time_sec=1.0):
         '''Model metadata upload, download, and parse
@@ -45,6 +46,7 @@ class ModelMetadata():
         self._local_dir = os.path.dirname(self._local_path)
         self._model_metadata = None
         self._s3_client = S3Client(region_name,
+                                   s3_endpoint_url,
                                    max_retry_attempts,
                                    backoff_time_sec)
 

--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/reward_function.py
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/reward_function.py
@@ -18,6 +18,7 @@ class RewardFunction():
     '''reward function upload, download, and parse
     '''
     def __init__(self, bucket, s3_key, region_name="us-east-1",
+                 s3_endpoint_url=None,
                  local_path="./custom_files/agent/customer_reward_function.py",
                  max_retry_attempts=5, backoff_time_sec=1.0):
         '''reward function upload, download, and parse
@@ -49,6 +50,7 @@ class RewardFunction():
         self._import_path = local_path.replace(".py", "").replace("./", "").replace("/", ".")
         self._reward_function = None
         self._s3_client = S3Client(region_name,
+                                   s3_endpoint_url,
                                    max_retry_attempts,
                                    backoff_time_sec)
 

--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/simtrace_video.py
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/simtrace_video.py
@@ -15,6 +15,7 @@ class SimtraceVideo():
     def __init__(self, upload_type, bucket, s3_prefix,
                  region_name="us-east-1", local_path="./custom_files/iteration_data/\
                  agent/file",
+                 s3_endpoint_url=None,
                  max_retry_attempts=5, backoff_time_sec=1.0):
         '''This class is for all s3 simtrace and video upload
 
@@ -36,6 +37,7 @@ class SimtraceVideo():
         self._local_path = local_path
         self._upload_num = 0
         self._s3_client = S3Client(region_name,
+                                   s3_endpoint_url, 
                                    max_retry_attempts,
                                    backoff_time_sec)
 

--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/yaml_file.py
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/files/yaml_file.py
@@ -29,7 +29,9 @@ class YamlFile():
     '''yaml file upload, download, and parse
     '''
     def __init__(self, agent_type, bucket, s3_key,
-                 region_name="us-east-1", local_path="params.yaml",
+                 region_name="us-east-1", 
+                 s3_endpoint_url=None, 
+                 local_path="params.yaml",
                  max_retry_attempts=5, backoff_time_sec=1.0):
         '''yaml upload, download, and parse
 
@@ -53,6 +55,7 @@ class YamlFile():
         self._s3_key = s3_key.replace('s3://{}/'.format(self._bucket), '')
         self._local_path = local_path
         self._s3_client = S3Client(region_name,
+                                   s3_endpoint_url,
                                    max_retry_attempts,
                                    backoff_time_sec)
         self._agent_type = agent_type

--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/s3_client.py
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/s3/s3_client.py
@@ -22,7 +22,7 @@ logger = Logger(__name__, logging.INFO).get_logger()
 
 
 class S3Client():
-    def __init__(self, region_name="us-east-1", max_retry_attempts=5, backoff_time_sec=1.0):
+    def __init__(self, region_name="us-east-1", s3_endpoint_url=None, max_retry_attempts=5, backoff_time_sec=1.0):
         '''S3 client
 
         Args:
@@ -32,6 +32,7 @@ class S3Client():
         '''
 
         self._region_name = region_name
+        self._s3_endpoint_url = s3_endpoint_url
         self._max_retry_attempts = max_retry_attempts
         self._backoff_time_sec = backoff_time_sec
 
@@ -46,6 +47,7 @@ class S3Client():
 
         s3_client = boto3.Session().client('s3',
                                            region_name=self._region_name,
+                                           endpoint_url=self._s3_endpoint_url,
                                            config=self._get_boto_config())
         return s3_client
 

--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/samples/sample_collector.py
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/samples/sample_collector.py
@@ -11,6 +11,7 @@ class SampleCollector:
     Sample Collector class to collect sample and persist to S3.
     """
     def __init__(self, bucket, s3_prefix, region_name,
+                 s3_endpoint_url=None,
                  max_sample_count=None, sampling_frequency=None,
                  max_retry_attempts=5, backoff_time_sec=1.0):
         '''Sample Collector class to collect sample and persist to S3.
@@ -35,6 +36,7 @@ class SampleCollector:
         self._cur_frequency = 0
         self._bucket = bucket
         self._s3_client = S3Client(region_name,
+                                   s3_endpoint_url,
                                    max_retry_attempts,
                                    backoff_time_sec)
 

--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/tournament_worker.py
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/markov/tournament_worker.py
@@ -256,6 +256,10 @@ def main():
                         type=str,
                         nargs='+',
                         default=rospy.get_param("MODEL_S3_PREFIX", ["sagemaker"]))
+    parser.add_argument('--s3_endpoint_url',
+                        help='(string) S3 endpoint URL',
+                        type=str,
+                        default=rospy.get_param("S3_ENDPOINT_URL", None))                             
     parser.add_argument('--aws_region',
                         help='(string) AWS region',
                         type=str,
@@ -301,7 +305,9 @@ def main():
     args = parser.parse_args()
     arg_s3_bucket = args.s3_bucket
     arg_s3_prefix = args.s3_prefix
-    logger.info("S3 bucket: %s \n S3 prefix: %s", arg_s3_bucket, arg_s3_prefix)
+    logger.info("S3 bucket: %s", args.s3_bucket)
+    logger.info("S3 prefix: %s", args.s3_prefix) 
+    logger.info("S3 endpoint URL: %s" % args.s3_endpoint_url)
 
     # tournament_worker: names to be displayed in MP4.
     # This is racer alias in tournament worker case.
@@ -382,6 +388,7 @@ def main():
         model_metadata = ModelMetadata(bucket=arg_s3_bucket[agent_index],
                                        s3_key=get_s3_key(arg_s3_prefix[agent_index], MODEL_METADATA_S3_POSTFIX),
                                        region_name=args.aws_region,
+                                       s3_endpoint_url=args.s3_endpoint_url,
                                        local_path=MODEL_METADATA_LOCAL_PATH_FORMAT.format(agent_name))
         _, _, version = model_metadata.get_model_metadata_info()
 
@@ -389,6 +396,7 @@ def main():
         checkpoint = Checkpoint(bucket=arg_s3_bucket[agent_index],
                                 s3_prefix=arg_s3_prefix[agent_index],
                                 region_name=args.aws_region,
+                                s3_endpoint_url=args.s3_endpoint_url,
                                 agent_name=agent_name,
                                 checkpoint_dir=args.local_model_directory)
         # make coach checkpoint compatible
@@ -430,6 +438,7 @@ def main():
 
         metrics_s3_config = {MetricsS3Keys.METRICS_BUCKET.value: metrics_s3_buckets[agent_index],
                              MetricsS3Keys.METRICS_KEY.value: metrics_s3_object_keys[agent_index],
+                             MetricsS3Keys.ENDPOINT_URL.value:  rospy.get_param('S3_ENDPOINT_URL', None),
                              # Replaced rospy.get_param('AWS_REGION') to be equal to the argument being passed
                              # or default argument set
                              MetricsS3Keys.REGION.value: args.aws_region}
@@ -440,6 +449,7 @@ def main():
                               bucket=simtrace_s3_bucket[agent_index],
                               s3_prefix=simtrace_s3_object_prefix[agent_index],
                               region_name=aws_region,
+                              s3_endpoint_url=args.s3_endpoint_url,
                               local_path=SIMTRACE_EVAL_LOCAL_PATH_FORMAT.format(agent_name)))
         if mp4_s3_bucket:
             simtrace_video_s3_writers.extend([
@@ -447,16 +457,19 @@ def main():
                               bucket=mp4_s3_bucket[agent_index],
                               s3_prefix=mp4_s3_object_prefix[agent_index],
                               region_name=aws_region,
+                              s3_endpoint_url=args.s3_endpoint_url,
                               local_path=CAMERA_PIP_MP4_LOCAL_PATH_FORMAT.format(agent_name)),
                 SimtraceVideo(upload_type=SimtraceVideoNames.DEGREE45.value,
                               bucket=mp4_s3_bucket[agent_index],
                               s3_prefix=mp4_s3_object_prefix[agent_index],
                               region_name=aws_region,
+                              s3_endpoint_url=args.s3_endpoint_url,
                               local_path=CAMERA_45DEGREE_LOCAL_PATH_FORMAT.format(agent_name)),
                 SimtraceVideo(upload_type=SimtraceVideoNames.TOPVIEW.value,
                               bucket=mp4_s3_bucket[agent_index],
                               s3_prefix=mp4_s3_object_prefix[agent_index],
                               region_name=aws_region,
+                              s3_endpoint_url=args.s3_endpoint_url,
                               local_path=CAMERA_TOPVIEW_LOCAL_PATH_FORMAT.format(agent_name))])
 
         run_phase_subject = RunPhaseSubject()


### PR DESCRIPTION
This patch allows the DeepRacer example to be used in a fully local mode with a different S3 endpoint. This is part of the activities we do in the AWS Deepracer Community (https://github.com/aws-deepracer-community)

Code should be non-intrusive, and should in theory trickle into all places where the DeepRacer Markov-code is used, e.g. the Robomaker code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
