### PR TITLE
Updated pytorch_mnist_elastic_inference.ipynb for SageMaker SDK v2

### DIFF
--- a/sagemaker-python-sdk/pytorch_mnist/pytorch_mnist_elastic_inference.ipynb
+++ b/sagemaker-python-sdk/pytorch_mnist/pytorch_mnist_elastic_inference.ipynb
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,8 +172,8 @@
     "                    role=role,\n",
     "                    framework_version='1.4.0',\n",
     "                    py_version='py3',\n",
-    "                    train_instance_count=2,\n",
-    "                    train_instance_type='ml.c4.xlarge',\n",
+    "                    instance_count=2,\n",
+    "                    instance_type='ml.c4.xlarge',\n",
     "                    hyperparameters={\n",
     "                        'epochs': 6,\n",
     "                        'backend': 'gloo'\n",


### PR DESCRIPTION
Notebook needed updates to be compatible with the v2 of the SageMaker SDK, which is the new Default SDK version in SageMaker.

Issue #, if available:

Description of changes:
Notebook needed updates to be compatible with the v2 of the SageMaker SDK, which is the new Default SDK version in SageMaker.

Fixed:
Use instance_count, instance_type instead of train_instance_count and train_instance_type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
