### PR TITLE
Added newline character for pip installation

### DIFF
--- a/sagemaker-experiments/mnist-handwritten-digits-classification-experiment/mnist-handwritten-digits-classification-experiment.ipynb
+++ b/sagemaker-experiments/mnist-handwritten-digits-classification-experiment/mnist-handwritten-digits-classification-experiment.ipynb
@@ -64,7 +64,7 @@
     "# https://github.com/pytorch/pytorch/issues/25214\n",
     "!{sys.executable} -m pip install torch==1.1.0\n",
     "!{sys.executable} -m pip install torchvision==0.3.0\n",
-    "!{sys.executable} -m pip install pillow==6.2.2 ",
+    "!{sys.executable} -m pip install pillow==6.2.2\n",
     "!{sys.executable} -m pip install --upgrade sagemaker"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:*
The last pip install command breaks. Re: It is incorrectly formatted and on the same line as a previous pip install command:

```
!{sys.executable} -m pip install torch==1.1.0    
!{sys.executable} -m pip install torchvision==0.3.0      
!{sys.executable} -m pip install pillow==6.2.2 !{sys.executable} -m pip install --upgrade sagemaker
```

*Description of changes:*
Added a newline character "\n" to pip install command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
