### PR TITLE
Fix: updating processes_per_host parameter name

### DIFF
--- a/training/distributed_training/pytorch/model_parallel/bert/smp_bert_tutorial.ipynb
+++ b/training/distributed_training/pytorch/model_parallel/bert/smp_bert_tutorial.ipynb
@@ -268,7 +268,7 @@
     "                                },\n",
     "                                \"mpi\": {\n",
     "                                    \"enabled\": True,\n",
-    "                                    \"process_per_host\": 8,\n",
+    "                                    \"processes_per_host\": 8,\n",
     "                                    \"custom_mpi_options\": mpi_options,\n",
     "                                }\n",
     "                            },\n",


### PR DESCRIPTION
*Issue #, if available:*
* https://github.com/aws/amazon-sagemaker-examples/issues/1872 

*Description of changes:*
Update process_per_host --> processes_per_host

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
