### PR TITLE
Fix low batch size debugger notebook

### DIFF
--- a/sagemaker-debugger/tensorflow_profiling/callback_bottleneck.ipynb
+++ b/sagemaker-debugger/tensorflow_profiling/callback_bottleneck.ipynb
@@ -57,17 +57,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Dataset uploaded to s3://sagemaker-us-east-2-072677473360/data/cifar10-tfrecords\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import sagemaker\n",
     "\n",
@@ -98,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -241,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -401,9 +393,9 @@
  "metadata": {
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "conda_python3",
+   "display_name": "conda_tensorflow2_p36",
    "language": "python",
-   "name": "conda_python3"
+   "name": "conda_tensorflow2_p36"
   },
   "language_info": {
    "codemirror_mode": {

--- a/sagemaker-debugger/tensorflow_profiling/low_batch_size.ipynb
+++ b/sagemaker-debugger/tensorflow_profiling/low_batch_size.ipynb
@@ -110,7 +110,7 @@
    "source": [
     "### Define hyperparameters\n",
     "\n",
-    "The start_up script, [train_tf_bottleneck.py](./demo/train_tf_bottleneck), accepts a number of parameters. Here we set the batch_size to 64, and the number of epochs to 3."
+    "The start_up script, [train_tf_bottleneck.py](./demo/train_tf_bottleneck), accepts a number of parameters. Here we set the batch_size to 64, and the number of epochs to 3 to keep the training short for testing."
    ]
   },
   {

--- a/sagemaker-debugger/tensorflow_profiling/low_batch_size.ipynb
+++ b/sagemaker-debugger/tensorflow_profiling/low_batch_size.ipynb
@@ -110,7 +110,7 @@
    "source": [
     "### Define hyperparameters\n",
     "\n",
-    "The start_up script, [train_tf_bottleneck.py](./demo/train_tf_bottleneck), accepts a number of parameters. Here we set the batch_size to 64, and the number of epochs to 20."
+    "The start_up script, [train_tf_bottleneck.py](./demo/train_tf_bottleneck), accepts a number of parameters. Here we set the batch_size to 64, and the number of epochs to 3."
    ]
   },
   {

--- a/sagemaker-debugger/tensorflow_profiling/low_batch_size.ipynb
+++ b/sagemaker-debugger/tensorflow_profiling/low_batch_size.ipynb
@@ -119,9 +119,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "batch_size = 1024\n",
+    "batch_size = 64\n",
     "\n",
-    "hyperparameters = {'epoch': 20, \n",
+    "hyperparameters = {'epoch': 3, \n",
     "                   'batch_size': batch_size,\n",
     "                  }"
    ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update batch size used in low batch size debugger notebook to be 64, as the description in the notebook states. Also reduce the number of epochs to 3.
- Also clear output in callback notebook.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
