### PR TITLE
Update  with sagemakerV2 functions

### DIFF
--- a/introduction_to_amazon_algorithms/deepar_electricity/DeepAR-Electricity.ipynb
+++ b/introduction_to_amazon_algorithms/deepar_electricity/DeepAR-Electricity.ipynb
@@ -985,7 +985,7 @@
     "%%time\n",
     "estimator_new_features = sagemaker.estimator.Estimator(\n",
     "    sagemaker_session=sagemaker_session,\n",
-    "    image_name=image_name,\n",
+    "    image_uri=image_name,\n",
     "    role=role,\n",
     "    train_instance_count=1,\n",
     "    train_instance_type='ml.c4.2xlarge',\n",

--- a/introduction_to_amazon_algorithms/deepar_electricity/DeepAR-Electricity.ipynb
+++ b/introduction_to_amazon_algorithms/deepar_electricity/DeepAR-Electricity.ipynb
@@ -119,7 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "image_name = sagemaker.amazon.amazon_estimator.get_image_uri(region, \"forecasting-deepar\", \"latest\")"
+    "image_name = sagemaker.image_uris.retrieve(\"forecasting-deepar\", region, \"latest\")"
    ]
   },
   {
@@ -425,7 +425,7 @@
    "source": [
     "estimator = sagemaker.estimator.Estimator(\n",
     "    sagemaker_session=sagemaker_session,\n",
-    "    image_name=image_name,\n",
+    "    image_uri=image_name,\n",
     "    role=role,\n",
     "    train_instance_count=1,\n",
     "    train_instance_type='ml.c4.2xlarge',\n",


### PR DESCRIPTION
*Issue #, if available:*

Notebook fails on estimator requiring "image_uri".
Warning thrown for "sagemaker.amazon_estimator.get_image_uri()"

*Description of changes:*
Update Estimators to use "image_uri"
Get image uri with "sagemaker.image_uris.retrieve()"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
