### PR TITLE
fix: resolve breaking changes of neo container, adding `softmax_label…

### DIFF
--- a/sagemaker-python-sdk/mxnet_mnist/mxnet_mnist.ipynb
+++ b/sagemaker-python-sdk/mxnet_mnist/mxnet_mnist.ipynb
@@ -154,7 +154,7 @@
     "    output_path = '/'.join(mnist_estimator.output_path.split('/')[:-1])\n",
     "    neo_optimize = True\n",
     "    compiled_model = mnist_estimator.compile_model(target_instance_family='ml_m4', \n",
-    "                                                   input_shape={'data':[1, 784]},\n",
+    "                                                   input_shape={'data':[1, 784], 'softmax_label': [1]},\n",
     "                                                   role=role,\n",
     "                                                   output_path=output_path)"
    ]


### PR DESCRIPTION
…` to `compile_model`

*Issue #, if available:*
NEO container's breaking change requires `softmax_label` as an arg of `compile_model`
Related changes: https://github.com/aws/sagemaker-python-sdk/pull/1934/files 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
