### PR TITLE
update names of renamed serializers/deserializers in v2

### DIFF
--- a/introduction_to_amazon_algorithms/lda_topic_modeling/LDA-Introduction.ipynb
+++ b/introduction_to_amazon_algorithms/lda_topic_modeling/LDA-Introduction.ipynb
@@ -130,7 +130,7 @@
    "source": [
     "from sagemaker import get_execution_role\n",
     "\n",
-    "session = sagemaker.Session()",
+    "session = sagemaker.Session()\n",
     "role = get_execution_role()\n",
     "bucket = session.default_bucket()\n",
     "prefix = 'sagemaker/DEMO-lda-introduction'\n",

--- a/introduction_to_amazon_algorithms/lda_topic_modeling/LDA-Introduction.ipynb
+++ b/introduction_to_amazon_algorithms/lda_topic_modeling/LDA-Introduction.ipynb
@@ -76,8 +76,9 @@
     "\n",
     "# accessing the SageMaker Python SDK\n",
     "import sagemaker\n",
-    "from sagemaker.amazon.common import numpy_to_record_serializer\n",
-    "from sagemaker.predictor import csv_serializer, json_deserializer"
+    "from sagemaker.amazon.common import RecordSerializer\n",
+    "from sagemaker.serializers import CSVSerializer\n",
+    "from sagemaker.deserializers import JSONDeserializer"
    ]
   },
   {
@@ -258,7 +259,7 @@
    "source": [
     "## Store Data on S3\n",
     "\n",
-    "A SageMaker training job needs access to training data stored in an S3 bucket. Although training can accept data of various formats we convert the documents MXNet RecordIO Protobuf format before uploading to the S3 bucket defined at the beginning of this notebook. We do so by making use of the SageMaker Python SDK utility `numpy_to_record_serializer`."
+    "A SageMaker training job needs access to training data stored in an S3 bucket. Although training can accept data of various formats we convert the documents MXNet RecordIO Protobuf format before uploading to the S3 bucket defined at the beginning of this notebook. We do so by making use of the SageMaker Python SDK utility `RecordSerializer`."
    ]
   },
   {
@@ -270,8 +271,8 @@
    "outputs": [],
    "source": [
     "# convert documents_training to Protobuf RecordIO format\n",
-    "recordio_protobuf_serializer = numpy_to_record_serializer()\n",
-    "fbuffer = recordio_protobuf_serializer(documents_training)\n",
+    "recordio_protobuf_serializer = RecordSerializer()\n",
+    "fbuffer = recordio_protobuf_serializer.serialize(documents_training)\n",
     "\n",
     "# upload to S3 in bucket/prefix/train\n",
     "fname = 'lda.data'\n",
@@ -439,7 +440,7 @@
    },
    "outputs": [],
    "source": [
-    "print('Endpoint name: {}'.format(lda_inference.endpoint))"
+    "print('Endpoint name: {}'.format(lda_inference.endpoint_name))"
    ]
   },
   {
@@ -448,7 +449,7 @@
    "source": [
     "With this realtime endpoint at our fingertips we can finally perform inference on our training and test data.\n",
     "\n",
-    "We can pass a variety of data formats to our inference endpoint. In this example we will demonstrate passing CSV-formatted data. Other available formats are JSON-formatted, JSON-sparse-formatter, and RecordIO Protobuf. We make use of the SageMaker Python SDK utilities `csv_serializer` and `json_deserializer` when configuring the inference endpoint."
+    "We can pass a variety of data formats to our inference endpoint. In this example we will demonstrate passing CSV-formatted data. Other available formats are JSON-formatted, JSON-sparse-formatter, and RecordIO Protobuf. We make use of the SageMaker Python SDK utilities `CSVSerializer` and `JSONDeserializer` when configuring the inference endpoint."
    ]
   },
   {
@@ -459,9 +460,8 @@
    },
    "outputs": [],
    "source": [
-    "lda_inference.content_type = 'text/csv'\n",
-    "lda_inference.serializer = csv_serializer\n",
-    "lda_inference.deserializer = json_deserializer"
+    "lda_inference.serializer = CSVSerializer()\n",
+    "lda_inference.deserializer = JSONDeserializer()"
    ]
   },
   {
@@ -555,7 +555,7 @@
    },
    "outputs": [],
    "source": [
-    "sagemaker.Session().delete_endpoint(lda_inference.endpoint)"
+    "sagemaker.Session().delete_endpoint(lda_inference.endpoint_name)"
    ]
   },
   {

--- a/introduction_to_amazon_algorithms/lda_topic_modeling/LDA-Introduction.ipynb
+++ b/introduction_to_amazon_algorithms/lda_topic_modeling/LDA-Introduction.ipynb
@@ -130,8 +130,9 @@
    "source": [
     "from sagemaker import get_execution_role\n",
     "\n",
+    "session = sagemaker.Session()",
     "role = get_execution_role()\n",
-    "bucket = '<your_s3_bucket_name_here>'\n",
+    "bucket = session.default_bucket()\n",
     "prefix = 'sagemaker/DEMO-lda-introduction'\n",
     "\n",
     "print('Training input/output will be stored in {}/{}'.format(bucket, prefix))\n",
@@ -350,8 +351,6 @@
    },
    "outputs": [],
    "source": [
-    "session = sagemaker.Session()\n",
-    "\n",
     "# specify general training job information\n",
     "lda = sagemaker.estimator.Estimator(\n",
     "    container,\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
While following thru the existing notebook, I realized it's using sagemaker v1 references. I renamed them to align with the new names in v2 and was able to finish the example with the fix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
