### PR TITLE
Updated feature_transformation_with_sagemaker_processing.ipynb for SageMaker SDK v2

### DIFF
--- a/sagemaker_processing/feature_transformation_with_sagemaker_processing/feature_transformation_with_sagemaker_processing.ipynb
+++ b/sagemaker_processing/feature_transformation_with_sagemaker_processing/feature_transformation_with_sagemaker_processing.ipynb
@@ -354,9 +354,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
+    "from sagemaker.image_uris import retrieve\n",
     "\n",
-    "training_image = get_image_uri(sagemaker_session.boto_region_name, 'xgboost', repo_version=\"0.90-1\")\n",
+    "training_image = retrieve('xgboost', boto3.Session().region_name, '0.90-1')\n",
     "print(training_image)"
    ]
   },
@@ -375,16 +375,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sagemaker.inputs import TrainingInput\n",
+    "\n",
     "s3_train_data = 's3://{}/{}/{}'.format(bucket, input_preprocessed_prefix, 'train/part')\n",
     "s3_validation_data = 's3://{}/{}/{}'.format(bucket, input_preprocessed_prefix, 'validation/part')\n",
     "s3_output_location = 's3://{}/{}/{}'.format(bucket, prefix, 'xgboost_model')\n",
     "\n",
     "xgb_model = sagemaker.estimator.Estimator(training_image,\n",
     "                                          role, \n",
-    "                                          train_instance_count=1, \n",
-    "                                          train_instance_type='ml.m4.xlarge',\n",
-    "                                          train_volume_size = 20,\n",
-    "                                          train_max_run = 3600,\n",
+    "                                          instance_count=1, \n",
+    "                                          instance_type='ml.m4.xlarge',\n",
+    "                                          volume_size = 20,\n",
+    "                                          max_run = 3600,\n",
     "                                          input_mode= 'File',\n",
     "                                          output_path=s3_output_location,\n",
     "                                          sagemaker_session=sagemaker_session)\n",
@@ -398,9 +400,9 @@
     "                              silent = 0,\n",
     "                              min_child_weight = 6)\n",
     "\n",
-    "train_data = sagemaker.session.s3_input(s3_train_data, distribution='FullyReplicated', \n",
+    "train_data = TrainingInput(s3_train_data, distribution='FullyReplicated', \n",
     "                        content_type='text/csv', s3_data_type='S3Prefix')\n",
-    "validation_data = sagemaker.session.s3_input(s3_validation_data, distribution='FullyReplicated', \n",
+    "validation_data = TrainingInput(s3_validation_data, distribution='FullyReplicated', \n",
     "                             content_type='text/csv', s3_data_type='S3Prefix')\n",
     "\n",
     "data_channels = {'train': train_data, 'validation': validation_data}"
@@ -448,7 +450,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION

Notebook needed updates to be compatible with the v2 of the SageMaker SDK, which is the new Default SDK version in SageMaker.

Issue #, if available:

Description of changes:
Notebook needed updates to be compatible with the v2 of the SageMaker SDK, which is the new Default SDK version in SageMaker.

Fixed:
Use retrieve instead of get_image_uri.
Use instance_count, instance_type, volume_size and max_run instead of train_instance_count, train_instance_type, train_volume_size and train_max_run.
Use TrainingInput instead of s3_input.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
