### PR TITLE
updated for sagemaker python sdk 2.x

### DIFF
--- a/autopilot/autopilot_customer_churn_high_level_with_evaluation.ipynb
+++ b/autopilot/autopilot_customer_churn_high_level_with_evaluation.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "---\n",
     "\n",
-    "This notebook works with sagemaker python sdk >= 1.65.1.\n",
+    "This notebook works with sagemaker python sdk 2.x\n",
     "\n",
     "## Contents\n",
     "\n",
@@ -794,17 +794,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sagemaker.predictor import RealTimePredictor\n",
-    "from sagemaker.content_types import CONTENT_TYPE_CSV\n",
+    "from sagemaker.predictor import Predictor\n",
+    "from sagemaker.serializers import CSVSerializer\n",
+    "from sagemaker.deserializers import CSVDeserializer\n",
     "\n",
     "predictor = automl.deploy(initial_instance_count=1,\n",
     "                          instance_type='ml.m5.2xlarge',\n",
     "                          candidate=candidates[best_candidate_idx],\n",
     "                          inference_response_keys=inference_response_keys,\n",
-    "                          predictor_cls=RealTimePredictor)\n",
-    "predictor.content_type = CONTENT_TYPE_CSV\n",
+    "                          predictor_cls=Predictor,\n",
+    "                          serializer=CSVSerializer(),\n",
+    "                          deserializer=CSVDeserializer())\n",
     "\n",
-    "print(\"Created endpoint: {}\".format(predictor.endpoint))\n"
+    "print(\"Created endpoint: {}\".format(predictor.endpoint_name))\n"
    ]
   },
   {
@@ -829,11 +831,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from io import StringIO\n",
-    "\n",
-    "prediction = predictor.predict(test_data_no_target.to_csv(sep=',', header=False, index=False)).decode('utf-8')\n",
-    "prediction_df = pd.read_csv(StringIO(prediction), header=None, names=inference_response_keys)\n",
-    "custom_predicted_labels = prediction_df.iloc[:,1].values >= best_candidate_threshold\n",
+    "prediction = predictor.predict(test_data_no_target.to_csv(sep=',', header=False, index=False))\n",
+    "prediction_df = pd.DataFrame(prediction, columns=inference_response_keys)\n",
+    "custom_predicted_labels = prediction_df.iloc[:,1].astype(float).values >= best_candidate_threshold\n",
     "prediction_df['custom_predicted_label'] = custom_predicted_labels\n",
     "prediction_df['custom_predicted_label'] = prediction_df['custom_predicted_label'].map({False: target_attribute_values[0], True: target_attribute_values[1]})\n",
     "prediction_df"


### PR DESCRIPTION
*Issue #, if available:*
1530

*Description of changes:*
The notebook by default will install the latest version of sagemaker python sdk, which is 2.x and incompatible with the **predictor** and **prediction** sections (expecting version 1.x)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
