### PR TITLE
Remove 'pip install sagemaker' as SDK v2 is the default version on the notebooks.

### DIFF
--- a/reinforcement_learning/bandits_recsys_movielens_testbed/bandits_movielens_testbed.ipynb
+++ b/reinforcement_learning/bandits_recsys_movielens_testbed/bandits_movielens_testbed.ipynb
@@ -60,16 +60,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Install sagemaker SDK v2\n",
-    "!pip install sagemaker==2.16.1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import sagemaker\n",
     "import boto3\n",
     "import sys\n",

--- a/reinforcement_learning/bandits_statlog_vw_customEnv/bandits_statlog_vw_customEnv.ipynb
+++ b/reinforcement_learning/bandits_statlog_vw_customEnv/bandits_statlog_vw_customEnv.ipynb
@@ -66,16 +66,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Install sagemaker SDK v2\n",
-    "!pip install sagemaker==2.16.1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import yaml\n",
     "import sys\n",
     "import numpy as np\n",

--- a/reinforcement_learning/rl_cartpole_batch_coach/rl_cartpole_batch_coach.ipynb
+++ b/reinforcement_learning/rl_cartpole_batch_coach/rl_cartpole_batch_coach.ipynb
@@ -34,16 +34,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Install sagemaker SDK v2\n",
-    "!pip install sagemaker==2.16.1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import sagemaker\n",
     "import boto3\n",
     "import sys\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
