### PR TITLE
26-Nov: Fixes to Issue #1800 and SDKv2 corrections

### DIFF
--- a/introduction_to_amazon_algorithms/deepar_electricity/DeepAR-Electricity.ipynb
+++ b/introduction_to_amazon_algorithms/deepar_electricity/DeepAR-Electricity.ipynb
@@ -16,9 +16,21 @@
     "* Make requests to the deployed model to obtain forecasts interactively\n",
     "* Illustrate advanced features of DeepAR: missing values, additional time features, non-regular frequencies and category information\n",
     "\n",
-    "Running this notebook takes around 40 min on a ml.c4.2xlarge for the training, and inference is done on a ml.m4.xlarge (the usage time will depend on how long you leave your served model running).\n",
+    "Running this notebook takes around 40 min on a ml.c4.2xlarge for the training, and inference is done on a ml.m5.large (the usage time will depend on how long you leave your served model running).\n",
+    "\n",
+    "This notebook is tested using SageMaker Studio but using classic Notebook (From the SageMaker Menu, go to Help -> select `Launch Classic Notebook`). \n",
     "\n",
     "For more information see the DeepAR [documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/deepar.html) or [paper](https://arxiv.org/abs/1704.04110), "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "!{sys.executable} -m pip install s3fs"
    ]
   },
   {
@@ -116,7 +128,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "image_name = sagemaker.amazon.amazon_estimator.get_image_uri(region, \"forecasting-deepar\", \"latest\")"
@@ -424,8 +438,8 @@
    "outputs": [],
    "source": [
     "estimator = sagemaker.estimator.Estimator(\n",
+    "    image_uri=image_name,\n",
     "    sagemaker_session=sagemaker_session,\n",
-    "    image_name=image_name,\n",
     "    role=role,\n",
     "    train_instance_count=1,\n",
     "    train_instance_type='ml.c4.2xlarge',\n",
@@ -530,10 +544,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class DeepARPredictor(sagemaker.predictor.RealTimePredictor):\n",
+    "from sagemaker.serializers import IdentitySerializer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class DeepARPredictor(sagemaker.predictor.Predictor):\n",
     "    \n",
     "    def __init__(self, *args, **kwargs):\n",
-    "        super().__init__(*args, content_type=sagemaker.content_types.CONTENT_TYPE_JSON, **kwargs)\n",
+    "        super().__init__(*args, \n",
+    "                         #serializer=JSONSerializer(),\n",
+    "                         serializer=IdentitySerializer(content_type=\"application/json\"),\n",
+    "                         **kwargs)\n",
     "        \n",
     "    def predict(self, ts, cat=None, dynamic_feat=None, \n",
     "                num_samples=100, return_samples=False, quantiles=[\"0.1\", \"0.5\", \"0.9\"]):\n",
@@ -556,7 +582,7 @@
     "    \n",
     "    def __encode_request(self, ts, cat, dynamic_feat, num_samples, return_samples, quantiles):\n",
     "        instance = series_to_dict(ts, cat if cat is not None else None, dynamic_feat if dynamic_feat else None)\n",
-    "\n",
+    "        \n",
     "        configuration = {\n",
     "            \"num_samples\": num_samples,\n",
     "            \"output_types\": [\"quantiles\", \"samples\"] if return_samples else [\"quantiles\"],\n",
@@ -619,7 +645,7 @@
    "source": [
     "predictor = estimator.deploy(\n",
     "    initial_instance_count=1,\n",
-    "    instance_type='ml.m4.xlarge',\n",
+    "    instance_type='ml.m5.large',\n",
     "    predictor_cls=DeepARPredictor)"
    ]
   },
@@ -984,8 +1010,8 @@
    "source": [
     "%%time\n",
     "estimator_new_features = sagemaker.estimator.Estimator(\n",
+    "    image_uri=image_name,\n",
     "    sagemaker_session=sagemaker_session,\n",
-    "    image_name=image_name,\n",
     "    role=role,\n",
     "    train_instance_count=1,\n",
     "    train_instance_type='ml.c4.2xlarge',\n",
@@ -1030,7 +1056,7 @@
     "%%time\n",
     "predictor_new_features = estimator_new_features.deploy(\n",
     "    initial_instance_count=1,\n",
-    "    instance_type='ml.m4.xlarge',\n",
+    "    instance_type='ml.m5.large',\n",
     "    predictor_cls=DeepARPredictor)"
    ]
   },
@@ -1115,9 +1141,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (Data Science)",
    "language": "python",
-   "name": "python3"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/datascience-1.0"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
## Description of Changes

1- Solution to https://github.com/aws/amazon-sagemaker-examples/issues/1800 to call serializer in the Predictor constructor
2-SDKv2 updates incorporated (renamed RealTimePredictor, removed content_type from Predictor constructor, renamed image_name in estimator call etc.)
3-Changed inference instance type to m5.large (newer generation, less cost)

## Test Scenario

Tested in SageMaker Studio (but with Sagemaker Classic Notebook option)
SageMaker SDK version = 2.16.3.post0

See completed notebook here: https://github.com/CloudaYolla/fastai-study-group-DL4coders/blob/main/zoo-smaker-nb/DeepAR-Electricity-StudioNI-PA4.ipynb

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
