### PR TITLE
fix get_execution_role error

### DIFF
--- a/introduction_to_applying_machine_learning/ensemble_modeling/EnsembleLearnerCensusIncome.ipynb
+++ b/introduction_to_applying_machine_learning/ensemble_modeling/EnsembleLearnerCensusIncome.ipynb
@@ -73,7 +73,7 @@
     "import time\n",
     "import re\n",
     "import sagemaker \n",
-    "role = get_execution_role()\n",
+    "role = sagemaker.get_execution_role()\n",
     "\n",
     "# Now let's define the S3 bucket we'll used for the remainder of this example.\n",
     "\n",


### PR DESCRIPTION
*Issue #, if available:*

---------------------------------------------------------------------------
The error occurs on EnsembleLearnerCensusIncome.ipynb

NameError                                 Traceback (most recent call last)
<ipython-input-5-fa31bedc9b92> in <module>
      4 import re
      5 import sagemaker
----> 6 role = get_execution_role()
      7 
      8 # Now let's define the S3 bucket we'll used for the remainder of this example.

NameError: name 'get_execution_role' is not defined


*Description of changes:*
change to 'sagemaker.get_execution_role()' from 'get_execution_role()'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
