### PR TITLE
Running tests in parallel for RL notebooks.

### DIFF
--- a/reinforcement_learning/testnotebooks.txt
+++ b/reinforcement_learning/testnotebooks.txt
@@ -1,2 +1,2 @@
-rl_cartpole_ray/rl_cartpole_ray_gymEnv.ipynb
-rl_cartpole_coach/rl_cartpole_coach_gymEnv.ipynb
+./rl_roboschool_ray/rl_roboschool_ray.ipynb
+./rl_cartpole_ray/rl_cartpole_ray_gymEnv.ipynb


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR enables running integration tests for RL notebooks in parallel to reduce the time spent on tests. Using the `multiprocessing` module, this change uses process-based parallelism to run all the papermill-executions (i.e., integration tests) simultaneously.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
