### PR TITLE
Add SDK version rollback code.

### DIFF
--- a/aws_sagemaker_studio/sagemaker_neo_compilation_jobs/deploy_tensorflow_model_on_Inf1_instance/tensorflow_distributed_mnist_neo_inf1_studio.ipynb
+++ b/aws_sagemaker_studio/sagemaker_neo_compilation_jobs/deploy_tensorflow_model_on_Inf1_instance/tensorflow_distributed_mnist_neo_inf1_studio.ipynb
@@ -34,6 +34,9 @@
    "source": [
     "import sagemaker\n",
     "if sagemaker.__version__ >= '2':\n",
+    "    orig_sm_version = sagemaker.__version__\n",
+    "    with open('orig_sm_version.txt', \"w\") as f:\n",
+    "        f.write(orig_sm_version)\n",
     "    %pip install \"sagemaker>=1.14.2,<2\"\n",
     "\n",
     "if sagemaker.__version__ >= '2':\n",
@@ -312,6 +315,36 @@
    "outputs": [],
    "source": [
     "sagemaker_session.delete_endpoint(optimized_predictor.endpoint)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Rollback the SageMaker Python SDK version"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# rollback the SageMaker Python SDK to the kernel's original version\n",
+    "if os.path.exists('orig_sm_version.txt'):\n",
+    "    with open('orig_sm_version.txt', 'r') as f:\n",
+    "        orig_sm_version = f.read()\n",
+    "    print(f\"Original version: {orig_sm_version}\")\n",
+    "    print(f\"Current version: {sagemaker.__version__}\")\n",
+    "    %pip install sagemaker=={orig_sm_version}\n",
+    "    os.remove('orig_sm_version.txt')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Restart the kernel to run the updated version of the SDK."
    ]
   }
  ],


### PR DESCRIPTION
Added code to store the original SDK version to a file before the SDK is downgraded to 1.72, and to roll the version back to the original SDK version after the notebook completes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
