### PR TITLE
Pytorch mnist refactor 2

### DIFF
--- a/pytorch/mnist/01_train_pytorch.ipynb
+++ b/pytorch/mnist/01_train_pytorch.ipynb
@@ -1,0 +1,223 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# MNIST Training using PyTorch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Contents\n",
+    "\n",
+    "1. [Background](#Background)\n",
+    "1. [Setup](#Setup)\n",
+    "1. [Data](#Data)\n",
+    "1. [Train](#Train)\n",
+    "1. [Host](#Host)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Background\n",
+    "\n",
+    "MNIST is a widely used dataset for handwritten digit classification. It consists of 70,000 labeled 28x28 pixel grayscale images of hand-written digits. The dataset is split into 60,000 training images and 10,000 test images. There are 10 classes (one for each of the 10 digits). This tutorial will show how to train and test an MNIST model on SageMaker using PyTorch.\n",
+    "\n",
+    "For more information about the PyTorch in SageMaker, please visit [sagemaker-pytorch-containers](https://github.com/aws/sagemaker-pytorch-containers) and [sagemaker-python-sdk](https://github.com/aws/sagemaker-python-sdk) github repositories.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Setup\n",
+    "\n",
+    "_This notebook was created and tested on an ml.m4.xlarge notebook instance._\n",
+    "\n",
+    "Let's start by creating a SageMaker session and specifying:\n",
+    "\n",
+    "- The S3 bucket and prefix that you want to use for training and model data.  This should be within the same region as the Notebook Instance, training, and hosting.\n",
+    "- The IAM role arn used to give training and hosting access to your data. See the documentation for how to create these.  Note, if more than one role is required for notebook instances, training, and/or hosting, please replace the `sagemaker.get_execution_role()` with a the appropriate full IAM role arn string(s).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sagemaker\n",
+    "\n",
+    "sagemaker_session = sagemaker.Session()\n",
+    "\n",
+    "bucket = sagemaker_session.default_bucket()\n",
+    "prefix = 'sagemaker/DEMO-pytorch-mnist'\n",
+    "\n",
+    "role = sagemaker.get_execution_role()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data\n",
+    "### Getting the data\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torchvision import datasets, transforms\n",
+    "\n",
+    "datasets.MNIST('data', download=True, transform=transforms.Compose([\n",
+    "    transforms.ToTensor(),\n",
+    "    transforms.Normalize((0.1307,), (0.3081,))\n",
+    "]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Uploading the data to S3\n",
+    "We are going to use the `sagemaker.Session.upload_data` function to upload our datasets to an S3 location. The return value inputs identifies the location -- we will use later when we start the training job.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inputs = sagemaker_session.upload_data(path='data', bucket=bucket, key_prefix=prefix)\n",
+    "print('input spec (in this case, just an S3 path): {}'.format(inputs))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train\n",
+    "### Training script\n",
+    "The `mnist.py` script provides all the code we need for training and hosting a SageMaker model (`model_fn` function to load a model).\n",
+    "The training script is very similar to a training script you might run outside of SageMaker, but you can access useful properties about the training environment through various environment variables, such as:\n",
+    "\n",
+    "* `SM_MODEL_DIR`: A string representing the path to the directory to write model artifacts to.\n",
+    "  These artifacts are uploaded to S3 for model hosting.\n",
+    "* `SM_NUM_GPUS`: The number of gpus available in the current container.\n",
+    "* `SM_CURRENT_HOST`: The name of the current container on the container network.\n",
+    "* `SM_HOSTS`: JSON encoded list containing all the hosts .\n",
+    "\n",
+    "Supposing one input channel, 'training', was used in the call to the PyTorch estimator's `fit()` method, the following will be set, following the format `SM_CHANNEL_[channel_name]`:\n",
+    "\n",
+    "* `SM_CHANNEL_TRAINING`: A string representing the path to the directory containing data in the 'training' channel.\n",
+    "\n",
+    "For more information about training environment variables, please visit [SageMaker Containers](https://github.com/aws/sagemaker-containers).\n",
+    "\n",
+    "A typical training script loads data from the input channels, configures training with hyperparameters, trains a model, and saves a model to `model_dir` so that it can be hosted later. Hyperparameters are passed to your script as arguments and can be retrieved with an `argparse.ArgumentParser` instance.\n",
+    "\n",
+    "Because the SageMaker imports the training script, you should put your training code in a main guard (``if __name__=='__main__':``) if you are using the same script to host your model as we do in this example, so that SageMaker does not inadvertently run your training code at the wrong point in execution.\n",
+    "\n",
+    "For example, the script run by this notebook:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pygmentize mnist.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Run training in SageMaker\n",
+    "\n",
+    "The `PyTorch` class allows us to run our training function as a training job on SageMaker infrastructure. We need to configure it with our training script, an IAM role, the number of training instances, the training instance type, and hyperparameters. In this case we are going to run our training job on 2 ```ml.c4.xlarge``` instances. But this example can be ran on one or multiple, cpu or gpu instances ([full list of available instances](https://aws.amazon.com/sagemaker/pricing/instance-types/)). The hyperparameters parameter is a dict of values that will be passed to your training script -- you can see how to access these values in the `mnist.py` script above.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.pytorch import PyTorch\n",
+    "\n",
+    "estimator = PyTorch(entry_point='code/train.py',\n",
+    "                    role=role,\n",
+    "                    framework_version='1.6.0',\n",
+    "                    train_instance_count=2,\n",
+    "                    train_instance_type='ml.c4.xlarge',\n",
+    "                    hyperparameters={\n",
+    "                        'epochs': 6,\n",
+    "                        'backend': 'gloo'\n",
+    "                    })"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After we've constructed our `PyTorch` object, we can fit it using the data we uploaded to S3. SageMaker makes sure our data is available in the local filesystem, so our training script can simply read the data from disk.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "estimator.fit({'training': inputs})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next Step\n",
+    "Now that you have trained the model, you can depoly an endpoint to host the model. After you depolyed the endpoint, you can then test\n",
+    "it with inference requests. The following cell will store the `model_data` to be used with the inference notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_data = estimator.model_data\n",
+    "print(\"Storing {} as model_data\".format(model_data))\n",
+    "%store model_data"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  },
+  "notice": "Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pytorch/mnist/02_infer_pytroch.ipynb
+++ b/pytorch/mnist/02_infer_pytroch.ipynb
@@ -1,0 +1,183 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SageMaker Endpoint\n",
+    "To deploy the model you [previously trained](01_train_pytorch.ipynb), you need to create a SageMaker Endpoint. This is hosted prediction\n",
+    "service that you can use to perform inference.\n",
+    "\n",
+    "## Finding the model\n",
+    "This notebook uses a stored model. If you recently ran a training example uses %store% magic, it will be restored in the next cell.\n",
+    "\n",
+    "Otherwise, you can pass the URI to the model file (a .tar.gz file) in the `model_data` variable.\n",
+    "\n",
+    "You can find your model file through [SageMaker Console](https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/dashboard)\n",
+    "by choosing **Training > Training jobs** in the left navigation pane. Find your current training job, choose it and then look for the s3:// link in the **Output** pane. If you have not run the [training notebook](01_train_pytorch.ipynb) you can still run this notebook by using a model artifact we have pretrained. To do so, uncomment the `model_data` line in the next cell that manually sets the model's URI. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Retrieve a saved model from a previous notebook run's stored variable\n",
+    "%store -r model_data\n",
+    "\n",
+    "# If no model was found, set it manually here.\n",
+    "# model_data = 's3://sagemaker-us-west-2-688520471316/pytorch-herring-mnist-2020-10-16-17-15-16-419/output/model.tar.gz'\n",
+    "\n",
+    "print(\"Using this model: {}\".format(model_data))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a model object\n",
+    "You define the model object by using SageMaker SDK's `PyTorchModel` and pass in the model from the `model_data` and `entry_point`. \n",
+    "The endpoint's entry point for inference is defined by `model_fn` as seen in the following code block that prints out `inference.py`. \n",
+    "The function loads the model and sets it to use GPU, if available."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pygmentize code/inference.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sagemaker\n",
+    "\n",
+    "role = sagemaker.get_execution_role()\n",
+    "\n",
+    "from sagemaker.pytorch import PyTorchModel\n",
+    "model = PyTorchModel(\n",
+    "    model_data=model_data,\n",
+    "    source_dir='code',\n",
+    "    entry_point='inference.py',\n",
+    "    role=role,\n",
+    "    framework_version='1.6.0',\n",
+    "    py_version='py3')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Deploy the model on an endpoint\n",
+    "You create a `predictor` by using the `model.deploy` function. You can optionally change both the instance count and instance type."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictor = model.deploy(\n",
+    "    initial_instance_count=1,\n",
+    "    instance_type='ml.m4.xlarge'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download the test set\n",
+    "import numpy as np\n",
+    "import random\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "\n",
+    "from code.utils import mnist_to_numpy\n",
+    "\n",
+    "data_dir = './data'\n",
+    "X, Y = mnist_to_numpy(data) # test images and labels\n",
+    "\n",
+    "# randomly sample 16 images from the test set\n",
+    "mask = random.sample(range(X.shape[0]), 16)\n",
+    "samples = X[mask]\n",
+    "\n",
+    "# plot the images for inspect\n",
+    "fig, axs = plt.subplots(nrows=1, ncols=16, figsize=(16, 1))\n",
+    "\n",
+    "for i, splt in enumerate(axs):\n",
+    "    splt.imshow(samples[i])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from code.utils import adjust_to_framework, normalize\n",
+    "\n",
+    "# Send the sampled images to the endpoint for inference\n",
+    "samples = adjust_to_framework(\n",
+    "    normalize(samples, axis=(1, 2)), framework='pytorch')\n",
+    "\n",
+    "# depolyed model only accept 32-bit floating pt as input\n",
+    "outputs = predictor.predict(samples.astype(np.float32))\n",
+    "\n",
+    "predictions = np.argmax(np.array(outputs, np.float32), axis=1)\n",
+    "print(\"Predictions: \\n\", predictions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Clean-up\n",
+    "If you don't intend to do anything else with the endpoint you should delete it. You can also\n",
+    "free some disk space by deleting the MNIST data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import shutil\n",
+    "predictor.delete_endpoint()\n",
+    "shutil.rmtree(data_dir)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pytorch/mnist/code/inference.py
+++ b/pytorch/mnist/code/inference.py
@@ -1,0 +1,12 @@
+import torch
+from train import Net
+
+def model_fn(model_dir):
+    """Load model"""
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = torch.nn.DataParallel(Net())
+    with open(os.path.join(model_dir, 'model.pth'), 'rb') as f:
+        model.load_state_dict(torch.load(f))
+    return model.to(device)
+
+

--- a/pytorch/mnist/code/train.py
+++ b/pytorch/mnist/code/train.py
@@ -1,0 +1,203 @@
+import argparse
+import json
+import logging
+import os
+import sys
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+import torch.utils.data
+import torch.utils.data.distributed
+from torchvision import datasets, transforms
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
+
+# Based on https://github.com/pytorch/examples/blob/master/mnist/main.py
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(1, 10, kernel_size=5)
+        self.conv2 = nn.Conv2d(10, 20, kernel_size=5)
+        self.conv2_drop = nn.Dropout2d()
+        self.fc1 = nn.Linear(320, 50)
+        self.fc2 = nn.Linear(50, 10)
+
+    def forward(self, x):
+        x = F.relu(F.max_pool2d(self.conv1(x), 2))
+        x = F.relu(F.max_pool2d(self.conv2_drop(self.conv2(x)), 2))
+        x = x.view(-1, 320)
+        x = F.relu(self.fc1(x))
+        x = F.dropout(x, training=self.training)
+        x = self.fc2(x)
+        return F.log_softmax(x, dim=1)
+
+
+def _get_train_data_loader(batch_size, training_dir, is_distributed, **kwargs):
+    logger.info("Get train data loader")
+    dataset = datasets.MNIST(training_dir, train=True, download=True, 
+        transform=transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.1307,), (0.3081,))
+    ]))
+    train_sampler = torch.utils.data.distributed.DistributedSampler(dataset) if is_distributed else None
+    return torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=train_sampler is None,
+                                       sampler=train_sampler, **kwargs)
+
+
+def _get_test_data_loader(test_batch_size, training_dir, **kwargs):
+    logger.info("Get test data loader")
+    return torch.utils.data.DataLoader(
+        datasets.MNIST(training_dir, train=False, download=True, 
+            transform=transforms.Compose([
+            transforms.ToTensor(),
+            transforms.Normalize((0.1307,), (0.3081,))
+        ])),
+        batch_size=test_batch_size, shuffle=True, **kwargs)
+
+
+def _average_gradients(model):
+    # Gradient averaging.
+    size = float(dist.get_world_size())
+    for param in model.parameters():
+        dist.all_reduce(param.grad.data, op=dist.reduce_op.SUM)
+        param.grad.data /= size
+
+
+def train(args):
+    if not os.path.exists(args.model_dir):
+        os.makedirs(args.model_dir)
+    is_distributed = (not args.debug) and len(args.hosts) > 1 and args.backend is not None
+    logger.debug("Distributed training - {}".format(is_distributed))
+    use_cuda = args.num_gpus > 0
+    logger.debug("Number of gpus available - {}".format(args.num_gpus))
+    kwargs = {'num_workers': 1, 'pin_memory': True} if use_cuda else {}
+    device = torch.device("cuda" if use_cuda else "cpu")
+
+    if is_distributed:
+        # Initialize the distributed environment.
+        world_size = len(args.hosts)
+        os.environ['WORLD_SIZE'] = str(world_size)
+        host_rank = args.hosts.index(args.current_host)
+        os.environ['RANK'] = str(host_rank)
+        dist.init_process_group(backend=args.backend, rank=host_rank, world_size=world_size)
+        logger.info('Initialized the distributed environment: \'{}\' backend on {} nodes. '.format(
+            args.backend, dist.get_world_size()) + 'Current host rank is {}. Number of gpus: {}'.format(
+            dist.get_rank(), args.num_gpus))
+
+    # set the seed for generating random numbers
+    torch.manual_seed(args.seed)
+    if use_cuda:
+        torch.cuda.manual_seed(args.seed)
+
+    train_loader = _get_train_data_loader(args.batch_size, args.data_dir, is_distributed, **kwargs)
+    test_loader = _get_test_data_loader(args.test_batch_size, args.data_dir, **kwargs)
+
+    logger.debug("Processes {}/{} ({:.0f}%) of train data".format(
+        len(train_loader.sampler), len(train_loader.dataset),
+        100. * len(train_loader.sampler) / len(train_loader.dataset)
+    ))
+
+    logger.debug("Processes {}/{} ({:.0f}%) of test data".format(
+        len(test_loader.sampler), len(test_loader.dataset),
+        100. * len(test_loader.sampler) / len(test_loader.dataset)
+    ))
+
+    model = Net().to(device)
+    if is_distributed and use_cuda:
+        # multi-machine multi-gpu case
+        model = torch.nn.parallel.DistributedDataParallel(model)
+    else:
+        # single-machine multi-gpu case or single-machine or multi-machine cpu case
+        model = torch.nn.DataParallel(model)
+
+    optimizer = optim.SGD(model.parameters(), lr=args.lr, momentum=args.momentum)
+
+    for epoch in range(1, args.epochs + 1):
+        model.train()
+        for batch_idx, (data, target) in enumerate(train_loader, 1):
+            data, target = data.to(device), target.to(device)
+            optimizer.zero_grad()
+            output = model(data)
+            loss = F.nll_loss(output, target)
+            loss.backward()
+            if is_distributed and not use_cuda:
+                # average gradients manually for multi-machine cpu case only
+                _average_gradients(model)
+            optimizer.step()
+            if batch_idx % args.log_interval == 0:
+                logger.info('Train Epoch: {} [{}/{} ({:.0f}%)] Loss: {:.6f}'.format(
+                    epoch, batch_idx * len(data), len(train_loader.sampler),
+                    100. * batch_idx / len(train_loader), loss.item()))
+        test(model, test_loader, device)
+    save_model(model, args.model_dir)
+
+
+def test(model, test_loader, device):
+    model.eval()
+    test_loss = 0
+    correct = 0
+    with torch.no_grad():
+        for data, target in test_loader:
+            data, target = data.to(device), target.to(device)
+            output = model(data)
+            test_loss += F.nll_loss(output, target, size_average=False).item()  # sum up batch loss
+            pred = output.max(1, keepdim=True)[1]  # get the index of the max log-probability
+            correct += pred.eq(target.view_as(pred)).sum().item()
+
+    test_loss /= len(test_loader.dataset)
+    logger.info('Test set: Average loss: {:.4f}, Accuracy: {}/{} ({:.0f}%)\n'.format(
+        test_loss, correct, len(test_loader.dataset),
+        100. * correct / len(test_loader.dataset)))
+
+
+def model_fn(model_dir):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = torch.nn.DataParallel(Net())
+    with open(os.path.join(model_dir, 'model.pth'), 'rb') as f:
+        model.load_state_dict(torch.load(f))
+    return model.to(device)
+
+
+def save_model(model, model_dir):
+    logger.info("Saving the model.")
+    path = os.path.join(model_dir, 'model.pth')
+    # recommended way from http://pytorch.org/docs/master/notes/serialization.html
+    torch.save(model.cpu().state_dict(), path)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+
+    # Data and model checkpoints directories
+    parser.add_argument('--batch-size', type=int, default=64, metavar='N',
+                        help='input batch size for training (default: 64)')
+    parser.add_argument('--test-batch-size', type=int, default=1000, metavar='N',
+                        help='input batch size for testing (default: 1000)')
+    parser.add_argument('--epochs', type=int, default=10, metavar='N',
+                        help='number of epochs to train (default: 10)')
+    parser.add_argument('--lr', type=float, default=0.01, metavar='LR',
+                        help='learning rate (default: 0.01)')
+    parser.add_argument('--momentum', type=float, default=0.5, metavar='M',
+                        help='SGD momentum (default: 0.5)')
+    parser.add_argument('--seed', type=int, default=1, metavar='S',
+                        help='random seed (default: 1)')
+    parser.add_argument('--log-interval', type=int, default=100, metavar='N',
+                        help='how many batches to wait before logging training status')
+    parser.add_argument('--backend', type=str, default=None,
+                        help='backend for distributed training (tcp, gloo on cpu and gloo, nccl on gpu)')
+    parser.add_argument('--debug', action='store_true', 
+                        help='debug this script')
+
+    # Container environment
+    parser.add_argument('--hosts', type=list, default=json.loads(os.environ['SM_HOSTS']))
+    parser.add_argument('--current-host', type=str, default=os.environ['SM_CURRENT_HOST'])
+    parser.add_argument('--model-dir', type=str, default=os.environ['SM_MODEL_DIR'])
+    parser.add_argument('--data-dir', type=str, default=os.environ['SM_CHANNEL_TRAINING'])
+    parser.add_argument('--num-gpus', type=int, default=os.environ['SM_NUM_GPUS'])
+
+    train(parser.parse_args())

--- a/pytorch/mnist/code/utils.py
+++ b/pytorch/mnist/code/utils.py
@@ -1,0 +1,98 @@
+import numpy as np
+from urllib import request
+import gzip 
+import os
+
+def mnist_to_numpy(data_dir='data', train=True):
+    """Download MNIST dataset and convert it to numpy array
+    
+    Args:
+        data_dir (str): directory to save the data
+        train (bool): download training set
+    
+    Returns:
+        tuple of images and labels as numpy arrays
+    """
+    
+    if not os.path.exists(data_dir):
+        os.makedirs(data_dir)
+    
+    base_url = "http://yann.lecun.com/exdb/mnist/"
+    
+    if train:
+        images_file = "train-images-idx3-ubyte.gz"
+        labels_file = "train-labels-idx1-ubyte.gz"
+    else:
+        images_file = "t10k-images-idx3-ubyte.gz"
+        labels_file = "t10k-labels-idx1-ubyte.gz"
+    
+    # download images and labels
+    if not os.path.exists(os.path.join(data_dir, images_file)):
+        request.urlretrieve(
+            os.path.join(base_url, images_file),
+            os.path.join(data_dir, images_file))
+     
+    if not os.path.exists(os.path.join(data_dir, labels_file)):
+        request.urlretrieve(
+            os.path.join(base_url, labels_file),
+            os.path.join(data_dir, labels_file))
+    
+    return _convert_to_numpy(data_dir, images_file, labels_file)
+
+
+def _convert_to_numpy(data_dir, images_file, labels_file):
+    """Byte string to numpy arrays"""
+    with gzip.open(os.path.join(data_dir, images_file), 'rb') as f:
+        images = np.frombuffer(f.read(), np.uint8, offset=16).reshape(-1, 28, 28)
+    
+    with gzip.open(os.path.join(data_dir, labels_file), 'rb') as f:
+        labels = np.frombuffer(f.read(), np.uint8, offset=8)
+
+    return (images, labels)
+
+def normalize(x, axis):
+    eps = np.finfo(float).eps
+
+    mean = np.mean(x, axis=axis, keepdims=True)
+    # avoid division by zero
+    std = np.std(x, axis=axis, keepdims=True) + eps
+    return (x - mean) / std
+
+def adjust_to_framework(x, framework='pytorch'):
+    """Adjust a ``numpy.ndarray`` to be used as input for specified framework
+    
+    Args:
+        x (numpy.ndarray): Batch of images to be adjusted 
+            to follow the convention in pytorch / tensorflow / mxnet
+            
+        framework (str): Framework to use. Takes value in
+            ``pytorch``, ``tensorflow`` or ``mxnet``
+    Return:
+        numpy.ndarray following the convention of tensors in the given
+        framework
+    """
+    
+    if x.ndim == 3:
+        # input is gray-scale
+        x = np.expand_dims(x, 1)
+    
+    if framework in ['pytorch', 'mxnet']:
+        # depth-major
+        return x
+    elif framework == 'tensorlfow':
+        # depth-minor
+        return np.transpose(x, (0, 2, 3, 1))
+    elif framework == 'mxnet':
+        return x
+    else:
+        raise ValueError('framework must be one of ' + \
+                        '[pytorch, tensorflow, mxnet], got {}'.format(framework))
+
+if __name__ == '__main__':
+    X, Y = mnist_to_numpy()
+    X, Y = X.astype(np.float32), Y.astype(np.int8)
+
+    
+    
+    
+    


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1.Split training and inference into different notebooks
2.entry points train.py and inference.py reside in code/
3.use samples from test set to validate the endpoints
4.when testing the endpoint, we download mnist directly from Yann LeCun's website and convert it to numpy array of appropriate shapes depending on the deep learning framework


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
