### PR TITLE
On Model Monitor intro example, updated calls to support SDKv2

### DIFF
--- a/sagemaker_model_monitor/introduction/SageMaker-ModelMonitoring.ipynb
+++ b/sagemaker_model_monitor/introduction/SageMaker-ModelMonitoring.ipynb
@@ -30,9 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "isConfigCell": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
@@ -126,13 +124,13 @@
    "source": [
     "from time import gmtime, strftime\n",
     "from sagemaker.model import Model\n",
-    "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
+    "from sagemaker.amazon.amazon_estimator import image_uris\n",
     "\n",
     "model_name = \"DEMO-xgb-churn-pred-model-monitor-\" + strftime(\"%Y-%m-%d-%H-%M-%S\", gmtime())\n",
     "model_url = 'https://{}.s3-{}.amazonaws.com/{}/xgb-churn-prediction-model.tar.gz'.format(bucket, region, prefix)\n",
-    "image_uri = get_image_uri(boto3.Session().region_name, 'xgboost', '0.90-1')\n",
+    "image_uri = image_uris.retrieve('xgboost', boto3.Session().region_name, version='0.90-1')\n",
     "\n",
-    "model = Model(image=image_uri, model_data=model_url, role=role)"
+    "model = Model(image_uri=image_uri, model_data=model_url, role=role)"
    ]
   },
   {
@@ -186,10 +184,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sagemaker.predictor import RealTimePredictor\n",
+    "from sagemaker.predictor import Predictor\n",
+    "client = boto3.client('sagemaker-runtime')\n",
     "import time\n",
     "\n",
-    "predictor = RealTimePredictor(endpoint=endpoint_name,content_type='text/csv')\n",
+    "predictor = Predictor(endpoint_name=endpoint_name)\n",
     "\n",
     "# get a subset of test data for a quick test\n",
     "!head -120 test_data/test-dataset-input-cols.csv > test_data/test_sample.csv\n",
@@ -198,7 +197,10 @@
     "with open('test_data/test_sample.csv', 'r') as f:\n",
     "    for row in f:\n",
     "        payload = row.rstrip('\\n')\n",
-    "        response = predictor.predict(data=payload)\n",
+    "        response = client.invoke_endpoint(\n",
+    "            EndpointName= endpoint_name,\n",
+    "            Body= payload[2:],\n",
+    "            ContentType = 'text/csv')\n",
     "        time.sleep(0.5)\n",
     "        \n",
     "print(\"Done!\")        "
@@ -218,9 +220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "s3_client = boto3.Session().client('s3')\n",
@@ -261,9 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import json\n",
@@ -467,7 +465,7 @@
     "mon_schedule_name = 'DEMO-xgb-churn-pred-model-monitor-schedule-' + strftime(\"%Y-%m-%d-%H-%M-%S\", gmtime())\n",
     "my_default_monitor.create_monitoring_schedule(\n",
     "    monitor_schedule_name=mon_schedule_name,\n",
-    "    endpoint_input=predictor.endpoint,\n",
+    "    endpoint_input=predictor.endpoint_name,\n",
     "    #record_preprocessor_script=pre_processor_script,\n",
     "    post_analytics_processor_script=s3_code_postprocessor_uri,\n",
     "    output_s3_uri=s3_report_path,\n",
@@ -497,7 +495,7 @@
     "from time import sleep\n",
     "import time\n",
     "\n",
-    "endpoint_name=predictor.endpoint\n",
+    "endpoint_name=predictor.endpoint_name\n",
     "runtime_client = boto3.client('runtime.sagemaker')\n",
     "\n",
     "# (just repeating code from above for convenience/ able to run this section independently)\n",
@@ -699,9 +697,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "predictor.delete_endpoint()"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changed the API calls to support SDKv2. SageMaker Studio currently uses v2 by default.
Examples: get_image_uri > image_uris.retrieve, RealTimePredictor > Predictor, endpoint > endpoint_name

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
