### PR TITLE
fixed pandas deprecation warning

### DIFF
--- a/introduction_to_amazon_algorithms/deepar_electricity/DeepAR-Electricity.ipynb
+++ b/introduction_to_amazon_algorithms/deepar_electricity/DeepAR-Electricity.ipynb
@@ -274,7 +274,7 @@
     "training_data = [\n",
     "    {\n",
     "        \"start\": str(start_dataset),\n",
-    "        \"target\": ts[start_dataset:end_training - 1].tolist()  # We use -1, because pandas indexing includes the upper bound \n",
+    "        \"target\": ts[start_dataset:end_training - 1 * end_training.freq].tolist()  # We use -1, because pandas indexing includes the upper bound \n",
     "    }\n",
     "    for ts in timeseries\n",
     "]\n",
@@ -300,7 +300,7 @@
     "test_data = [\n",
     "    {\n",
     "        \"start\": str(start_dataset),\n",
-    "        \"target\": ts[start_dataset:end_training + k * prediction_length].tolist()\n",
+    "        \"target\": ts[start_dataset:end_training + k * prediction_length * end_training.freq].tolist()\n",
     "    }\n",
     "    for k in range(1, num_test_windows + 1) \n",
     "    for ts in timeseries\n",
@@ -779,9 +779,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "# Additional features\n",
     "\n",
@@ -1125,10 +1123,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.5"
   },
   "notice": "Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
the notebook was using a deprecated method while doing date manipulations which was generating a warning. the new way to subtracting dates has been implemented as part of the fix. the warning error is fixed now.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
