### PR TITLE
Correct spelling of 'Amazon SageMaker Processing'

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ These examples provide you an introduction to how to use Neo to optimizes deep l
 - [Distributed TensorFlow](sagemaker_neo_compilation_jobs/tensorflow_distributed_mnist) Adapts form [tensorflow mnist](sagemaker-python-sdk/tensorflow_distributed_mnist) including Neo API and comparsion between the baseline
 - [Predicting Customer Churn](sagemaker_neo_compilation_jobs/xgboost_customer_churn) Adapts form [xgboost customer churn](introduction_to_applying_machine_learning/xgboost_customer_churn) including Neo API and comparsion between the baseline
 
-### Amazon SageMaker Procesing
+### Amazon SageMaker Processing
 
 These examples show you how to use SageMaker Processing jobs to run data processing workloads.
 


### PR DESCRIPTION
Amazon SageMaker 'Procesing' -> Processing
Add the missing 's' 

jewarric@

*Issue #, if available:*

*Description of changes:*
Spelling correction on main README.
Amazon SageMaker Procesing -> Amazon SageMaker Processing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
