### PR TITLE
remove mpi flag mca btl_vader_single_copy_mechanism none on MNIST tes…

### DIFF
--- a/training/distributed_training/pytorch/model_parallel/mnist/pytorch_smmodelparallel_mnist.ipynb
+++ b/training/distributed_training/pytorch/model_parallel/mnist/pytorch_smmodelparallel_mnist.ipynb
@@ -140,7 +140,6 @@
    "source": [
     "sagemaker_session = sagemaker.session.Session(boto_session=session)\n",
     "mpioptions = \"-verbose -x orte_base_help_aggregate=0 \"\n",
-    "mpioptions += \"--mca btl_vader_single_copy_mechanism none \"\n",
     "\n",
     "all_experiment_names = [exp.experiment_name for exp in Experiment.list()]\n",
     "\n",

--- a/training/distributed_training/tensorflow/model_parallel/mnist/tensorflow_smmodelparallel_mnist.ipynb
+++ b/training/distributed_training/tensorflow/model_parallel/mnist/tensorflow_smmodelparallel_mnist.ipynb
@@ -150,7 +150,6 @@
    "source": [
     "sagemaker_session = sagemaker.session.Session(boto_session=session)\n",
     "mpioptions = \"-verbose -x orte_base_help_aggregate=0 \"\n",
-    "mpioptions += \"--mca btl_vader_single_copy_mechanism none \"\n",
     "\n",
     "#choose an experiment name (only need to create it once)\n",
     "experiment_name = \"SM-MP-DEMO\"\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Our tests are failing because of this change to SM training toolkit:
https://github.com/aws/sagemaker-training-toolkit/pull/90
Since SM adds this new MPI flag by default we need to remove it from our scripts to prevent it from being listed multiple times.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
