### PR TITLE
Fixed broken links

### DIFF
--- a/introduction_to_amazon_algorithms/imageclassification_mscoco_multi_label/Image-classification-multilabel-lst.ipynb
+++ b/introduction_to_amazon_algorithms/imageclassification_mscoco_multi_label/Image-classification-multilabel-lst.ipynb
@@ -87,7 +87,7 @@
     "\n",
     "An image can contain objects of multiple categories. We first create a dataset with these 5 categories. COCO is a very large dataset, and the purpose of this notebook is to show how multi-label classification works. So, instead we’ll take what COCO calls their validation dataset from 2017, and use this as our only data.  We then split this dataset into a train and holdout dataset for fine tuning the model and testing our final accuracy\n",
     "\n",
-    "The image classification algorithm can take two types of input formats. The first is a [recordio format](https://mxnet.apache.org/versions/1.7.0/api/faq/recordio) and the other is a [lst format](https://mxnet.apache.org/versions/1.7.0/api/python/docs/api/mxnet/recordio/index.html). We will use the lst file format for training. "
+    "The image classification algorithm can take two types of input formats. The first is a [recordio format](https://mxnet.apache.org/versions/1.7.0/api/faq/recordio) and the other is a lst format. We will use the lst file format for training. "
    ]
   },
   {

--- a/introduction_to_amazon_algorithms/imageclassification_mscoco_multi_label/Image-classification-multilabel-lst.ipynb
+++ b/introduction_to_amazon_algorithms/imageclassification_mscoco_multi_label/Image-classification-multilabel-lst.ipynb
@@ -87,7 +87,7 @@
     "\n",
     "An image can contain objects of multiple categories. We first create a dataset with these 5 categories. COCO is a very large dataset, and the purpose of this notebook is to show how multi-label classification works. So, instead we’ll take what COCO calls their validation dataset from 2017, and use this as our only data.  We then split this dataset into a train and holdout dataset for fine tuning the model and testing our final accuracy\n",
     "\n",
-    "The image classification algorithm can take two types of input formats. The first is a [recordio format](https://mxnet.incubator.apache.org/tutorials/basic/record_io.html) and the other is a [lst format](https://mxnet.incubator.apache.org/how_to/recordio.html?highlight=im2rec). We will use the lst file format for training. "
+    "The image classification algorithm can take two types of input formats. The first is a [recordio format](https://mxnet.apache.org/versions/1.7.0/api/faq/recordio) and the other is a [lst format](https://mxnet.apache.org/versions/1.7.0/api/python/docs/api/mxnet/recordio/index.html). We will use the lst file format for training. "
    ]
   },
   {


### PR DESCRIPTION
**Issue #, if available:**
There were two broken links in Image-classification-multilabel-lst.ipynb notebook. 

Broken links: 
https://mxnet.incubator.apache.org/tutorials/basic/record_io.html
https://mxnet.incubator.apache.org/how_to/recordio.html?highlight=im2rec

**Description of changes:**
Replaced broken links with current MXNet links.

Replaced the above with:
https://mxnet.apache.org/versions/1.7.0/api/faq/recordio
https://mxnet.apache.org/versions/1.7.0/api/python/docs/api/mxnet/recordio/index.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
