### PR TITLE
Updated tensorboard_keras.ipynb for SageMaker SDK v2

### DIFF
--- a/sagemaker-python-sdk/tensorboard_keras/tensorboard_keras.ipynb
+++ b/sagemaker-python-sdk/tensorboard_keras/tensorboard_keras.ipynb
@@ -36,37 +36,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Upgrading SageMaker python SDK and TensorFlow to the current latest version. We need to restart the notebook's kernel to use the newly installed version.\n",
-    "**The following command will upgrade packages in your current kernel environment, which can affect other notebooks using the same kernel.**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import sys\n",
-    "!{sys.executable} -m pip install --upgrade pip\n",
-    "!{sys.executable} -m pip install --upgrade grpcio sagemaker==2.23.* awscli==1.* tensorflow==2.2.* tensorboard_plugin_profile==2.2.*"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "%%javascript\n",
-    "Jupyter.notebook.kernel.restart()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "This notebook is using the default SageMaker's S3 bucket. Tensorflow logs will be written to `s3://sagemaker-<region>-<account_id>/tensorboard_keras_cifar10/logs`."
    ]
   },
@@ -91,7 +60,7 @@
     "tensorflow_logs_path = \"s3://{}/{}/logs\".format(bucket, prefix)\n",
     "\n",
     "print('Bucket: {}'.format(bucket))\n",
-    "print('Sensorflow ver: ' + sagemaker.__version__)\n",
+    "print('SageMaker ver: ' + sagemaker.__version__)\n",
     "print('Tensorflow ver: ' + tf.__version__)"
    ]
   },
@@ -410,9 +379,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda_tensorflow_p36",
+   "display_name": "conda_tensorflow2_p36",
    "language": "python",
-   "name": "conda_tensorflow_p36"
+   "name": "conda_tensorflow2_p36"
   },
   "language_info": {
    "codemirror_mode": {

--- a/sagemaker-python-sdk/tensorboard_keras/tensorboard_keras.ipynb
+++ b/sagemaker-python-sdk/tensorboard_keras/tensorboard_keras.ipynb
@@ -48,7 +48,7 @@
    "source": [
     "import sys\n",
     "!{sys.executable} -m pip install --upgrade pip\n",
-    "!{sys.executable} -m pip install --upgrade grpcio sagemaker==1.60.* awscli==1.* tensorflow==2.2.* tensorboard_plugin_profile==2.2.*"
+    "!{sys.executable} -m pip install --upgrade grpcio sagemaker==2.23.* awscli==1.* tensorflow==2.2.* tensorboard_plugin_profile==2.2.*"
    ]
   },
   {
@@ -91,6 +91,7 @@
     "tensorflow_logs_path = \"s3://{}/{}/logs\".format(bucket, prefix)\n",
     "\n",
     "print('Bucket: {}'.format(bucket))\n",
+    "print('Sensorflow ver: ' + sagemaker.__version__)\n",
     "print('Tensorflow ver: ' + tf.__version__)"
    ]
   },
@@ -180,8 +181,8 @@
     "                       framework_version='2.2.0',\n",
     "                       py_version='py37',\n",
     "                       hyperparameters=hyperparameters,\n",
-    "                       train_instance_count=1,\n",
-    "                       train_instance_type='local')\n",
+    "                       instance_count=1,\n",
+    "                       instance_type='local')\n",
     "\n",
     "estimator.fit(inputs)"
    ]
@@ -265,8 +266,8 @@
     "                       framework_version='2.2.0',\n",
     "                       py_version='py37',\n",
     "                       hyperparameters=hyperparameters,\n",
-    "                       train_instance_count=1,\n",
-    "                       train_instance_type='ml.c5.xlarge',\n",
+    "                       instance_count=1,\n",
+    "                       instance_type='ml.c5.xlarge',\n",
     "                       metric_definitions=keras_metric_definition,\n",
     "                       input_mode='Pipe')\n",
     "\n",
@@ -310,8 +311,8 @@
     "                       framework_version='2.2.0',\n",
     "                       py_version='py37',\n",
     "                       hyperparameters=shared_hyperparameters,\n",
-    "                       train_instance_count=1,\n",
-    "                       train_instance_type='ml.p3.2xlarge',\n",
+    "                       instance_count=1,\n",
+    "                       instance_type='ml.p3.2xlarge',\n",
     "                       metric_definitions=keras_metric_definition,\n",
     "                       input_mode='Pipe')"
    ]
@@ -423,7 +424,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.10"
   },
   "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.",
   "pycharm": {


### PR DESCRIPTION
Notebook needed updates to be compatible with the v2 of the SageMaker SDK, which is the new Default SDK version in SageMaker.

Issue #, if available:

Description of changes:
Notebook needed updates to be compatible with the v2 of the SageMaker SDK, which is the new Default SDK version in SageMaker.

Fixed:

Upgraded SageMaker pip version from 1.60.* to 2.23.*.
Use instance_count and instance_type instead of train_instance_count and train_instance_type.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
