### PR TITLE
Fix: add 'import tensorflow as tf' required by _save_tf_model

### DIFF
--- a/reinforcement_learning/common/sagemaker_rl/coach_launcher.py
+++ b/reinforcement_learning/common/sagemaker_rl/coach_launcher.py
@@ -8,6 +8,7 @@ from rl_coach.core_types import SelectedPhaseOnlyDumpFilter, MaxDumpFilter, RunP
 import rl_coach.core_types 
 from rl_coach import logger
 from rl_coach.logger import screen
+import tensorflow as tf
 import argparse
 import copy
 import logging


### PR DESCRIPTION
*Description of changes:*
This fix adds `import tensorflow as tf` in `coach_launcher.py` because it is required by the `_save_tf_model` method.  The lack of this import leads to an error after training RL models using Coach with TensorFlow Framework.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
