### PR TITLE
In deepar_chicago_traffic_violations.ipynb, removed conda command to install s3fs

### DIFF
--- a/introduction_to_applying_machine_learning/deepar_chicago_traffic_violations/deepar_chicago_traffic_violations.ipynb
+++ b/introduction_to_applying_machine_learning/deepar_chicago_traffic_violations/deepar_chicago_traffic_violations.ipynb
@@ -81,7 +81,6 @@
     "import matplotlib.pyplot as plt\n",
     "import pandas as pd\n",
     "\n",
-    "!conda install -y s3fs\n",
     "import s3fs"
    ]
   },
@@ -449,7 +448,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.10"
   },
   "notice": "Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved. Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },


### PR DESCRIPTION
Fixes #1399 

Removed conda command to install s3fs.

Successfully ran notebook without errors. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
