### PR TITLE
fixing multi-instance and multi-GPU PyTorch DistributedDataParallel training to use all GPUs

### DIFF
--- a/sagemaker-python-sdk/pytorch_mnist/pytorch_mnist.ipynb
+++ b/sagemaker-python-sdk/pytorch_mnist/pytorch_mnist.ipynb
@@ -156,7 +156,7 @@
     "\n",
     "estimator = PyTorch(entry_point='mnist.py',\n",
     "                    role=role,\n",
-    "                    framework_version='1.4.0',\n",
+    "                    framework_version='1.6.0',\n",
     "                    train_instance_count=2,\n",
     "                    train_instance_type='ml.c4.xlarge',\n",
     "                    hyperparameters={\n",


### PR DESCRIPTION
*Issue #, if available:*

None

*Description of changes:*

The existing pytorch distributed training example does not spawn workers per GPU, which results in utilizing 1 GPU on each instance. So, this is a fix to utilize all the GPUs by spawning workers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
