### PR TITLE
Set drop_last=True for DataLoader

### DIFF
--- a/training/distributed_training/pytorch/model_parallel/bert/bert_example/sagemaker_smp_pretrain.py
+++ b/training/distributed_training/pytorch/model_parallel/bert/bert_example/sagemaker_smp_pretrain.py
@@ -92,7 +92,7 @@ def create_pretraining_dataset(input_file, max_pred_length, shared_list, args, w
     train_dataloader = DataLoader(train_data, sampler=train_sampler,
                                   batch_size=args.train_batch_size * args.n_gpu,
                                   num_workers=4, worker_init_fn=worker_init,
-                                  pin_memory=True)
+                                  pin_memory=True, drop_last=True)
     return train_dataloader, input_file
 
 
@@ -696,7 +696,7 @@ def main():
             train_dataloader = DataLoader(train_data, sampler=train_sampler,
                                         batch_size=args.train_batch_size * args.n_gpu,
                                         num_workers=4, worker_init_fn=worker_init,
-                                        pin_memory=True)
+                                        pin_memory=True, drop_last=True)
             # shared_file_list["0"] = (train_dataloader, data_file)
         else:
             train_dataloader = restored_data_loader


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Set drop_last=True for DataLoader. This has become a common pitfall (where the batch size of last batch is not divisible by number of microbatches) and better to set it to True by default. Downside is if the total number of samples is smaller than batch size in which case there is no data, and may cause failures (which I am guessing is less likely compared to customers running into "batch size not divisible by num_microbatches" issue).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

@hsl89 