### PR TITLE
Updated sklearn_multi_model_endpoint_home_value.ipynb for SageMaker SDK v2

### DIFF
--- a/advanced_functionality/multi_model_sklearn_home_value/sklearn_multi_model_endpoint_home_value.ipynb
+++ b/advanced_functionality/multi_model_sklearn_home_value/sklearn_multi_model_endpoint_home_value.ipynb
@@ -143,6 +143,7 @@
    "source": [
     "import sagemaker\n",
     "from sagemaker import get_execution_role\n",
+    "from sagemaker.inputs import TrainingInput\n",
     "import boto3\n",
     "\n",
     "s3 = boto3.resource('s3')\n",
@@ -395,8 +396,8 @@
     "        entry_point=TRAINING_FILE, # script to use for training job\n",
     "        role=role,\n",
     "        source_dir=SOURCE_DIR, # Location of scripts\n",
-    "        train_instance_count=1,\n",
-    "        train_instance_type=TRAIN_INSTANCE_TYPE,\n",
+    "        instance_count=1,\n",
+    "        instance_type=TRAIN_INSTANCE_TYPE,\n",
     "        framework_version='0.23-1',# 0.23-1 is the latest version\n",
     "        output_path=s3_output_path,# Where to store model artifacts\n",
     "        base_job_name=_job,\n",
@@ -410,10 +411,10 @@
     "    \n",
     "    DISTRIBUTION_MODE = 'FullyReplicated'\n",
     "    \n",
-    "    train_input = sagemaker.s3_input(s3_data=inputs+'/train', \n",
+    "    train_input = TrainingInput(s3_data=inputs+'/train', \n",
     "                                      distribution=DISTRIBUTION_MODE, content_type='csv')\n",
     "    \n",
-    "    val_input   = sagemaker.s3_input(s3_data=inputs+'/val', \n",
+    "    val_input   = TrainingInput(s3_data=inputs+'/val', \n",
     "                                      distribution=DISTRIBUTION_MODE, content_type='csv')\n",
     "    \n",
     "    remote_inputs = {'train': train_input, 'validation': val_input}\n",
@@ -570,7 +571,8 @@
    "outputs": [],
    "source": [
     "# This is where our MME will read models from on S3.\n",
-    "model_data_prefix = f's3://{BUCKET}/{DATA_PREFIX}/{MULTI_MODEL_ARTIFACTS}/'"
+    "model_data_prefix = f's3://{BUCKET}/{DATA_PREFIX}/{MULTI_MODEL_ARTIFACTS}/'\n",
+    "print(model_data_prefix)"
    ]
   },
   {


### PR DESCRIPTION
Notebook needed updates to be compatible with the v2 of the SageMaker SDK, which is the new Default SDK version in SageMaker.

Issue #, if available:

Description of changes:
Notebook needed updates to be compatible with the v2 of the SageMaker SDK, which is the new Default SDK version in SageMaker.

Fixed:
- Use TrainingInput instead of s3_input.
- Use instance_count and instance_type instead of train_instance_count and train_instance_type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
