### PR TITLE
update Step Functions notebooks to include AmazonSageMaker in role names

### DIFF
--- a/step-functions-data-science-sdk/automate_model_retraining_workflow/automate_model_retraining_workflow.ipynb
+++ b/step-functions-data-science-sdk/automate_model_retraining_workflow/automate_model_retraining_workflow.ipynb
@@ -133,7 +133,7 @@
     "2. Select **Roles** and then **Create role**.\n",
     "3. Under **Choose the service that will use this role** select **Step Functions**.\n",
     "4. Choose **Next** until you can enter a **Role name**.\n",
-    "5. Enter a name such as `StepFunctionsWorkflowExecutionRole` and then select **Create role**.\n",
+    "5. Enter a name such as `AmazonSageMaker-StepFunctionsWorkflowExecutionRole` and then select **Create role**.\n",
     "\n",
     "Next, create and attach a policy to the role you created. As a best practice, the following steps will attach a policy that only provides access to the specific resources and actions needed for this solution.\n",
     "\n",
@@ -206,13 +206,13 @@
     "```\n",
     "\n",
     "3. Replace **NOTEBOOK_ROLE_ARN** with the ARN for your notebook that you created in the previous step.\n",
-    "4. Choose **Review policy** and give the policy a name such as `StepFunctionsWorkflowExecutionPolicy`.\n",
+    "4. Choose **Review policy** and give the policy a name such as `AmazonSageMaker-StepFunctionsWorkflowExecutionPolicy`.\n",
     "5. Choose **Create policy**.\n",
-    "6. Select **Roles** and search for your `StepFunctionsWorkflowExecutionRole` role.\n",
+    "6. Select **Roles** and search for your `AmazonSageMaker-StepFunctionsWorkflowExecutionRole` role.\n",
     "7. Under the **Permissions** tab, click **Attach policies**.\n",
-    "8. Search for your newly created `StepFunctionsWorkflowExecutionPolicy` policy and select the check box next to it.\n",
+    "8. Search for your newly created `AmazonSageMaker-StepFunctionsWorkflowExecutionPolicy` policy and select the check box next to it.\n",
     "9. Choose **Attach policy**. You will then be redirected to the details page for the role.\n",
-    "10. Copy the StepFunctionsWorkflowExecutionRole **Role ARN** at the top of the Summary."
+    "10. Copy the AmazonSageMaker-StepFunctionsWorkflowExecutionRole **Role ARN** at the top of the Summary."
    ]
   },
   {
@@ -228,7 +228,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# paste the StepFunctionsWorkflowExecutionRole ARN from above\n",
+    "# paste the AmazonSageMaker-StepFunctionsWorkflowExecutionRole ARN from above\n",
     "workflow_execution_role = ''\n",
     "\n",
     "# SageMaker Execution Role\n",

--- a/step-functions-data-science-sdk/hello_world_workflow/hello_world_workflow.ipynb
+++ b/step-functions-data-science-sdk/hello_world_workflow/hello_world_workflow.ipynb
@@ -70,7 +70,7 @@
     "2. Select **Roles** and then **Create role**.\n",
     "3. Under **Choose the service that will use this role** select **Step Functions**\n",
     "4. Choose **Next** until you can enter a **Role name**\n",
-    "5. Enter a name such as `StepFunctionsWorkflowExecutionRole` and then select **Create role**\n",
+    "5. Enter a name such as `AmazonSageMaker-StepFunctionsWorkflowExecutionRole` and then select **Create role**\n",
     "\n",
     "\n",
     "Attach a policy to the role you created. The following steps attach a policy that provides full access to Step Functions, however as a good practice you should only provide access to the resources you need.  \n",
@@ -173,7 +173,7 @@
     "\n",
     "stepfunctions.set_stream_logger(level=logging.INFO)\n",
     "\n",
-    "workflow_execution_role = \"<execution-role-arn>\" # paste the StepFunctionsWorkflowExecutionRole ARN from above"
+    "workflow_execution_role = \"<execution-role-arn>\" # paste the AmazonSageMaker-StepFunctionsWorkflowExecutionRole ARN from above"
    ]
   },
   {

--- a/step-functions-data-science-sdk/machine_learning_workflow_abalone/machine_learning_workflow_abalone.ipynb
+++ b/step-functions-data-science-sdk/machine_learning_workflow_abalone/machine_learning_workflow_abalone.ipynb
@@ -63,7 +63,7 @@
     "2. Select **Roles** and then **Create role**.\n",
     "3. Under **Choose the service that will use this role** select **Step Functions**\n",
     "4. Choose **Next** until you can enter a **Role name**\n",
-    "5. Enter a name such as `StepFunctionsWorkflowExecutionRole` and then select **Create role**\n",
+    "5. Enter a name such as `AmazonSageMaker-StepFunctionsWorkflowExecutionRole` and then select **Create role**\n",
     "\n",
     "\n",
     "Attach a policy to the role you created. The following steps attach a policy that provides full access to Step Functions, however as a good practice you should only provide access to the resources you need.  \n",
@@ -145,7 +145,7 @@
     "}\n",
     "```\n",
     "\n",
-    "3. Choose **Review policy** and give the policy a name such as `StepFunctionsWorkflowExecutionPolicy`\n",
+    "3. Choose **Review policy** and give the policy a name such as `AmazonSageMaker-StepFunctionsWorkflowExecutionPolicy`\n",
     "4. Choose **Create policy**. You will be redirected to the details page for the role.\n",
     "5. Copy the **Role ARN** at the top of the **Summary**"
    ]
@@ -169,7 +169,7 @@
     "# You can use sagemaker.get_execution_role() if running inside sagemaker's notebook instance\n",
     "sagemaker_execution_role = sagemaker.get_execution_role() #Replace with ARN if not in an AWS SageMaker notebook\n",
     "\n",
-    "# paste the StepFunctionsWorkflowExecutionRole ARN from above\n",
+    "# paste the AmazonSageMaker-StepFunctionsWorkflowExecutionRole ARN from above\n",
     "workflow_execution_role = \"<execution-role-arn>\" "
    ]
   },

--- a/step-functions-data-science-sdk/step_functions_mlworkflow_processing/step_functions_mlworkflow_scikit_learn_data_processing_and_model_evaluation.ipynb
+++ b/step-functions-data-science-sdk/step_functions_mlworkflow_processing/step_functions_mlworkflow_scikit_learn_data_processing_and_model_evaluation.ipynb
@@ -134,13 +134,13 @@
     "2. Select **Roles** and then **Create role**.\n",
     "3. Under **Choose the service that will use this role** select **Step Functions**.\n",
     "4. Choose **Next** until you can enter a **Role name**.\n",
-    "5. Enter a name such as `StepFunctionsWorkflowExecutionRole` and then select **Create role**.\n",
+    "5. Enter a name such as `AmazonSageMaker-StepFunctionsWorkflowExecutionRole` and then select **Create role**.\n",
     "\n",
     "Next, attach a AWS Managed IAM policy to the role you created as per below steps.\n",
     "\n",
     "1. Go to the [IAM console](https://console.aws.amazon.com/iam/).\n",
     "2. Select **Roles**\n",
-    "3. Search for `StepFunctionsWorkflowExecutionRole` IAM Role\n",
+    "3. Search for `AmazonSageMaker-StepFunctionsWorkflowExecutionRole` IAM Role\n",
     "4. Under the **Permissions** tab, click **Attach policies** and then search for `CloudWatchEventsFullAccess` IAM Policy managed by AWS.\n",
     "5. Click on `Attach Policy`\n",
     "\n",
@@ -230,13 +230,13 @@
     "```\n",
     "\n",
     "3. Replace **NOTEBOOK_ROLE_ARN** with the ARN for your notebook that you created in the previous step in the above Policy.\n",
-    "4. Choose **Review policy** and give the policy a name such as `StepFunctionsWorkflowExecutionPolicy`.\n",
+    "4. Choose **Review policy** and give the policy a name such as `AmazonSageMaker-StepFunctionsWorkflowExecutionPolicy`.\n",
     "5. Choose **Create policy**.\n",
-    "6. Select **Roles** and search for your `StepFunctionsWorkflowExecutionRole` role.\n",
+    "6. Select **Roles** and search for your `AmazonSageMaker-StepFunctionsWorkflowExecutionRole` role.\n",
     "7. Under the **Permissions** tab, click **Attach policies**.\n",
-    "8. Search for your newly created `StepFunctionsWorkflowExecutionPolicy` policy and select the check box next to it.\n",
+    "8. Search for your newly created `AmazonSageMaker-StepFunctionsWorkflowExecutionPolicy` policy and select the check box next to it.\n",
     "9. Choose **Attach policy**. You will then be redirected to the details page for the role.\n",
-    "10. Copy the StepFunctionsWorkflowExecutionRole **Role ARN** at the top of the Summary."
+    "10. Copy the AmazonSageMaker-StepFunctionsWorkflowExecutionRole **Role ARN** at the top of the Summary."
    ]
   },
   {
@@ -245,7 +245,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# paste the StepFunctionsWorkflowExecutionRole ARN from above\n",
+    "# paste the AmazonSageMaker-StepFunctionsWorkflowExecutionRole ARN from above\n",
     "workflow_execution_role = \"\" "
    ]
   },

--- a/step-functions-data-science-sdk/training_pipeline_pytorch_mnist/training_pipeline_pytorch_mnist.ipynb
+++ b/step-functions-data-science-sdk/training_pipeline_pytorch_mnist/training_pipeline_pytorch_mnist.ipynb
@@ -69,7 +69,7 @@
     "2. Select **Roles** and then **Create role**.\n",
     "3. Under **Choose the service that will use this role** select **Step Functions**\n",
     "4. Choose **Next** until you can enter a **Role name**\n",
-    "5. Enter a name such as `StepFunctionsWorkflowExecutionRole` and then select **Create role**\n",
+    "5. Enter a name such as `AmazonSageMaker-StepFunctionsWorkflowExecutionRole` and then select **Create role**\n",
     "\n",
     "\n",
     "Attach a policy to the role you created. The following steps attach a policy that provides full access to Step Functions, however as a good practice you should only provide access to the resources you need.  \n",
@@ -151,7 +151,7 @@
     "}\n",
     "```\n",
     "\n",
-    "3. Choose **Review policy** and give the policy a name such as `StepFunctionsWorkflowExecutionPolicy`\n",
+    "3. Choose **Review policy** and give the policy a name such as `AmazonSageMaker-StepFunctionsWorkflowExecutionPolicy`\n",
     "4. Choose **Create policy**. You will be redirected to the details page for the role.\n",
     "5. Copy the **Role ARN** at the top of the **Summary**"
    ]
@@ -187,7 +187,7 @@
     "# You can use sagemaker.get_execution_role() if running inside sagemaker's notebook instance\n",
     "sagemaker_execution_role = sagemaker.get_execution_role() #Replace with ARN if not in an AWS SageMaker notebook\n",
     "\n",
-    "# paste the StepFunctionsWorkflowExecutionRole ARN from above\n",
+    "# paste the AmazonSageMaker-StepFunctionsWorkflowExecutionRole ARN from above\n",
     "workflow_execution_role = \"<execution-role-arn>\" "
    ]
   },


### PR DESCRIPTION
Updating the instructions so that the role which will be executing Step Functions workflows so that they include `AmazonSageMaker` in their name. This role is passed to SageMaker when a workflow is executed in these examples.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
