### PR TITLE
Use conda to install shap

### DIFF
--- a/autopilot/model-explainability/explaining_customer_churn_model.ipynb
+++ b/autopilot/model-explainability/explaining_customer_churn_model.ipynb
@@ -124,7 +124,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "automl_job_name = '<your_automl_job_name_here>'\n",
+    "automl_job_name = 'demo_autopilot_customerchurn_job'\n",
     "automl_job = AutoML.attach(automl_job_name, sagemaker_session=session)\n",
     "\n",
     "# Endpoint name\n",

--- a/autopilot/model-explainability/explaining_customer_churn_model.ipynb
+++ b/autopilot/model-explainability/explaining_customer_churn_model.ipynb
@@ -124,7 +124,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "automl_job_name = 'demo_autopilot_customerchurn_job'\n",
+    "automl_job_name = 'demo-autopilot-customerchurn-job'\n",
     "automl_job = AutoML.attach(automl_job_name, sagemaker_session=session)\n",
     "\n",
     "# Endpoint name\n",

--- a/autopilot/model-explainability/explaining_customer_churn_model.ipynb
+++ b/autopilot/model-explainability/explaining_customer_churn_model.ipynb
@@ -90,7 +90,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -m pip install shap"
+    "%conda install -c conda-forge shap"
    ]
   },
   {

--- a/autopilot/model-explainability/explaining_customer_churn_model.ipynb
+++ b/autopilot/model-explainability/explaining_customer_churn_model.ipynb
@@ -124,7 +124,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "automl_job_name = 'demo-autopilot-customerchurn-job'\n",
+    "automl_job_name = 'your-autopilot-job-that-exists'\n",
     "automl_job = AutoML.attach(automl_job_name, sagemaker_session=session)\n",
     "\n",
     "# Endpoint name\n",


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/aws/amazon-sagemaker-examples/issues/1890

*Description of changes:*
Installs conda without gcc available outside of conda.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
