### PR TITLE
fix get_execution_role error

### DIFF
--- a/introduction_to_applying_machine_learning/ensemble_modeling/EnsembleLearnerCensusIncome.ipynb
+++ b/introduction_to_applying_machine_learning/ensemble_modeling/EnsembleLearnerCensusIncome.ipynb
@@ -73,7 +73,7 @@
     "import time\n",
     "import re\n",
     "import sagemaker \n",
-    "role = get_execution_role()\n",
+    "role = sagemaker.get_execution_role()\n",
     "\n",
     "# Now let's define the S3 bucket we'll used for the remainder of this example.\n",
     "\n",
@@ -340,8 +340,8 @@
    },
    "outputs": [],
    "source": [
-    "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
-    "container = get_image_uri(boto3.Session().region_name, 'xgboost')"
+    "from sagemaker.amazon.amazon_estimator import image_uris\n",
+    "container = image_uris.retrieve(region=boto3.Session().region_name, framework='xgboost', version='1')"
    ]
   },
   {
@@ -645,11 +645,11 @@
     "    \n",
     "    for offset in range(0, items, batch_size):\n",
     "        if offset+batch_size < items:\n",
-    "            datav = data.iloc[offset:(offset+batch_size),:].as_matrix()\n",
+    "            datav = data.iloc[offset:(offset+batch_size),:].values\n",
     "            results = do_predict(datav, endpoint_name, content_type)\n",
     "            arrs.extend(results)\n",
     "        else:\n",
-    "            datav = data.iloc[offset:items,:].as_matrix()\n",
+    "            datav = data.iloc[offset:items,:].values\n",
     "            arrs.extend(do_predict(datav, endpoint_name, content_type))\n",
     "        sys.stdout.write('.')\n",
     "    return(arrs)"
@@ -739,14 +739,14 @@
     "data_test = pd.read_csv(\"formatted_test.csv\", sep=',', header=None) \n",
     "data_val = pd.read_csv(\"formatted_val.csv\", sep=',', header=None) \n",
     "\n",
-    "train_y = data_train.iloc[:,0].as_matrix();\n",
-    "train_X = data_train.iloc[:,1:].as_matrix();\n",
+    "train_y = data_train.iloc[:,0].values;\n",
+    "train_X = data_train.iloc[:,1:].values;\n",
     "\n",
-    "val_y = data_val.iloc[:,0].as_matrix();\n",
-    "val_X = data_val.iloc[:,1:].as_matrix();\n",
+    "val_y = data_val.iloc[:,0].values;\n",
+    "val_X = data_val.iloc[:,1:].values;\n",
     "\n",
-    "test_y = data_test.iloc[:,0].as_matrix();\n",
-    "test_X = data_test.iloc[:,1:].as_matrix();\n"
+    "test_y = data_test.iloc[:,0].values;\n",
+    "test_X = data_test.iloc[:,1:].values;\n"
    ]
   },
   {
@@ -826,8 +826,8 @@
    },
    "outputs": [],
    "source": [
-    "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
-    "container = get_image_uri(boto3.Session().region_name, 'linear-learner')"
+    "from sagemaker.amazon.amazon_estimator import image_uris\n",
+    "container = image_uris.retrieve(region=boto3.Session().region_name, framework='linear-learner', version='1')"
    ]
   },
   {
@@ -1097,11 +1097,11 @@
     "    \n",
     "    for offset in range(0, items, batch_size):\n",
     "        if offset+batch_size < items:\n",
-    "            datav = data.iloc[offset:(offset+batch_size),:].as_matrix()\n",
+    "            datav = data.iloc[offset:(offset+batch_size),:].values\n",
     "            results = do_predict_linear(datav, endpoint_name, content_type)\n",
     "            arrs.extend(results)\n",
     "        else:\n",
-    "            datav = data.iloc[offset:items,:].as_matrix()\n",
+    "            datav = data.iloc[offset:items,:].values\n",
     "            arrs.extend(do_predict_linear(datav, endpoint_name, content_type))\n",
     "        sys.stdout.write('.')\n",
     "    return(arrs)"


### PR DESCRIPTION
*Issue #, if available:*
---------------------------------------------------------------------------
### get_execution_role
NameError                                 Traceback (most recent call last)
<ipython-input-5-fa31bedc9b92> in <module>
      4 import re
      5 import sagemaker
----> 6 role = get_execution_role()
      7 
      8 # Now let's define the S3 bucket we'll used for the remainder of this example.

NameError: name 'get_execution_role' is not defined

### get_image_uri
The method get_image_uri has been renamed in sagemaker>=2.
See: https://sagemaker.readthedocs.io/en/stable/v2.html for details.
Defaulting to the only supported framework/algorithm version: 1. Ignoring framework/algorithm version: 1.

*Description of changes:*
* use `sagemaker.get_execution_role()`
* use `image_uris.retrieve(...)`
* use `values` instead of `as_matrix()`



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
