### PR TITLE
rm requirements.txt / not used but causes security vulnerability issues

### DIFF
--- a/sagemaker_batch_transform/tensorflow_open-images_tfrecord/code/requirements.txt
+++ b/sagemaker_batch_transform/tensorflow_open-images_tfrecord/code/requirements.txt
@@ -1,1 +1,0 @@
-tensorflow==1.15.4


### PR DESCRIPTION
*Issue #, if available:*
- `requirements.txt` of the batch transform example notebook causes security vulnerabilities. 
  - https://github.com/aws/amazon-sagemaker-examples/security/dependabot/sagemaker_batch_transform/tensorflow_open-images_tfrecord/code/requirements.txt/tensorflow/open

*Description of changes:*
- Removing the file since it is not used in the example notebooks.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
