### PR TITLE
Update the python version parameter from py3 to py37 for smdataparallel TF2 MNIST

### DIFF
--- a/training/distributed_training/tensorflow/data_parallel/mnist/tensorflow2_smdataparallel_mnist_demo.ipynb
+++ b/training/distributed_training/tensorflow/data_parallel/mnist/tensorflow2_smdataparallel_mnist_demo.ipynb
@@ -31,6 +31,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "pip install sagemaker --upgrade"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import sagemaker\n",
     "\n",
     "sagemaker_session = sagemaker.Session()\n",

--- a/training/distributed_training/tensorflow/data_parallel/mnist/tensorflow2_smdataparallel_mnist_demo.ipynb
+++ b/training/distributed_training/tensorflow/data_parallel/mnist/tensorflow2_smdataparallel_mnist_demo.ipynb
@@ -94,7 +94,7 @@
     "                        source_dir='code',\n",
     "                        entry_point='train_tensorflow_smdataparallel_mnist.py',\n",
     "                        role=role,\n",
-    "                        py_version='py3',\n",
+    "                        py_version='py37',\n",
     "                        framework_version='2.3.1',\n",
     "                        # For training with multinode distributed training, set this count. Example: 2\n",
     "                        instance_count=2,\n",


### PR DESCRIPTION
*Issue:*
Getting the below issue when using `py_version='py3'` . The sagemaker SDK version is v2.19.0.

```
~/anaconda3/envs/tensorflow_p36/lib/python3.6/site-packages/sagemaker/image_uris.py in _validate_arg(arg, available_options, arg_name)
    286             "Unsupported {arg_name}: {arg}. You may need to upgrade your SDK version "
    287             "(pip install -U sagemaker) for newer {arg_name}s. Supported {arg_name}(s): "
--> 288             "{options}.".format(arg_name=arg_name, arg=arg, options=", ".join(available_options))
    289         )
    290 

ValueError: Unsupported Python version: py3. You may need to upgrade your SDK version (pip install -U sagemaker) for newer Python versions. Supported Python version(s): py37.
```
*Description of changes:*
- Modifying the `py_version='py37'` solves the above issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
