### PR TITLE
Added missing argument for py_version

### DIFF
--- a/hyperparameter_tuning/tensorflow_mnist/hpo_tensorflow_mnist.ipynb
+++ b/hyperparameter_tuning/tensorflow_mnist/hpo_tensorflow_mnist.ipynb
@@ -179,10 +179,11 @@
     "estimator = TensorFlow(entry_point='mnist.py',\n",
     "                  role=role,\n",
     "                  framework_version='1.12.0',\n",
+    "                  py_version='py3',\n",
     "                  training_steps=1000, \n",
     "                  evaluation_steps=100,\n",
-    "                  train_instance_count=1,\n",
-    "                  train_instance_type='ml.m4.xlarge',\n",
+    "                  instance_count=1,\n",
+    "                  instance_type='ml.m4.xlarge',\n",
     "                  base_job_name='DEMO-hpo-tensorflow')"
    ]
   },


### PR DESCRIPTION



*Issue #, if available:*
Without my addition I get this error (using sagemaker SDK>2.0):
`ValueError: framework_version or py_version was None, yet image_uri was also None. Either specify both framework_version and py_version, or specify image_uri.`

*Description of changes:*
added py_version
remove "train_" from instance type and count params.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
