### PR TITLE
Updated Python version to py36 instead of py3

### DIFF
--- a/training/distributed_training/pytorch/data_parallel/mnist/pytorch_smdataparallel_mnist_demo.ipynb
+++ b/training/distributed_training/pytorch/data_parallel/mnist/pytorch_smdataparallel_mnist_demo.ipynb
@@ -104,7 +104,7 @@
     "                        entry_point='train_pytorch_smdataparallel_mnist.py',\n",
     "                        role=role,\n",
     "                        framework_version='1.6.0',\n",
-    "                        py_version='py3',\n",
+    "                        py_version='py36',\n",
     "                        # For training with multinode distributed training, set this count. Example: 2\n",
     "                        instance_count=2,\n",
     "                        # For training with p3dn instance use - ml.p3dn.24xlarge\n",

--- a/training/distributed_training/pytorch/data_parallel/mnist/pytorch_smdataparallel_mnist_demo.ipynb
+++ b/training/distributed_training/pytorch/data_parallel/mnist/pytorch_smdataparallel_mnist_demo.ipynb
@@ -40,6 +40,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "pip install sagemaker --upgrade"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import sagemaker\n",
     "\n",
     "sagemaker_session = sagemaker.Session()\n",


### PR DESCRIPTION
To pick up the correct container

*Issue #, if available:*

*Description of changes:*
The training job was picking an incorrect container with `py3` . 
Changing it to `py36` fixes it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
