### PR TITLE
Fix mda not found in the r_bring_your_own_container_example

### DIFF
--- a/advanced_functionality/r_bring_your_own/Dockerfile
+++ b/advanced_functionality/r_bring_your_own/Dockerfile
@@ -1,9 +1,11 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
-MAINTAINER Amazon SageMaker Examples <amazon-sagemaker-examples@amazon.com>
+ARG DEBIAN_FRONTEND=noninteractive 
 
 RUN apt-get -y update && apt-get install -y --no-install-recommends \
     wget \
+    libcurl4-openssl-dev\
+    libsodium-dev \
     r-base \
     r-base-dev \
     ca-certificates

--- a/advanced_functionality/r_bring_your_own/r_bring_your_own.ipynb
+++ b/advanced_functionality/r_bring_your_own/r_bring_your_own.ipynb
@@ -266,12 +266,14 @@
     "Smaller containers are preferred for Amazon SageMaker as they lead to faster spin up times in training and endpoint creation, so this container is kept minimal.  It simply starts with Ubuntu, installs R, mda, and plumber libraries, then adds `mars.R` and `plumber.R`, and finally runs `mars.R` when the entrypoint is launched.\n",
     "\n",
     "```Dockerfile\n",
-    "FROM ubuntu:16.04\n",
+    "FROM ubuntu:20.04\n",
     "\n",
-    "MAINTAINER Amazon SageMaker Examples <amazon-sagemaker-examples@amazon.com>\n",
+    "ARG DEBIAN_FRONTEND=noninteractive \n",
     "\n",
     "RUN apt-get -y update && apt-get install -y --no-install-recommends \\\n",
     "    wget \\\n",
+    "    libcurl4-openssl-dev\\\n",
+    "    libsodium-dev \\\n",
     "    r-base \\\n",
     "    r-base-dev \\\n",
     "    ca-certificates\n",
@@ -652,7 +654,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Environment (conda_python3)",
+   "display_name": "conda_python3",
    "language": "python",
    "name": "conda_python3"
   },
@@ -666,10 +668,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.10"
   },
   "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
*Issue #, 1805:*

*Description of changes:*

- Updated the docker base image to 20.04 to solve the dependency issue in the mda package in the R bring your own container example.
- Updated the dockerfile preview in the notebook in the same example.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
