### PR TITLE
SDK update for 5 coach nb examples

### DIFF
--- a/reinforcement_learning/rl_knapsack_coach_custom/rl_knapsack_coach_customEnv.ipynb
+++ b/reinforcement_learning/rl_knapsack_coach_custom/rl_knapsack_coach_customEnv.ipynb
@@ -227,9 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "if local_mode:\n",
@@ -241,11 +239,11 @@
     "                        source_dir='src',\n",
     "                        dependencies=[\"common/sagemaker_rl\"],\n",
     "                        toolkit=RLToolkit.COACH,\n",
-    "                        toolkit_version='0.11.0',\n",
+    "                        toolkit_version='1.0.0',\n",
     "                        framework=RLFramework.TENSORFLOW,\n",
     "                        role=role,\n",
-    "                        train_instance_type=instance_type,\n",
-    "                        train_instance_count=1,\n",
+    "                        instance_type=instance_type,\n",
+    "                        instance_count=1,\n",
     "                        output_path=s3_output_path,\n",
     "                        base_job_name=job_name_prefix,\n",
     "                        hyperparameters = {\n",
@@ -432,11 +430,11 @@
     "                      source_dir='src/',\n",
     "                      dependencies=[\"common/sagemaker_rl\"],\n",
     "                      toolkit=RLToolkit.COACH,\n",
-    "                      toolkit_version='0.11.0',\n",
+    "                      toolkit_version='1.0.0',\n",
     "                      framework=RLFramework.TENSORFLOW,\n",
     "                      entry_point=\"evaluate-coach.py\",\n",
-    "                      train_instance_count=1,\n",
-    "                      train_instance_type=instance_type,\n",
+    "                      instance_count=1,\n",
+    "                      instance_type=instance_type,\n",
     "                      hyperparameters = {\n",
     "                                 \"RLCOACH_PRESET\":\"preset-knapsack-clippedppo\",\n",
     "                                 \"evaluate_steps\": 250, #5 episodes\n",
@@ -472,7 +470,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.8.3"
   },
   "notice": "Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved. Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },

--- a/reinforcement_learning/rl_mountain_car_coach_gymEnv/rl_mountain_car_coach_gymEnv.ipynb
+++ b/reinforcement_learning/rl_mountain_car_coach_gymEnv/rl_mountain_car_coach_gymEnv.ipynb
@@ -266,8 +266,8 @@
     "                        toolkit_version='0.11.0',\n",
     "                        framework=RLFramework.MXNET,\n",
     "                        role=role,\n",
-    "                        train_instance_type=instance_type,\n",
-    "                        train_instance_count=1,\n",
+    "                        instance_type=instance_type,\n",
+    "                        instance_count=1,\n",
     "                        output_path=s3_output_path,\n",
     "                        base_job_name=job_name_prefix,\n",
     "                        hyperparameters = {                        \n",
@@ -491,8 +491,8 @@
     "                             toolkit_version='0.11.0',\n",
     "                             framework=RLFramework.MXNET,\n",
     "                             entry_point=\"evaluate-coach.py\",\n",
-    "                             train_instance_count=1,\n",
-    "                             train_instance_type=instance_type,\n",
+    "                             instance_count=1,\n",
+    "                             instance_type=instance_type,\n",
     "                             hyperparameters = {\n",
     "                                 \"RLCOACH_PRESET\": \"preset-mountain-car-continuous-clipped-ppo\",\n",
     "                                 \"evaluate_steps\": 10000*2 # evaluate on 2 episodes\n",
@@ -606,7 +606,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.8.3"
   },
   "notice": "Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved. Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },

--- a/reinforcement_learning/rl_portfolio_management_coach_customEnv/rl_portfolio_management_coach_customEnv.ipynb
+++ b/reinforcement_learning/rl_portfolio_management_coach_customEnv/rl_portfolio_management_coach_customEnv.ipynb
@@ -324,8 +324,8 @@
     "                      toolkit_version='0.11.0',\n",
     "                      framework=RLFramework.MXNET,\n",
     "                      role=role,\n",
-    "                      train_instance_count=1,\n",
-    "                      train_instance_type=instance_type,\n",
+    "                      instance_count=1,\n",
+    "                      instance_type=instance_type,\n",
     "                      output_path=s3_output_path,\n",
     "                      base_job_name=job_name_prefix,\n",
     "                      hyperparameters = {\n",
@@ -543,9 +543,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
@@ -557,8 +555,8 @@
     "                      toolkit_version='0.11.0',\n",
     "                      framework=RLFramework.MXNET,\n",
     "                      entry_point=\"evaluate-coach.py\",\n",
-    "                      train_instance_count=1,\n",
-    "                      train_instance_type=instance_type,\n",
+    "                      instance_count=1,\n",
+    "                      instance_type=instance_type,\n",
     "                      hyperparameters = {\n",
     "                          \"evaluate_steps\": 731*2 # evaluate on 2 episodes\n",
     "                      }\n",
@@ -580,9 +578,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "conda_python3",
+   "display_name": "conda_mxnet_p36",
    "language": "python",
-   "name": "conda_python3"
+   "name": "conda_mxnet_p36"
   },
   "language_info": {
    "codemirror_mode": {
@@ -594,7 +592,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.8.3"
   },
   "notice": "Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved. Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },

--- a/reinforcement_learning/rl_predictive_autoscaling_coach_customEnv/rl_predictive_autoscaling_coach_customEnv.ipynb
+++ b/reinforcement_learning/rl_predictive_autoscaling_coach_customEnv/rl_predictive_autoscaling_coach_customEnv.ipynb
@@ -341,11 +341,11 @@
     "                        source_dir='src',\n",
     "                        dependencies=[\"common/sagemaker_rl\"],\n",
     "                        toolkit=RLToolkit.COACH,\n",
-    "                        toolkit_version='0.11.0',\n",
+    "                        toolkit_version='1.0.0',\n",
     "                        framework=RLFramework.TENSORFLOW,\n",
     "                        role=role,\n",
-    "                        train_instance_type=instance_type,\n",
-    "                        train_instance_count=1,\n",
+    "                        instance_type=instance_type,\n",
+    "                        instance_count=1,\n",
     "                        output_path=s3_output_path,\n",
     "                        base_job_name=job_name_prefix,\n",
     "                        hyperparameters = {\n",
@@ -518,11 +518,11 @@
     "                      source_dir='src/',\n",
     "                      dependencies=[\"common/sagemaker_rl\"],\n",
     "                      toolkit=RLToolkit.COACH,\n",
-    "                      toolkit_version='0.11.0',\n",
+    "                      toolkit_version='1.0.0',\n",
     "                      framework=RLFramework.TENSORFLOW,\n",
     "                      entry_point=\"evaluate-coach.py\",\n",
-    "                      train_instance_count=1,\n",
-    "                      train_instance_type=instance_type,\n",
+    "                      instance_count=1,\n",
+    "                      instance_type=instance_type,\n",
     "                      hyperparameters = {\n",
     "                                 \"RLCOACH_PRESET\": \"preset-autoscale-ppo\",\n",
     "                                 \"evaluate_steps\": 10001*2 # evaluate on 2 episodes\n",
@@ -588,23 +588,23 @@
   }
  ],
  "metadata": {
- "anaconda-cloud": {},
+  "anaconda-cloud": {},
   "kernelspec": {
-    "name": "conda_tensorflow_p36",
-    "display_name": "conda_tensorflow_p36",
-    "language": "python"
+   "display_name": "conda_tensorflow_p36",
+   "language": "python",
+   "name": "conda_tensorflow_p36"
   },
   "language_info": {
-    "name": "python",
-    "version": "3.7.0",
-    "mimetype": "text/x-python",
-    "codemirror_mode": {
-      "name": "ipython",
-      "version": 3
-    },
-    "pygments_lexer": "ipython3",
-    "nbconvert_exporter": "python",
-    "file_extension": ".py"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
   },
   "notice": "Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved. Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },

--- a/reinforcement_learning/rl_traveling_salesman_vehicle_routing_coach/rl_traveling_salesman_vehicle_routing_coach.ipynb
+++ b/reinforcement_learning/rl_traveling_salesman_vehicle_routing_coach/rl_traveling_salesman_vehicle_routing_coach.ipynb
@@ -2,9 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "# Traveling Salesman Problem with Reinforcement Learning"
    ]
@@ -278,11 +276,11 @@
     "                        source_dir='src',\n",
     "                        dependencies = [\"common/sagemaker_rl\"],\n",
     "                        toolkit=RLToolkit.COACH,\n",
-    "                        toolkit_version='0.11.0',\n",
+    "                        toolkit_version='1.0.0',\n",
     "                        framework=RLFramework.TENSORFLOW,\n",
     "                        role=role,\n",
-    "                        train_instance_type=instance_type,\n",
-    "                        train_instance_count=1,\n",
+    "                        instance_type=instance_type,\n",
+    "                        instance_count=1,\n",
     "                        output_path=s3_output_path,\n",
     "                        base_job_name=job_name_prefix,\n",
     "                        hyperparameters = {\n",
@@ -542,11 +540,11 @@
     "                             source_dir='src/',\n",
     "                             dependencies = [\"common/sagemaker_rl\"],\n",
     "                             toolkit=RLToolkit.COACH,\n",
-    "                             toolkit_version='0.11.0',\n",
+    "                             toolkit_version='1.0.0',\n",
     "                             framework=RLFramework.TENSORFLOW,\n",
     "                             entry_point=\"evaluate-coach.py\",\n",
-    "                             train_instance_count=1,\n",
-    "                             train_instance_type=instance_type,\n",
+    "                             instance_count=1,\n",
+    "                             instance_type=instance_type,\n",
     "                             hyperparameters = {\n",
     "                                 \"RLCOACH_PRESET\": \"preset-tsp-easy\",\n",
     "                                 \"evaluate_steps\": 200, #max 4 episodes\n",
@@ -636,11 +634,11 @@
     "                        source_dir='src',\n",
     "                        dependencies = [\"common/sagemaker_rl\"],\n",
     "                        toolkit=RLToolkit.COACH,\n",
-    "                        toolkit_version='0.11.0',\n",
+    "                        toolkit_version='1.0.0',\n",
     "                        framework=RLFramework.TENSORFLOW,\n",
     "                        role=role,\n",
-    "                        train_instance_type=instance_type,\n",
-    "                        train_instance_count=1,\n",
+    "                        instance_type=instance_type,\n",
+    "                        instance_count=1,\n",
     "                        output_path=s3_output_path,\n",
     "                        base_job_name=job_name_prefix,\n",
     "                        hyperparameters = {\n",
@@ -752,11 +750,11 @@
     "                        source_dir='src',\n",
     "                        dependencies = [\"common/sagemaker_rl\"],\n",
     "                        toolkit=RLToolkit.COACH,\n",
-    "                        toolkit_version='0.11.0',\n",
+    "                        toolkit_version='1.0.0',\n",
     "                        framework=RLFramework.TENSORFLOW,\n",
     "                        role=role,\n",
-    "                        train_instance_type=instance_type,\n",
-    "                        train_instance_count=1,\n",
+    "                        instance_type=instance_type,\n",
+    "                        instance_count=1,\n",
     "                        output_path=s3_output_path,\n",
     "                        base_job_name=job_name_prefix,\n",
     "                        hyperparameters = {\n",
@@ -793,7 +791,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.8.3"
   },
   "notice": "Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved. Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },

--- a/reinforcement_learning/rl_traveling_salesman_vehicle_routing_coach/src/preset-tsp-medium.py
+++ b/reinforcement_learning/rl_traveling_salesman_vehicle_routing_coach/src/preset-tsp-medium.py
@@ -41,7 +41,7 @@ vis_params.dump_gifs=True
 ####################
 
 schedule_params=SimpleSchedule()
-schedule_params.improve_steps = TrainingSteps(5000000)
+schedule_params.improve_steps = TrainingSteps(200000)
 schedule_params.steps_between_evaluation_periods = EnvironmentEpisodes(20)
 schedule_params.evaluation_steps = EnvironmentEpisodes(5)
 schedule_params.heatup_steps = EnvironmentSteps(1000)


### PR DESCRIPTION
1. Bumped SDK version for 5 Coach notebook examples.
2. Decreased `schedule_params.improve_steps` in the tsp-medium notebook to control running time.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
