### PR TITLE
Implemented proposed changes to fix issue SageMaker Studio # 1890. Us…

### DIFF
--- a/autopilot/model-explainability/explaining_customer_churn_model.ipynb
+++ b/autopilot/model-explainability/explaining_customer_churn_model.ipynb
@@ -90,7 +90,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -m pip install shap"
+    "conda install -c conda-forge shap"
    ]
   },
   {
@@ -432,9 +432,9 @@
  "metadata": {
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (Data Science)",
    "language": "python",
-   "name": "python3"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:eu-central-1:936697816551:image/datascience-1.0"
   },
   "language_info": {
    "codemirror_mode": {
@@ -446,7 +446,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.6"
   },
   "pycharm": {
    "stem_cell": {


### PR DESCRIPTION
…ing conda instead pip to install shap avoids dependency on gcc being installed on the machine.

*Issue #, if available:* #1890

*Description of changes:*
Using conda instead pip to install shap libraries. This avoids dependency of having gcc installed locally to build the native extensions as conda packages come pre-build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
