### PR TITLE
Separate MXNet and Tensorflow code for coach-launcher

### DIFF
--- a/reinforcement_learning/common/sagemaker_rl/save_coach_model_mxnet.py
+++ b/reinforcement_learning/common/sagemaker_rl/save_coach_model_mxnet.py
@@ -1,0 +1,25 @@
+import glob
+import os
+import re
+import shutil
+from rl_coach.logger import screen
+
+def save_onnx_model():
+    from .onnx_utils import fix_onnx_model
+    ckpt_dir = '/opt/ml/output/data/checkpoint'
+    model_dir = '/opt/ml/model'
+    # find latest onnx file
+    # currently done by name, expected to be changed in future release of coach.
+    glob_pattern = os.path.join(ckpt_dir, '*.onnx')
+    onnx_files = [file for file in glob.iglob(glob_pattern, recursive=True)]
+    if len(onnx_files) > 0:
+        extract_step = lambda string: int(re.search('/(\d*)_Step.*', string, re.IGNORECASE).group(1))
+        onnx_files.sort(key=extract_step)
+        latest_onnx_file = onnx_files[-1]
+        # move to model directory
+        filepath_from = os.path.abspath(latest_onnx_file)
+        filepath_to = os.path.join(model_dir, "model.onnx")
+        shutil.move(filepath_from, filepath_to)
+        fix_onnx_model(filepath_to)
+    else:
+        screen.warning("No ONNX files found in {}".format(ckpt_dir))

--- a/reinforcement_learning/common/sagemaker_rl/save_coach_model_tensorflow.py
+++ b/reinforcement_learning/common/sagemaker_rl/save_coach_model_tensorflow.py
@@ -1,0 +1,33 @@
+import shutil
+import tensorflow as tf
+
+def save_tf_model():
+    ckpt_dir = '/opt/ml/output/data/checkpoint'
+    model_dir = '/opt/ml/model'
+
+    # Re-Initialize from the checkpoint so that you will have the latest models up.
+    tf.train.init_from_checkpoint(ckpt_dir,
+                                    {'main_level/agent/online/network_0/': 'main_level/agent/online/network_0'})
+    tf.train.init_from_checkpoint(ckpt_dir,
+                                    {'main_level/agent/online/network_1/': 'main_level/agent/online/network_1'})
+
+    # Create a new session with a new tf graph.
+    sess = tf.Session(config=tf.ConfigProto(allow_soft_placement=True))
+    sess.run(tf.global_variables_initializer())  # initialize the checkpoint.
+
+    # This is the node that will accept the input.
+    input_nodes = tf.get_default_graph().get_tensor_by_name('main_level/agent/main/online/' + \
+                                                            'network_0/observation/observation:0')
+    # This is the node that will produce the output.
+    output_nodes = tf.get_default_graph().get_operation_by_name('main_level/agent/main/online/' + \
+                                                                'network_1/ppo_head_0/policy')
+    # Save the model as a servable model.
+    tf.saved_model.simple_save(session=sess,
+                                export_dir='model',
+                                inputs={"observation": input_nodes},
+                                outputs={"policy": output_nodes.outputs[0]})
+    # Move to the appropriate folder. Don't mind the directory, this just works.
+    # rl-cart-pole is the name of the model. Remember it.
+    shutil.move('model/', model_dir + '/model/tf-model/00000001/')
+    # EASE will pick it up and upload to the right path.
+    print("Success")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
RL Coach notebooks use MXNet in the backend, but the code also imports tensorflow. This causes the notebooks to error out during training, as the docker image for training doesn't have tensorflow. This change will fix the behaviour so that only notebooks that need tensorflow will import it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
