### PR TITLE
fixed broken URL

### DIFF
--- a/sagemaker-python-sdk/pytorch_lstm_word_language_model/pytorch_rnn.ipynb
+++ b/sagemaker-python-sdk/pytorch_lstm_word_language_model/pytorch_rnn.ipynb
@@ -71,7 +71,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "wget http://research.metamind.io.s3.amazonaws.com/wikitext/wikitext-2-raw-v1.zip\n",
+    "wget https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-2-raw-v1.zip\n",
     "unzip -n wikitext-2-raw-v1.zip\n",
     "cd wikitext-2-raw\n",
     "mv wiki.test.raw test && mv wiki.train.raw train && mv wiki.valid.raw valid\n"


### PR DESCRIPTION
*Issue:* 
[#1299](https://github.com/aws/amazon-sagemaker-examples/issues/1299)

*Description of changes:*
Updated the URL used to download the wikitext-2 data set used in the example. 
Update was needed since the current URL returns a 403 HTTP status code (Forbidden). 

The new URL was found using the [source](https://www.salesforce.com/products/einstein/ai-research/the-wikitext-dependency-language-modeling-dataset/) mentioned in the notebook one line above.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
