### PR TITLE
Add JAX/Trax example

### DIFF
--- a/advanced_functionality/README.md
+++ b/advanced_functionality/README.md
@@ -12,6 +12,7 @@ These examples that showcase unique functionality available in Amazon SageMaker.
 - [Bring Your Own k-means Model](kmeans_bring_your_own_model) shows how to take a model that's been fit elsewhere and use Amazon SageMaker Algorithms containers to host it.
 - [Installing the R Kernel](install_r_kernel) shows how to install the R kernel into an Amazon SageMaker Notebook Instance.
 - [Bring Your Own R Algorithm](r_bring_your_own) shows how to bring your own algorithm container to Amazon SageMaker using the R language.
+- [Bring Your Own JAX Algorithm](jax_bring_your_own) shows how to bring your own algorithm container to Amazon SageMaker using the JAX framework.
 - [Bring Your Own scikit Algorithm](scikit_bring_your_own) provides a detailed walkthrough on how to package a scikit learn algorithm for training and production-ready hosting.
 - [Bring Your Own MXNet Model](mxnet_mnist_byom) shows how to bring a model trained anywhere using MXNet into Amazon SageMaker
 - [Bring Your Own TensorFlow Model](tensorflow_iris_byom) shows how to bring a model trained anywhere using TensorFlow into Amazon SageMaker

--- a/advanced_functionality/jax_bring_your_own/docker/Dockerfile
+++ b/advanced_functionality/jax_bring_your_own/docker/Dockerfile
@@ -1,5 +1,17 @@
-# Dockerfile for training models using JAX
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
 
+# Dockerfile for training models using JAX
 # We build from NVIDIA container so that CUDA is available for GPU acceleration should the AWS instance support it
 FROM nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04
 

--- a/advanced_functionality/jax_bring_your_own/docker/Dockerfile
+++ b/advanced_functionality/jax_bring_your_own/docker/Dockerfile
@@ -1,0 +1,25 @@
+# Dockerfile for training models using JAX
+
+# We build from NVIDIA container so that CUDA is available for GPU acceleration should the AWS instance support it
+FROM nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04
+
+# Install python3
+RUN apt update && apt install -y python3-pip
+
+RUN ln -sf /usr/bin/python3 /usr/bin/python && \
+    ln -sf /usr/bin/pip3 /usr/bin/pip
+
+# Install the SageMaker Training Toolkit
+# This provides entry points for the training script
+RUN pip --no-cache-dir install sagemaker-training
+
+# Install JAX built with CUDA11 support
+RUN pip --no-cache-dir install --upgrade pip
+RUN pip --no-cache-dir install --upgrade jax jaxlib==0.1.57+cuda110 -f https://storage.googleapis.com/jax-releases/jax_releases.html
+
+# Install Trax
+RUN pip --no-cache-dir install matplotlib trax
+
+# Setting some environment variables related to logging
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1

--- a/advanced_functionality/jax_bring_your_own/sagemaker_jax.py
+++ b/advanced_functionality/jax_bring_your_own/sagemaker_jax.py
@@ -1,0 +1,61 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""
+Custom Framework Estimator for JAX
+"""
+from sagemaker.estimator import Framework
+from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
+from sagemaker.tensorflow.model import TensorFlowModel
+
+
+class JaxEstimator(Framework):
+    def __init__(
+        self,
+        entry_point,
+        source_dir=None,
+        hyperparameters=None,
+        image_name=None,
+        **kwargs
+    ):
+        super(JaxEstimator, self).__init__(
+            entry_point, source_dir, hyperparameters, image_name=image_name, **kwargs
+        )
+
+    def create_model(
+            self,
+            role=None,
+            vpc_config_override=VPC_CONFIG_DEFAULT,
+            entry_point=None,
+            source_dir=None,
+            dependencies=None,
+            **kwargs
+    ):
+        """Creates ``TensorFlowModel`` object to be used for creating SageMaker model entities
+        """
+        kwargs["name"] = self._get_or_create_name(kwargs.get("name"))
+
+        if "enable_network_isolation" not in kwargs:
+            kwargs["enable_network_isolation"] = self.enable_network_isolation()
+
+        return TensorFlowModel(
+            model_data=self.model_data,
+            role=role or self.role,
+            container_log_level=self.container_log_level,
+            framework_version='2.3.1',
+            sagemaker_session=self.sagemaker_session,
+            vpc_config=self.get_vpc_config(vpc_config_override),
+            entry_point=entry_point,
+            source_dir=source_dir,
+            dependencies=dependencies,
+            **kwargs
+        )

--- a/advanced_functionality/jax_bring_your_own/train_deploy_jax.ipynb
+++ b/advanced_functionality/jax_bring_your_own/train_deploy_jax.ipynb
@@ -1,0 +1,510 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Training and Deploying ML Models using JAX on SageMaker\n",
+    "Amazon SageMaker provides you the flexibility to train models using any framework that can work in a Docker container. In this example we'll show how to utilize the bring your own container paradigm to train machine learning models using the increasingly popular [JAX library from Google](https://github.com/google/jax). We'll train a fashion mnist classification model using vanilla JAX and another model using the [higher level Trax library from Google](https://github.com/google/trax).\n",
+    "\n",
+    "For both of these demos, we'll show how both JAX and Trax can serialize models using the TensorFlow standard [SavedModel format](https://www.tensorflow.org/guide/saved_model). This enables us to train these models in a custom container, but then deploy them using the managed and optimized SageMaker TensorFlow inference containers.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import json\n",
+    "\n",
+    "import boto3\n",
+    "import sagemaker\n",
+    "from sagemaker import get_execution_role\n",
+    "\n",
+    "from sagemaker_jax import JaxEstimator\n",
+    "\n",
+    "client = boto3.client('sts')\n",
+    "account = client.get_caller_identity()['Account']\n",
+    "role = get_execution_role()\n",
+    "my_session = boto3.session.Session()\n",
+    "region = my_session.region_name\n",
+    "\n",
+    "container_name = 'sagemaker-jax'\n",
+    "ecr_image = '{}.dkr.ecr.{}.amazonaws.com/{}'.format(account, region, container_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Custom Framework Estimator\n",
+    "Since we'll be saving our JAX and Trax models as SavedModel format, we can create a subclass of the base [SageMaker Framework estimator](https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html?highlight=Framework#sagemaker.estimator.Framework). This will enable us to specify a custom `create_model` method which leverages the existing TensorFlowModel class to launch inference containers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[37m# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.\u001b[39;49;00m\n",
+      "\u001b[37m#\u001b[39;49;00m\n",
+      "\u001b[37m# Licensed under the Apache License, Version 2.0 (the \"License\"). You\u001b[39;49;00m\n",
+      "\u001b[37m# may not use this file except in compliance with the License. A copy of\u001b[39;49;00m\n",
+      "\u001b[37m# the License is located at\u001b[39;49;00m\n",
+      "\u001b[37m#\u001b[39;49;00m\n",
+      "\u001b[37m#     http://aws.amazon.com/apache2.0/\u001b[39;49;00m\n",
+      "\u001b[37m#\u001b[39;49;00m\n",
+      "\u001b[37m# or in the \"license\" file accompanying this file. This file is\u001b[39;49;00m\n",
+      "\u001b[37m# distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF\u001b[39;49;00m\n",
+      "\u001b[37m# ANY KIND, either express or implied. See the License for the specific\u001b[39;49;00m\n",
+      "\u001b[37m# language governing permissions and limitations under the License.\u001b[39;49;00m\n",
+      "\u001b[33m\"\"\"\u001b[39;49;00m\n",
+      "\u001b[33mCustom Framework Estimator for JAX\u001b[39;49;00m\n",
+      "\u001b[33m\"\"\"\u001b[39;49;00m\n",
+      "\u001b[34mfrom\u001b[39;49;00m \u001b[04m\u001b[36msagemaker\u001b[39;49;00m\u001b[04m\u001b[36m.\u001b[39;49;00m\u001b[04m\u001b[36mestimator\u001b[39;49;00m \u001b[34mimport\u001b[39;49;00m Framework\n",
+      "\u001b[34mfrom\u001b[39;49;00m \u001b[04m\u001b[36msagemaker\u001b[39;49;00m\u001b[04m\u001b[36m.\u001b[39;49;00m\u001b[04m\u001b[36mvpc_utils\u001b[39;49;00m \u001b[34mimport\u001b[39;49;00m VPC_CONFIG_DEFAULT\n",
+      "\u001b[34mfrom\u001b[39;49;00m \u001b[04m\u001b[36msagemaker\u001b[39;49;00m\u001b[04m\u001b[36m.\u001b[39;49;00m\u001b[04m\u001b[36mtensorflow\u001b[39;49;00m\u001b[04m\u001b[36m.\u001b[39;49;00m\u001b[04m\u001b[36mmodel\u001b[39;49;00m \u001b[34mimport\u001b[39;49;00m TensorFlowModel\n",
+      "\n",
+      "\n",
+      "\u001b[34mclass\u001b[39;49;00m \u001b[04m\u001b[32mJaxEstimator\u001b[39;49;00m(Framework):\n",
+      "    \u001b[34mdef\u001b[39;49;00m \u001b[32m__init__\u001b[39;49;00m(\n",
+      "        \u001b[36mself\u001b[39;49;00m,\n",
+      "        entry_point,\n",
+      "        source_dir=\u001b[34mNone\u001b[39;49;00m,\n",
+      "        hyperparameters=\u001b[34mNone\u001b[39;49;00m,\n",
+      "        image_name=\u001b[34mNone\u001b[39;49;00m,\n",
+      "        **kwargs\n",
+      "    ):\n",
+      "        \u001b[36msuper\u001b[39;49;00m(JaxEstimator, \u001b[36mself\u001b[39;49;00m).\u001b[32m__init__\u001b[39;49;00m(\n",
+      "            entry_point, source_dir, hyperparameters, image_name=image_name, **kwargs\n",
+      "        )\n",
+      "\n",
+      "    \u001b[34mdef\u001b[39;49;00m \u001b[32mcreate_model\u001b[39;49;00m(\n",
+      "            \u001b[36mself\u001b[39;49;00m,\n",
+      "            role=\u001b[34mNone\u001b[39;49;00m,\n",
+      "            vpc_config_override=VPC_CONFIG_DEFAULT,\n",
+      "            entry_point=\u001b[34mNone\u001b[39;49;00m,\n",
+      "            source_dir=\u001b[34mNone\u001b[39;49;00m,\n",
+      "            dependencies=\u001b[34mNone\u001b[39;49;00m,\n",
+      "            **kwargs\n",
+      "    ):\n",
+      "        \u001b[33m\"\"\"Creates ``TensorFlowModel`` object to be used for creating SageMaker model entities\u001b[39;49;00m\n",
+      "\u001b[33m        \"\"\"\u001b[39;49;00m\n",
+      "        kwargs[\u001b[33m\"\u001b[39;49;00m\u001b[33mname\u001b[39;49;00m\u001b[33m\"\u001b[39;49;00m] = \u001b[36mself\u001b[39;49;00m._get_or_create_name(kwargs.get(\u001b[33m\"\u001b[39;49;00m\u001b[33mname\u001b[39;49;00m\u001b[33m\"\u001b[39;49;00m))\n",
+      "\n",
+      "        \u001b[34mif\u001b[39;49;00m \u001b[33m\"\u001b[39;49;00m\u001b[33menable_network_isolation\u001b[39;49;00m\u001b[33m\"\u001b[39;49;00m \u001b[35mnot\u001b[39;49;00m \u001b[35min\u001b[39;49;00m kwargs:\n",
+      "            kwargs[\u001b[33m\"\u001b[39;49;00m\u001b[33menable_network_isolation\u001b[39;49;00m\u001b[33m\"\u001b[39;49;00m] = \u001b[36mself\u001b[39;49;00m.enable_network_isolation()\n",
+      "\n",
+      "        \u001b[34mreturn\u001b[39;49;00m TensorFlowModel(\n",
+      "            model_data=\u001b[36mself\u001b[39;49;00m.model_data,\n",
+      "            role=role \u001b[35mor\u001b[39;49;00m \u001b[36mself\u001b[39;49;00m.role,\n",
+      "            container_log_level=\u001b[36mself\u001b[39;49;00m.container_log_level,\n",
+      "            framework_version=\u001b[33m'\u001b[39;49;00m\u001b[33m2.3.1\u001b[39;49;00m\u001b[33m'\u001b[39;49;00m,\n",
+      "            sagemaker_session=\u001b[36mself\u001b[39;49;00m.sagemaker_session,\n",
+      "            vpc_config=\u001b[36mself\u001b[39;49;00m.get_vpc_config(vpc_config_override),\n",
+      "            entry_point=entry_point,\n",
+      "            source_dir=source_dir,\n",
+      "            dependencies=dependencies,\n",
+      "            **kwargs\n",
+      "        )\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pygmentize sagemaker_jax.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Training Docker Container\n",
+    "Our custom training container is straight forward, though there are a few things worth mentioning that can be seen in the comments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# Dockerfile for training models using JAX\n",
+      "\n",
+      "# We build from NVIDIA container so that CUDA is available for GPU acceleration should the AWS instance support it\n",
+      "FROM nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04\n",
+      "\n",
+      "# Install python3\n",
+      "RUN apt update && apt install -y python3-pip\n",
+      "\n",
+      "RUN ln -sf /usr/bin/python3 /usr/bin/python && \\\n",
+      "    ln -sf /usr/bin/pip3 /usr/bin/pip\n",
+      "\n",
+      "# Install the SageMaker Training Toolkit\n",
+      "# This provides entry points for the training script\n",
+      "RUN pip --no-cache-dir install sagemaker-training\n",
+      "\n",
+      "# Install JAX built with CUDA11 support\n",
+      "RUN pip --no-cache-dir install --upgrade pip\n",
+      "RUN pip --no-cache-dir install --upgrade jax jaxlib==0.1.57+cuda110 -f https://storage.googleapis.com/jax-releases/jax_releases.html\n",
+      "\n",
+      "# Install Trax\n",
+      "RUN pip --no-cache-dir install matplotlib trax\n",
+      "\n",
+      "# Setting some environment variables related to logging\n",
+      "ENV PYTHONDONTWRITEBYTECODE=1 \\\n",
+      "    PYTHONUNBUFFERED=1\n"
+     ]
+    }
+   ],
+   "source": [
+    "!cat docker/Dockerfile"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Building and Publishing the Image\n",
+    "The below shell script must only be ran if the docker image has not already been pushed to the Elastic Container Registry. \n",
+    "\n",
+    "**NOTE: Since SageMaker studio is already running inside of a Docker container, this script cannot be ran inside of SageMaker Studio. Please push your container using awscli or use this toolkit: https://github.com/aws-samples/sagemaker-studio-image-build-cli**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sh\n",
+    "\n",
+    "container_name=sagemaker-jax\n",
+    "account=$(aws sts get-caller-identity --query Account --output text)\n",
+    "\n",
+    "# Get the region defined in the current configuration (default to us-west-2 if none defined)\n",
+    "region=$(aws configure get region)\n",
+    "region=${region:-us-west-2}\n",
+    "\n",
+    "fullname=\"${account}.dkr.ecr.${region}.amazonaws.com/${container_name}\"\n",
+    "\n",
+    "# If the repository doesn't exist in ECR, create it.\n",
+    "aws ecr describe-repositories --repository-names \"${container_name}\" > /dev/null 2>&1\n",
+    "if [ $? -ne 0 ]\n",
+    "then\n",
+    "    aws ecr create-repository --repository-name \"${container_name}\" > /dev/null\n",
+    "fi\n",
+    "\n",
+    "# Get the login command from ECR and execute it directly\n",
+    "$(aws ecr get-login --region ${region} --no-include-email)\n",
+    "\n",
+    "# Build the docker image locally with the image name and then push it to ECR\n",
+    "# with the full name.\n",
+    "docker build  -t ${container_name} docker/\n",
+    "docker tag ${container_name} ${fullname}\n",
+    "\n",
+    "docker push ${fullname}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Serializing models as SavedModel format\n",
+    "In the upcoming training jobs we'll be training a vanilla JAX model and a Trax model on the [fashion mnist dataset](https://github.com/zalandoresearch/fashion-mnist). The full details of the model can be seen in the `training_scripts/` directory, but it is worth calling out the methods for serialization. \n",
+    "\n",
+    "The JAX model utilizes the new experimental jax2tf converter: https://github.com/google/jax/tree/master/jax/experimental/jax2tf\n",
+    "\n",
+    "The Trax model utilizes the new trax2keras functionality: https://github.com/google/trax/blob/master/trax/trax2keras.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train using Vanilla JAX"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "2021-01-11 23:22:59 Starting - Starting the training job\n",
+      "2021-01-11 23:23:00 Starting - Launching requested ML instances.............\n",
+      "2021-01-11 23:24:10 Starting - Preparing the instances for training............\n",
+      "2021-01-11 23:25:18 Downloading - Downloading input data.\n",
+      "2021-01-11 23:25:25 Training - Downloading the training image...........................................................\n",
+      "2021-01-11 23:30:27 Training - Training image download completed. Training in progress.............\n",
+      "2021-01-11 23:31:33 Uploading - Uploading generated training model\n",
+      "2021-01-11 23:31:41 Completed - Training job completed\n"
+     ]
+    }
+   ],
+   "source": [
+    "vanilla_jax_estimator = JaxEstimator(\n",
+    "        image_uri=ecr_image,\n",
+    "        role=role,\n",
+    "        instance_count=1,\n",
+    "        base_job_name = container_name + \"-jax\",\n",
+    "        source_dir=\"training_scripts\",\n",
+    "        entry_point=\"train_jax.py\",\n",
+    "        instance_type=\"ml.p2.xlarge\",\n",
+    "        hyperparameters={'num_epochs': 3}\n",
+    "    )\n",
+    "\n",
+    "vanilla_jax_estimator.fit(logs=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train Using JAX High level API Trax"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "2021-01-11 23:41:39 Starting - Starting the training job\n",
+      "2021-01-11 23:41:43 Starting - Launching requested ML instances.............\n",
+      "2021-01-11 23:42:54 Starting - Preparing the instances for training..............\n",
+      "2021-01-11 23:44:07 Downloading - Downloading input data\n",
+      "2021-01-11 23:44:14 Training - Downloading the training image...........................................................\n",
+      "2021-01-11 23:49:16 Training - Training image download completed. Training in progress..................\n",
+      "2021-01-11 23:50:43 Uploading - Uploading generated training model\n",
+      "2021-01-11 23:50:50 Completed - Training job completed\n"
+     ]
+    }
+   ],
+   "source": [
+    "trax_estimator = JaxEstimator(\n",
+    "        image_uri=ecr_image,\n",
+    "        role=role,\n",
+    "        instance_count=1,\n",
+    "        base_job_name = container_name + \"-trax\",\n",
+    "        source_dir=\"training_scripts\",\n",
+    "        entry_point=\"train_trax.py\",\n",
+    "        instance_type=\"ml.p2.xlarge\",\n",
+    "        hyperparameters={'train_steps': 1000}\n",
+    "    )\n",
+    "\n",
+    "trax_estimator.fit(logs=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Deploy Both Models to prebuilt TF Containers\n",
+    "Since we've our customer Framework Estimator knows the models are to be served using TensorFlowModel, deploying these endpoints is just a trivial call to the `estimator.deploy()` method"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "update_endpoint is a no-op in sagemaker>=2.\n",
+      "See: https://sagemaker.readthedocs.io/en/stable/v2.html for details.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------!"
+     ]
+    }
+   ],
+   "source": [
+    "vanilla_jax_predictor = vanilla_jax_estimator.deploy(initial_instance_count=1, instance_type=\"ml.m4.xlarge\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "update_endpoint is a no-op in sagemaker>=2.\n",
+      "See: https://sagemaker.readthedocs.io/en/stable/v2.html for details.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "---------------!"
+     ]
+    }
+   ],
+   "source": [
+    "trax_predictor = trax_estimator.deploy(initial_instance_count=1, instance_type=\"ml.m4.xlarge\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test Inference Endpoints\n",
+    "This requires TF to be installed on your notebook's kernel as it is used to load testing data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "import numpy as np\n",
+    "from matplotlib import pyplot as plt\n",
+    "(x_train, y_train), (x_test, y_test) = tf.keras.datasets.fashion_mnist.load_data()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_image(predictor, test_images, test_labels, image_number):\n",
+    "    np_img = np.expand_dims(np.expand_dims(test_images[image_number], axis=-1), axis=0)\n",
+    "    \n",
+    "    result = predictor.predict(np_img)\n",
+    "    pred_y = np.argmax(result['predictions'])\n",
+    "    \n",
+    "    print(\"True Label:\", test_labels[image_number])\n",
+    "    print(\"Predicted Label:\", pred_y)\n",
+    "    plt.imshow(test_images[image_number])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True Label: 9\n",
+      "Predicted Label: 9\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAQPklEQVR4nO3dW4xd9XXH8d+amTPjYWxjD77UNQZsMAhaCdNOTVqqiog0JbyYSCGCh5RKSI5UkIKE1CL6ENQn2jSN+lBFchoUt0pBqRIEqlADsmholAgxXGIMJFwshwwePJjxZXyd2+rDHKoJzF57OGefS7q+H2l0ZvY6e5/lM+fnfeb8995/c3cB+P+vp9MNAGgPwg4kQdiBJAg7kARhB5Loa+eD9duAr9BQOx8SSOWcTmvaz9tStabCbmY3S/onSb2S/sXdH4ruv0JDut5uauYhAQSe832FtYbfxptZr6R/lvQ5SddIusPMrml0ewBaq5m/2XdKesvdD7r7tKRHJe2qpi0AVWsm7Jsl/WrRz2P1Zb/GzHab2aiZjc7ofBMPB6AZzYR9qQ8BPnbsrbvvcfcRdx+paaCJhwPQjGbCPiZpy6KfL5Z0uLl2ALRKM2F/XtJ2M9tqZv2Sbpf0RDVtAahaw0Nv7j5rZvdI+qEWht4edvdXK+sMQKWaGmd39yclPVlRLwBaiMNlgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EAShB1IgrADSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0k0NWWzmR2SNCVpTtKsu49U0RSA6jUV9rpPu/vRCrYDoIV4Gw8k0WzYXdJTZvaCme1e6g5mttvMRs1sdEbnm3w4AI1q9m38De5+2Mw2SHrazH7u7s8uvoO775G0R5JW27A3+XgAGtTUnt3dD9dvJyQ9JmlnFU0BqF7DYTezITNb9eH3kj4r6UBVjQGoVjNv4zdKeszMPtzOv7v7f1XSFYDKNRx2dz8o6doKewHQQgy9AUkQdiAJwg4kQdiBJAg7kEQVJ8IAHWF98cvX5+aCYnMHc/ZccEFYnz9zJqzbdb9TWPOXXm2opzLs2YEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcbZs1s4RTmol+wP5oOxbEm927cV1iZu3Biuu+E/Xgvrc8dPhPVWKhtHL3Pwi6sLa1tfamrThdizA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EASjLMjVjKOXua9zxSPpR8bmQnXPb2p+JxvSbrkb3/SUE9V6Lt0S1h/d1dcr01V2c3ysGcHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQYZ0/O+mph3Wemw/rMZ34/rJ+4qvj67LX348c+f/m5uP7UZWH9veOrCmsXrIj/XcfGLgzrtbXnw/qFq46G9ROH4+23Qume3cweNrMJMzuwaNmwmT1tZm/Wb9e2tk0AzVrO2/jvSLr5I8vul7TP3bdL2lf/GUAXKw27uz8rafIji3dJ2lv/fq+kWyvuC0DFGv2AbqO7j0tS/XZD0R3NbLeZjZrZ6Iziv3MAtE7LP4139z3uPuLuIzUNtPrhABRoNOxHzGyTJNVvJ6prCUArNBr2JyTdWf/+TkmPV9MOgFYpHWc3s0ck3ShpnZmNSfqqpIckfc/M7pL0jqTbWtkkmtDTG5bLxtF718TjwW98Id6+BR/TzA3Ec6QProw/4zGL1+/pKa6XrXvFVeNh/eDhdWH92ImhsK6+5uaHb0Rp2N39joLSTRX3AqCFOFwWSIKwA0kQdiAJwg4kQdiBJDjFdbmiqY29ZBilZPhLPl9Sj7dvfcW/Rp+djbdd4u37rgnrAyWHU/WeK37ezlwS93bBQHyp6bH345Mte3qLn9f5+Xg/N3lmMKzPT8e/04FV8bBhrb/431423NnoVNXs2YEkCDuQBGEHkiDsQBKEHUiCsANJEHYgiTzj7NE4uVQ+Vl5WjzQ57XE0ji41N5Y+8Zd/FNanN8Rj3Wv2x5eDng9a71sdn147eSw+TdSP9cf1i4q3X+uLfye13uZ+Z9HptZK0crB4HH7m2m3xtn/0UmM9NbQWgN84hB1IgrADSRB2IAnCDiRB2IEkCDuQRJ5x9mbGyaXwnHTrLblc82w8Vl3WWzPj6OP3xePoU1fE217xbsm0ysPx43tweMOKwXic/dT4ynjjK+Ox8OgyAafOxrMTDQ7Evan0sI2SOwR+efOKsL71R41tlz07kARhB5Ig7EAShB1IgrADSRB2IAnCDiTxmzXOXnb99UjZtdmt5P+94Jx0b/J89TK9V2wN64du31RYmxssOa/67fglMFsy83DZtMvTw8XPTf90/NhWMlbdN1hy/EJgbi7+fZ+bjo8v0Fzc2/kzJef5zxevf+nOsfixG1S6Zzezh81swswOLFr2oJm9a2Yv179uaUl3ACqznLfx35F08xLLv+HuO+pfT1bbFoCqlYbd3Z+VNNmGXgC0UDMf0N1jZvvrb/MLJ90ys91mNmpmozOK578C0DqNhv2bki6XtEPSuKSvF93R3fe4+4i7j9QUn3wAoHUaCru7H3H3OXefl/QtSTurbQtA1RoKu5ktHuv5vKQDRfcF0B1Kx9nN7BFJN0paZ2Zjkr4q6UYz2yHJJR2S9OVlPZo1OZd4K8ezvfFt9225OKyfvWpjWJ+8Ov7z5uxvxWPZPcGp17WpeDx4+sJ427OrSs61r5VcJ6C/+PgGD8aaJenCi+N5yAdq8etl8kTxQQJzsyXXICjpTSXXhfezJccv9Bavf/RUfHDD+j+8trj4s58UlkrD7u53LLH422XrAeguHC4LJEHYgSQIO5AEYQeSIOxAEu09xdWbuyxy32WXFNbOXrkhXHdmZTzUMj0U/783O1hcm7osXLX0NNOembjedzoeBvKg9enV8bbnVsR1KxsNHYxPHbazxc/7zHT8nE/3xw9+/MiqsF5bXXx4dtllrE8fD37hkmpD8frr15wK6yfOFG//6nVHwnXHNmwvrM3Xil8r7NmBJAg7kARhB5Ig7EAShB1IgrADSRB2IImuupT0qduuj+u/XTxm21MyHnxuXVz34JRDSbLg0sE9syXrnorHyWeH4vXPbSw5/TbafHCKqST1Ho9fAtEYviT1royf+J6e4sefKbnc8tnT8am/vSfjYycG1jd+TEeZmePxtMoT8/ETF43zr+k/G657ODguw4KXEnt2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiirePs82uHNPVnnyqsz/75B+H6p968qLC24kj8/1YtPr1Y3hOPhUeXa/bekssOl5RrJePw87X432bBUPpMyaWgy3orO9+9dCbsvuL1hzecDNe9+qKJeONXxOXVtXOFtT4rOXZhS1x+79zqsL5hIH7BTU5fUFg7fObCcN3Bw6cLaz3Txb8Q9uxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kERbx9l7p85rzX8fLKy/sXNbuP6Ga94vrF36B8ca7kuSzs3G51YfObOysHb0WHz98tnj/WG9VnJe9nzJtMgejJX78Ey47o5t74T19Svi8eJtg0fD+lxwQvwD634Rrvt3HxRfH12SnjpydVj/2pX/WVgb7o3PlZ/zkuMTSpzx+Hn/4ZniORDeOhdP8f0/azYX1ryv+Pku3bOb2RYze8bMXjezV83sK/Xlw2b2tJm9Wb9dW7YtAJ2znLfxs5Luc/erJX1K0t1mdo2k+yXtc/ftkvbVfwbQpUrD7u7j7v5i/fspSa9L2ixpl6S99bvtlXRrq5oE0LxP9AGdmV0m6TpJz0na6O7j0sJ/CJKWnGzNzHab2aiZjU7Px9fWAtA6yw67ma2U9H1J97p7fAbDIu6+x91H3H2kvyeeLA9A6ywr7GZW00LQv+vuP6gvPmJmm+r1TZJKTlEC0EnmJUMMZmZa+Jt80t3vXbT8a5I+cPeHzOx+ScPu/lfRtlbbsF9vN1XQ9sf1ro0HA07edGVYP3ZlPPzVt7N4aO/y4Xj46ZKheFhw80Bc71XJtMvBeaoz8/Ho6munNoX1nx7cGtbXPhNfUnn9o/sLa/Oni0/VrML8vuLzVD+9/o1w3f1TxcNbkvTe6fgU1w9OF5/CKkmzs9FU1vHv7Mq7i4evf3rycZ2YfX/JF8RyxtlvkPQlSa+Y2cv1ZQ9IekjS98zsLknvSLptGdsC0CGlYXf3H6v4Eget2U0DqByHywJJEHYgCcIOJEHYgSQIO5BE6Th7lVo5zg5Aes736aRPLjl6xp4dSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EAShB1IgrADSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSKA27mW0xs2fM7HUze9XMvlJf/qCZvWtmL9e/bml9uwAatZz52Wcl3efuL5rZKkkvmNnT9do33P0fWtcegKosZ372cUnj9e+nzOx1SZtb3RiAan2iv9nN7DJJ10l6rr7oHjPbb2YPm9nagnV2m9momY3O6HxTzQJo3LLDbmYrJX1f0r3uflLSNyVdLmmHFvb8X19qPXff4+4j7j5S00AFLQNoxLLCbmY1LQT9u+7+A0ly9yPuPufu85K+JWln69oE0KzlfBpvkr4t6XV3/8dFyzctutvnJR2ovj0AVVnOp/E3SPqSpFfM7OX6sgck3WFmOyS5pEOSvtySDgFUYjmfxv9Y0lLzPT9ZfTsAWoUj6IAkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0mYu7fvwczel/TLRYvWSTratgY+mW7trVv7kuitUVX2dqm7r1+q0Nawf+zBzUbdfaRjDQS6tbdu7Uuit0a1qzfexgNJEHYgiU6HfU+HHz/Srb11a18SvTWqLb119G92AO3T6T07gDYh7EASHQm7md1sZr8ws7fM7P5O9FDEzA6Z2Sv1aahHO9zLw2Y2YWYHFi0bNrOnzezN+u2Sc+x1qLeumMY7mGa8o89dp6c/b/vf7GbWK+kNSX8qaUzS85LucPfX2tpIATM7JGnE3Tt+AIaZ/YmkU5L+1d1/t77s7yVNuvtD9f8o17r7X3dJbw9KOtXpabzrsxVtWjzNuKRbJf2FOvjcBX19UW143jqxZ98p6S13P+ju05IelbSrA310PXd/VtLkRxbvkrS3/v1eLbxY2q6gt67g7uPu/mL9+ylJH04z3tHnLuirLToR9s2SfrXo5zF113zvLukpM3vBzHZ3upklbHT3cWnhxSNpQ4f7+ajSabzb6SPTjHfNc9fI9OfN6kTYl5pKqpvG/25w99+T9DlJd9ffrmJ5ljWNd7ssMc14V2h0+vNmdSLsY5K2LPr5YkmHO9DHktz9cP12QtJj6r6pqI98OINu/Xaiw/38n26axnupacbVBc9dJ6c/70TYn5e03cy2mlm/pNslPdGBPj7GzIbqH5zIzIYkfVbdNxX1E5LurH9/p6THO9jLr+mWabyLphlXh5+7jk9/7u5t/5J0ixY+kX9b0t90ooeCvrZJ+ln969VO9ybpES28rZvRwjuiuyRdJGmfpDfrt8Nd1Nu/SXpF0n4tBGtTh3r7Yy38abhf0sv1r1s6/dwFfbXleeNwWSAJjqADkiDsQBKEHUiCsANJEHYgCcIOJEHYgST+Fztd/KktNyi2AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "test_image(trax_predictor, x_test, y_test, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True Label: 9\n",
+      "Predicted Label: 9\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAQPklEQVR4nO3dW4xd9XXH8d+amTPjYWxjD77UNQZsMAhaCdNOTVqqiog0JbyYSCGCh5RKSI5UkIKE1CL6ENQn2jSN+lBFchoUt0pBqRIEqlADsmholAgxXGIMJFwshwwePJjxZXyd2+rDHKoJzF57OGefS7q+H2l0ZvY6e5/lM+fnfeb8995/c3cB+P+vp9MNAGgPwg4kQdiBJAg7kARhB5Loa+eD9duAr9BQOx8SSOWcTmvaz9tStabCbmY3S/onSb2S/sXdH4ruv0JDut5uauYhAQSe832FtYbfxptZr6R/lvQ5SddIusPMrml0ewBaq5m/2XdKesvdD7r7tKRHJe2qpi0AVWsm7Jsl/WrRz2P1Zb/GzHab2aiZjc7ofBMPB6AZzYR9qQ8BPnbsrbvvcfcRdx+paaCJhwPQjGbCPiZpy6KfL5Z0uLl2ALRKM2F/XtJ2M9tqZv2Sbpf0RDVtAahaw0Nv7j5rZvdI+qEWht4edvdXK+sMQKWaGmd39yclPVlRLwBaiMNlgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EAShB1IgrADSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0k0NWWzmR2SNCVpTtKsu49U0RSA6jUV9rpPu/vRCrYDoIV4Gw8k0WzYXdJTZvaCme1e6g5mttvMRs1sdEbnm3w4AI1q9m38De5+2Mw2SHrazH7u7s8uvoO775G0R5JW27A3+XgAGtTUnt3dD9dvJyQ9JmlnFU0BqF7DYTezITNb9eH3kj4r6UBVjQGoVjNv4zdKeszMPtzOv7v7f1XSFYDKNRx2dz8o6doKewHQQgy9AUkQdiAJwg4kQdiBJAg7kEQVJ8IAHWF98cvX5+aCYnMHc/ZccEFYnz9zJqzbdb9TWPOXXm2opzLs2YEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcbZs1s4RTmol+wP5oOxbEm927cV1iZu3Biuu+E/Xgvrc8dPhPVWKhtHL3Pwi6sLa1tfamrThdizA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EASjLMjVjKOXua9zxSPpR8bmQnXPb2p+JxvSbrkb3/SUE9V6Lt0S1h/d1dcr01V2c3ysGcHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQYZ0/O+mph3Wemw/rMZ34/rJ+4qvj67LX348c+f/m5uP7UZWH9veOrCmsXrIj/XcfGLgzrtbXnw/qFq46G9ROH4+23Qume3cweNrMJMzuwaNmwmT1tZm/Wb9e2tk0AzVrO2/jvSLr5I8vul7TP3bdL2lf/GUAXKw27uz8rafIji3dJ2lv/fq+kWyvuC0DFGv2AbqO7j0tS/XZD0R3NbLeZjZrZ6Iziv3MAtE7LP4139z3uPuLuIzUNtPrhABRoNOxHzGyTJNVvJ6prCUArNBr2JyTdWf/+TkmPV9MOgFYpHWc3s0ck3ShpnZmNSfqqpIckfc/M7pL0jqTbWtkkmtDTG5bLxtF718TjwW98Id6+BR/TzA3Ec6QProw/4zGL1+/pKa6XrXvFVeNh/eDhdWH92ImhsK6+5uaHb0Rp2N39joLSTRX3AqCFOFwWSIKwA0kQdiAJwg4kQdiBJDjFdbmiqY29ZBilZPhLPl9Sj7dvfcW/Rp+djbdd4u37rgnrAyWHU/WeK37ezlwS93bBQHyp6bH345Mte3qLn9f5+Xg/N3lmMKzPT8e/04FV8bBhrb/431423NnoVNXs2YEkCDuQBGEHkiDsQBKEHUiCsANJEHYgiTzj7NE4uVQ+Vl5WjzQ57XE0ji41N5Y+8Zd/FNanN8Rj3Wv2x5eDng9a71sdn147eSw+TdSP9cf1i4q3X+uLfye13uZ+Z9HptZK0crB4HH7m2m3xtn/0UmM9NbQWgN84hB1IgrADSRB2IAnCDiRB2IEkCDuQRJ5x9mbGyaXwnHTrLblc82w8Vl3WWzPj6OP3xePoU1fE217xbsm0ysPx43tweMOKwXic/dT4ynjjK+Ox8OgyAafOxrMTDQ7Evan0sI2SOwR+efOKsL71R41tlz07kARhB5Ig7EAShB1IgrADSRB2IAnCDiTxmzXOXnb99UjZtdmt5P+94Jx0b/J89TK9V2wN64du31RYmxssOa/67fglMFsy83DZtMvTw8XPTf90/NhWMlbdN1hy/EJgbi7+fZ+bjo8v0Fzc2/kzJef5zxevf+nOsfixG1S6Zzezh81swswOLFr2oJm9a2Yv179uaUl3ACqznLfx35F08xLLv+HuO+pfT1bbFoCqlYbd3Z+VNNmGXgC0UDMf0N1jZvvrb/MLJ90ys91mNmpmozOK578C0DqNhv2bki6XtEPSuKSvF93R3fe4+4i7j9QUn3wAoHUaCru7H3H3OXefl/QtSTurbQtA1RoKu5ktHuv5vKQDRfcF0B1Kx9nN7BFJN0paZ2Zjkr4q6UYz2yHJJR2S9OVlPZo1OZd4K8ezvfFt9225OKyfvWpjWJ+8Ov7z5uxvxWPZPcGp17WpeDx4+sJ427OrSs61r5VcJ6C/+PgGD8aaJenCi+N5yAdq8etl8kTxQQJzsyXXICjpTSXXhfezJccv9Bavf/RUfHDD+j+8trj4s58UlkrD7u53LLH422XrAeguHC4LJEHYgSQIO5AEYQeSIOxAEu09xdWbuyxy32WXFNbOXrkhXHdmZTzUMj0U/783O1hcm7osXLX0NNOembjedzoeBvKg9enV8bbnVsR1KxsNHYxPHbazxc/7zHT8nE/3xw9+/MiqsF5bXXx4dtllrE8fD37hkmpD8frr15wK6yfOFG//6nVHwnXHNmwvrM3Xil8r7NmBJAg7kARhB5Ig7EAShB1IgrADSRB2IImuupT0qduuj+u/XTxm21MyHnxuXVz34JRDSbLg0sE9syXrnorHyWeH4vXPbSw5/TbafHCKqST1Ho9fAtEYviT1royf+J6e4sefKbnc8tnT8am/vSfjYycG1jd+TEeZmePxtMoT8/ETF43zr+k/G657ODguw4KXEnt2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiirePs82uHNPVnnyqsz/75B+H6p968qLC24kj8/1YtPr1Y3hOPhUeXa/bekssOl5RrJePw87X432bBUPpMyaWgy3orO9+9dCbsvuL1hzecDNe9+qKJeONXxOXVtXOFtT4rOXZhS1x+79zqsL5hIH7BTU5fUFg7fObCcN3Bw6cLaz3Txb8Q9uxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kERbx9l7p85rzX8fLKy/sXNbuP6Ga94vrF36B8ca7kuSzs3G51YfObOysHb0WHz98tnj/WG9VnJe9nzJtMgejJX78Ey47o5t74T19Svi8eJtg0fD+lxwQvwD634Rrvt3HxRfH12SnjpydVj/2pX/WVgb7o3PlZ/zkuMTSpzx+Hn/4ZniORDeOhdP8f0/azYX1ryv+Pku3bOb2RYze8bMXjezV83sK/Xlw2b2tJm9Wb9dW7YtAJ2znLfxs5Luc/erJX1K0t1mdo2k+yXtc/ftkvbVfwbQpUrD7u7j7v5i/fspSa9L2ixpl6S99bvtlXRrq5oE0LxP9AGdmV0m6TpJz0na6O7j0sJ/CJKWnGzNzHab2aiZjU7Px9fWAtA6yw67ma2U9H1J97p7fAbDIu6+x91H3H2kvyeeLA9A6ywr7GZW00LQv+vuP6gvPmJmm+r1TZJKTlEC0EnmJUMMZmZa+Jt80t3vXbT8a5I+cPeHzOx+ScPu/lfRtlbbsF9vN1XQ9sf1ro0HA07edGVYP3ZlPPzVt7N4aO/y4Xj46ZKheFhw80Bc71XJtMvBeaoz8/Ho6munNoX1nx7cGtbXPhNfUnn9o/sLa/Oni0/VrML8vuLzVD+9/o1w3f1TxcNbkvTe6fgU1w9OF5/CKkmzs9FU1vHv7Mq7i4evf3rycZ2YfX/JF8RyxtlvkPQlSa+Y2cv1ZQ9IekjS98zsLknvSLptGdsC0CGlYXf3H6v4Eget2U0DqByHywJJEHYgCcIOJEHYgSQIO5BE6Th7lVo5zg5Aes736aRPLjl6xp4dSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EAShB1IgrADSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSKA27mW0xs2fM7HUze9XMvlJf/qCZvWtmL9e/bml9uwAatZz52Wcl3efuL5rZKkkvmNnT9do33P0fWtcegKosZ372cUnj9e+nzOx1SZtb3RiAan2iv9nN7DJJ10l6rr7oHjPbb2YPm9nagnV2m9momY3O6HxTzQJo3LLDbmYrJX1f0r3uflLSNyVdLmmHFvb8X19qPXff4+4j7j5S00AFLQNoxLLCbmY1LQT9u+7+A0ly9yPuPufu85K+JWln69oE0KzlfBpvkr4t6XV3/8dFyzctutvnJR2ovj0AVVnOp/E3SPqSpFfM7OX6sgck3WFmOyS5pEOSvtySDgFUYjmfxv9Y0lLzPT9ZfTsAWoUj6IAkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0mYu7fvwczel/TLRYvWSTratgY+mW7trVv7kuitUVX2dqm7r1+q0Nawf+zBzUbdfaRjDQS6tbdu7Uuit0a1qzfexgNJEHYgiU6HfU+HHz/Srb11a18SvTWqLb119G92AO3T6T07gDYh7EASHQm7md1sZr8ws7fM7P5O9FDEzA6Z2Sv1aahHO9zLw2Y2YWYHFi0bNrOnzezN+u2Sc+x1qLeumMY7mGa8o89dp6c/b/vf7GbWK+kNSX8qaUzS85LucPfX2tpIATM7JGnE3Tt+AIaZ/YmkU5L+1d1/t77s7yVNuvtD9f8o17r7X3dJbw9KOtXpabzrsxVtWjzNuKRbJf2FOvjcBX19UW143jqxZ98p6S13P+ju05IelbSrA310PXd/VtLkRxbvkrS3/v1eLbxY2q6gt67g7uPu/mL9+ylJH04z3tHnLuirLToR9s2SfrXo5zF113zvLukpM3vBzHZ3upklbHT3cWnhxSNpQ4f7+ajSabzb6SPTjHfNc9fI9OfN6kTYl5pKqpvG/25w99+T9DlJd9ffrmJ5ljWNd7ssMc14V2h0+vNmdSLsY5K2LPr5YkmHO9DHktz9cP12QtJj6r6pqI98OINu/Xaiw/38n26axnupacbVBc9dJ6c/70TYn5e03cy2mlm/pNslPdGBPj7GzIbqH5zIzIYkfVbdNxX1E5LurH9/p6THO9jLr+mWabyLphlXh5+7jk9/7u5t/5J0ixY+kX9b0t90ooeCvrZJ+ln969VO9ybpES28rZvRwjuiuyRdJGmfpDfrt8Nd1Nu/SXpF0n4tBGtTh3r7Yy38abhf0sv1r1s6/dwFfbXleeNwWSAJjqADkiDsQBKEHUiCsANJEHYgCcIOJEHYgST+Fztd/KktNyi2AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "test_image(vanilla_jax_predictor, x_test, y_test, 0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Optionally Clean up the running endpoints"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean-Up\n",
+    "vanilla_jax_predictor.delete_endpoint()\n",
+    "trax_predictor.delete_endpoint()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "conda_tensorflow2_p36",
+   "language": "python",
+   "name": "conda_tensorflow2_p36"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/advanced_functionality/jax_bring_your_own/training_scripts/train_jax.py
+++ b/advanced_functionality/jax_bring_your_own/training_scripts/train_jax.py
@@ -1,0 +1,175 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""
+Train JAX model and serialize as TF SavedModel
+"""
+import time
+import argparse
+import functools
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import tensorflow as tf
+import tensorflow_datasets as tfds
+from jax.experimental import jax2tf
+
+
+def load_fashion_mnist(split: tfds.Split, batch_size: int):
+    ds = tfds.load("fashion_mnist", split=split)
+
+    def _prepare_example(x):
+        image = tf.cast(x["image"], tf.float32) / 255.0
+        label = tf.one_hot(x["label"], 10)
+        return (image, label)
+
+    ds = ds.map(_prepare_example)
+    # drop_remainder=True is important for use with Keras
+    ds = ds.cache().shuffle(1000).batch(batch_size, drop_remainder=True)
+    return ds
+
+
+class PureJaxMNIST:
+    name = "mnist_pure_jax"
+
+    @staticmethod
+    def predict(params, inputs, with_classifier=True):
+        x = inputs.reshape(
+            (inputs.shape[0], np.prod(inputs.shape[1:])))  # flatten to f32[B, 784]
+        for w, b in params[:-1]:
+            x = jnp.dot(x, w) + b
+            x = jnp.tanh(x)
+
+        if not with_classifier:
+            return x
+        final_w, final_b = params[-1]
+        logits = jnp.dot(x, final_w) + final_b
+        return logits - jax.scipy.special.logsumexp(
+            logits, axis=1, keepdims=True)
+
+    @staticmethod
+    def loss(params, inputs, labels):
+        predictions = PureJaxMNIST.predict(params, inputs, with_classifier=True)
+        return -jnp.mean(jnp.sum(predictions * labels, axis=1))
+
+    @staticmethod
+    def accuracy(predict, params, dataset):
+
+        @jax.jit
+        def _per_batch(inputs, labels):
+            target_class = jnp.argmax(labels, axis=1)
+            predicted_class = jnp.argmax(predict(params, inputs), axis=1)
+            return jnp.mean(predicted_class == target_class)
+
+        batched = [
+            _per_batch(inputs, labels) for inputs, labels in tfds.as_numpy(dataset)
+        ]
+        return jnp.mean(jnp.stack(batched))
+
+    @staticmethod
+    def update(params, step_size, inputs, labels):
+        grads = jax.grad(PureJaxMNIST.loss)(params, inputs, labels)
+        return [(w - step_size * dw, b - step_size * db)
+                for (w, b), (dw, db) in zip(params, grads)]
+
+    @staticmethod
+    def train(train_ds, test_ds, num_epochs, step_size, with_classifier=True):
+        layer_sizes = [784, 512, 512, 10]
+
+        rng = jax.random.PRNGKey(0)
+        params = [(0.1 * jax.random.normal(rng, (m, n)),
+                   0.1 * jax.random.normal(rng, (n,)))
+                  for m, n, in zip(layer_sizes[:-1], layer_sizes[1:])]
+
+        for epoch in range(num_epochs):
+            start_time = time.time()
+            for inputs, labels in tfds.as_numpy(train_ds):
+                params = jax.jit(PureJaxMNIST.update)(params, step_size, inputs, labels)
+            epoch_time = time.time() - start_time
+            train_acc = PureJaxMNIST.accuracy(PureJaxMNIST.predict, params, train_ds)
+            test_acc = PureJaxMNIST.accuracy(PureJaxMNIST.predict, params, test_ds)
+            print(
+                f"{PureJaxMNIST.name}: Epoch {epoch} in {epoch_time:0.2f} sec")
+            print(f"{PureJaxMNIST.name}: Training set accuracy {train_acc}")
+            print(f"{PureJaxMNIST.name}: Test set accuracy {test_acc}")
+
+        return (functools.partial(
+            PureJaxMNIST.predict, with_classifier=with_classifier), params)
+
+
+def save_model_tf(prediction_function, params_to_save):
+    tf_fun = jax2tf.convert(prediction_function, enable_xla=True)
+    param_vars = tf.nest.map_structure(
+        lambda param: tf.Variable(param),
+        params_to_save)
+
+    tf_graph = tf.function(lambda inputs: tf_fun(param_vars, inputs),
+                           autograph=False,
+                           experimental_compile=True)
+
+    # This signature is needed for TensorFlow Serving use.
+    signatures = {}
+    signatures[tf.saved_model.DEFAULT_SERVING_SIGNATURE_DEF_KEY] = tf_graph.get_concrete_function(tf.TensorSpec((1, 28, 28, 1), tf.float32))
+
+    wrapper = _ReusableSavedModelWrapper(tf_graph, param_vars)
+    model_dir = "/opt/ml/model/1"
+    tf.saved_model.save(wrapper, model_dir, signatures=signatures)
+
+
+class _ReusableSavedModelWrapper(tf.train.Checkpoint):
+    """Wraps a function and its parameters for saving to a SavedModel.
+    Implements the interface described at
+    https://www.tensorflow.org/hub/reusable_saved_models.
+    """
+
+    def __init__(self, tf_graph, param_vars):
+        """Args:
+          tf_graph: a tf.function taking one argument (the inputs), which can be
+             be tuples/lists/dictionaries of np.ndarray or tensors. The function
+             may have references to the tf.Variables in `param_vars`.
+          param_vars: the parameters, as tuples/lists/dictionaries of tf.Variable,
+             to be saved as the variables of the SavedModel.
+        """
+        super().__init__()
+        # Implement the interface from https://www.tensorflow.org/hub/reusable_saved_models
+        self.variables = tf.nest.flatten(param_vars)
+        self.trainable_variables = [v for v in self.variables if v.trainable]
+        # If you intend to prescribe regularization terms for users of the model,
+        # add them as @tf.functions with no inputs to this list. Else drop this.
+        self.regularization_losses = []
+        self.__call__ = tf_graph
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--num_epochs', type=int, default=3)
+    parser.add_argument('--batch_size', type=int, default=16)
+    parser.add_argument('--learning_rate', type=float, default=0.001)
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+
+    train_ds = load_fashion_mnist(tfds.Split.TRAIN, batch_size=args.batch_size)
+    test_ds = load_fashion_mnist(tfds.Split.TEST, batch_size=args.batch_size)
+
+    (predict_fn, predict_params) = PureJaxMNIST.train(
+        train_ds,
+        test_ds,
+        args.num_epochs,
+        args.learning_rate,
+        with_classifier=True)
+
+    save_model_tf(predict_fn, predict_params)

--- a/advanced_functionality/jax_bring_your_own/training_scripts/train_trax.py
+++ b/advanced_functionality/jax_bring_your_own/training_scripts/train_trax.py
@@ -1,0 +1,102 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""
+Train Trax model and serialize as TF SavedModel
+"""
+import argparse
+
+import trax
+import tensorflow as tf
+from trax import layers as tl
+from trax.supervised import training
+
+
+def get_model(n_output_classes=10):
+    """
+    Simple CNN to classify Fashion MNIST
+    """
+    model = tl.Serial(
+        tl.ToFloat(),
+        tl.Conv(32, (3, 3), (1, 1), "SAME"),
+        tl.LayerNorm(),
+        tl.Relu(),
+        tl.MaxPool(),
+        tl.Conv(64, (3, 3), (1, 1), "SAME"),
+        tl.LayerNorm(),
+        tl.Relu(),
+        tl.MaxPool(),
+        tl.Flatten(),
+        tl.Dense(n_output_classes),
+    )
+
+    return model
+
+
+def save_model_tf(model_to_save):
+    """
+    Serialize a TensorFlow graph from trained Trax Model
+    :param model_to_save: Trax Model
+    """
+    keras_layer = trax.AsKeras(model_to_save, batch_size=1)
+    inputs = tf.keras.Input(shape=(28, 28, 1))
+    hidden = keras_layer(inputs)
+
+    keras_model = tf.keras.Model(inputs=inputs, outputs=hidden)
+    keras_model.save("/opt/ml/model/1", save_format="tf")
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--train_steps', type=int, default=50)
+    parser.add_argument('--learning_rate', type=float, default=0.001)
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+
+    # Load Dataset from TensorFlow DataSets
+    train_stream = trax.data.TFDS("fashion_mnist", keys=("image", "label"), train=True)()
+    eval_stream = trax.data.TFDS("fashion_mnist", keys=("image", "label"), train=False)()
+
+    # Create Data Pipelines
+    train_data_pipeline = trax.data.Serial(
+        trax.data.Shuffle(),
+        trax.data.Batch(8),
+    )
+    train_batches_stream = train_data_pipeline(train_stream)
+
+    eval_data_pipeline = trax.data.Batch(1)
+    eval_batches_stream = eval_data_pipeline(eval_stream)
+
+    # Define Train and Eval tasks using Trax Training
+    train_task = training.TrainTask(
+        labeled_data=train_batches_stream,
+        loss_layer=tl.CategoryCrossEntropy(),
+        optimizer=trax.optimizers.Adam(args.learning_rate),
+    )
+
+    eval_task = training.EvalTask(
+        labeled_data=eval_batches_stream,
+        metrics=[tl.CategoryCrossEntropy(), tl.CategoryAccuracy()],
+        n_eval_batches=20,
+    )
+
+    # Train Model
+    model = get_model(n_output_classes=10)
+    training_loop = training.Loop(model, train_task, eval_tasks=[eval_task])
+    training_loop.run(args.train_steps)
+
+    # Save Model
+    save_model_tf(model)

--- a/training/bring_your_own_container.rst
+++ b/training/bring_your_own_container.rst
@@ -35,3 +35,12 @@ TensorFlow
    :maxdepth: 1
 
    ../advanced_functionality/tensorflow_bring_your_own/tensorflow_bring_your_own
+
+
+JAX
+============
+
+.. toctree::
+   :maxdepth: 1
+
+   ../advanced_functionality/jax_bring_your_own/train_deploy_jax

--- a/training/frameworks.rst
+++ b/training/frameworks.rst
@@ -98,3 +98,12 @@ TensorFlow
    ../sagemaker-python-sdk/tensorflow-eager-script-mode/tf-eager-sm-scriptmode
    ../sagemaker-python-sdk/tensorflow_script_mode_training_and_serving/tensorflow_script_mode_training_and_serving
    ../sagemaker-python-sdk/tensorboard_keras/tensorboard_keras
+
+
+JAX
+============
+
+.. toctree::
+   :maxdepth: 1
+
+   ../advanced_functionality/jax_bring_your_own/train_deploy_jax


### PR DESCRIPTION
*Description of changes:*
Adds a BYOC example for training models using [JAX](https://github.com/google/jax) and the higher level API [Trax](https://github.com/google/trax)

For both of these training examples, we utilize new functionality to serialize the models as [SavedModel format](https://www.tensorflow.org/guide/saved_model) so they can be easily deployed using TF Serving running on the default SageMaker TF Inference containers.

