### PR TITLE
Fixed predictions showing as array of False instead of a single True or False value

### DIFF
--- a/sagemaker-python-sdk/tensorflow_script_mode_training_and_serving/tensorflow_script_mode_training_and_serving.ipynb
+++ b/sagemaker-python-sdk/tensorflow_script_mode_training_and_serving/tensorflow_script_mode_training_and_serving.ipynb
@@ -268,7 +268,7 @@
    "source": [
     "predictions = predictor.predict(train_data[:50])\n",
     "for i in range(0, 50):\n",
-    "    prediction = np.argmax(predictions['predictions'][i]['classes'])\n",
+    "    prediction = np.argmax(predictions['predictions'][i])\n",
     "    label = train_labels[i]\n",
     "    print('prediction is {}, label is {}, matched: {}'.format(prediction, label, prediction == label))"
    ]

--- a/sagemaker-python-sdk/tensorflow_script_mode_training_and_serving/tensorflow_script_mode_training_and_serving.ipynb
+++ b/sagemaker-python-sdk/tensorflow_script_mode_training_and_serving/tensorflow_script_mode_training_and_serving.ipynb
@@ -268,7 +268,7 @@
    "source": [
     "predictions = predictor.predict(train_data[:50])\n",
     "for i in range(0, 50):\n",
-    "    prediction = predictions['predictions'][i]['classes']\n",
+    "    prediction = np.argmax(predictions['predictions'][i]['classes'])\n",
     "    label = train_labels[i]\n",
     "    print('prediction is {}, label is {}, matched: {}'.format(prediction, label, prediction == label))"
    ]
@@ -288,7 +288,7 @@
    "source": [
     "predictions2 = predictor2.predict(train_data[:50])\n",
     "for i in range(0, 50):\n",
-    "    prediction = predictions2['predictions'][i]\n",
+    "    prediction = np.argmax(predictions2['predictions'][i])\n",
     "    label = train_labels[i]\n",
     "    print('prediction is {}, label is {}, matched: {}'.format(prediction, label, prediction == label))"
    ]

--- a/sagemaker-python-sdk/tensorflow_script_mode_training_and_serving/tensorflow_script_mode_training_and_serving.ipynb
+++ b/sagemaker-python-sdk/tensorflow_script_mode_training_and_serving/tensorflow_script_mode_training_and_serving.ipynb
@@ -268,7 +268,7 @@
    "source": [
     "predictions = predictor.predict(train_data[:50])\n",
     "for i in range(0, 50):\n",
-    "    prediction = np.argmax(predictions['predictions'][i])\n",
+    "    prediction = predictions['predictions'][i]['classes']\n",
     "    label = train_labels[i]\n",
     "    print('prediction is {}, label is {}, matched: {}'.format(prediction, label, prediction == label))"
    ]


### PR DESCRIPTION
Fixed predictions showing as array of False instead of showing whether prediction is correct (True or False)
*Issue #, if available:*
Examining the prediction result from the TensorFlow 2.1 model, the output of matched was an array of False.
Example:
`prediction is [4.14109127e-06, 5.25921951e-06, 0.0425464138, 0.33870548, 4.62210573e-06, 8.76268314e-05, 1.13695599e-07, 0.617668867, 0.000189132668, 0.000788310659], label is 7, matched: [False False False False False False False False False False]`

*Description of changes:*
Adding `np.argmax` in order to get absolute highest value of prediction.

After the fix, it looks like this:
`prediction is 7, label is 7, matched: True`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
