### PR TITLE
Fix sagemaker processing notebook to work with SDKv2

### DIFF
--- a/sagemaker_processing/scikit_learn_data_processing_and_model_evaluation/scikit_learn_data_processing_and_model_evaluation.ipynb
+++ b/sagemaker_processing/scikit_learn_data_processing_and_model_evaluation/scikit_learn_data_processing_and_model_evaluation.ipynb
@@ -254,6 +254,7 @@
     "\n",
     "sklearn = SKLearn(\n",
     "    entry_point='train.py',\n",
+    "    framework_version='0.20.0',\n",
     "    train_instance_type=\"ml.m5.xlarge\",\n",
     "    role=role)"
    ]


### PR DESCRIPTION
*Description of changes:* 
SDKv2 requires SKLearn estimator to specify a framework version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
