### PR TITLE
GluonCV YoloV3 Darknet53 example minor fixes

### DIFF
--- a/sagemaker_neo_compilation_jobs/gluoncv_yolo_darknet/gluoncv_yolo_darknet_neo.ipynb
+++ b/sagemaker_neo_compilation_jobs/gluoncv_yolo_darknet/gluoncv_yolo_darknet_neo.ipynb
@@ -490,8 +490,10 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "%matplotlib inline\n",
     "def neo_visualize_detection(img_file, dets, classes=[], thresh=0.6):\n",
@@ -544,13 +546,6 @@
     "                                    fontsize=12, color='white')\n",
     "        plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",

--- a/sagemaker_neo_compilation_jobs/gluoncv_yolo_darknet/gluoncv_yolo_darknet_neo.ipynb
+++ b/sagemaker_neo_compilation_jobs/gluoncv_yolo_darknet/gluoncv_yolo_darknet_neo.ipynb
@@ -99,11 +99,13 @@
     "%%time\n",
     "# Download and extract the datasets\n",
     "\n",
-    "![ ! -f /tmp/VOCtrainval_11-May-2012.tar ] && { wget -P /tmp http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar; tar -xf /tmp/VOCtrainval_11-May-2012.tar; }\n",
+    "![ ! -f /tmp/VOCtrainval_11-May-2012.tar ] && { wget -P /tmp http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar; }\n",
     "\n",
-    "![ ! -f /tmp/VOCtrainval_06-Nov-2007.tar ] && { wget -P /tmp http://host.robots.ox.ac.uk/pascal/VOC/voc2007/VOCtrainval_06-Nov-2007.tar; tar -xf /tmp/VOCtrainval_06-Nov-2007.tar; }\n",
+    "![ ! -f /tmp/VOCtrainval_06-Nov-2007.tar ] && { wget -P /tmp http://host.robots.ox.ac.uk/pascal/VOC/voc2007/VOCtrainval_06-Nov-2007.tar; }\n",
     "\n",
-    "![ ! -f /tmp/VOCtest_06-Nov-2007.tar ] && { wget -P /tmp http://host.robots.ox.ac.uk/pascal/VOC/voc2007/VOCtest_06-Nov-2007.tar; tar -xf /tmp/VOCtest_06-Nov-2007.tar; }"
+    "![ ! -f /tmp/VOCtest_06-Nov-2007.tar ] && { wget -P /tmp http://host.robots.ox.ac.uk/pascal/VOC/voc2007/VOCtest_06-Nov-2007.tar; }\n",
+    "\n",
+    "![ ! -d VOCdevkit ] && { tar -xf /tmp/VOCtrainval_11-May-2012.tar; tar -xf /tmp/VOCtrainval_06-Nov-2007.tar; tar -xf /tmp/VOCtest_06-Nov-2007.tar; }"
    ]
   },
   {


### PR DESCRIPTION
*Description of changes:*

Fixes to [GluonCV YoloV3 Darknet53 example](https://github.com/awslabs/amazon-sagemaker-examples/commit/db08c55ec715362ce765bf18f3f3ad71a66e0a52):

- Corrects cell type from markdown to code
- Removes empty code cell

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
