### PR TITLE
Removed soon-to-be deprecated link on Neuron Github Repo

### DIFF
--- a/sagemaker_neo_compilation_jobs/deploy_pytorch_model_on_Inf1_instance/pytorch_torchvision_neo_on_Inf1.ipynb
+++ b/sagemaker_neo_compilation_jobs/deploy_pytorch_model_on_Inf1_instance/pytorch_torchvision_neo_on_Inf1.ipynb
@@ -328,7 +328,7 @@
    "source": [
     "In order to host model compiled for 2 cores, we set environment variables NEURONCORE_GROUP_SIZES and SAGEMAKER_MODEL_SERVER_WORKERS.\n",
     "### More Information on Environment Variables for Hosting\n",
-    "NEURONCORE_GROUP_SIZES - If the model is compiled for n inferentia cores , set NEURONCORE_GROUP_SIZES=n . For more information on NEURONCORE_GROUP_SIZES, refer to https://github.com/aws/aws-neuron-sdk/blob/master/docs/tensorflow-neuron/tutorial-NeuronCore-Group.md\n",
+    "NEURONCORE_GROUP_SIZES - If the model is compiled for n inferentia cores , set NEURONCORE_GROUP_SIZES=n . For more information on NEURONCORE_GROUP_SIZES, refer to https://awsdocs-neuron.readthedocs-hosted.com/en/latest/neuron-guide/neuron-frameworks/tensorflow-neuron/tutorials/tutorial-tensorflow-NeuronCore-Group.html\n",
     "\n",
     "SAGEMAKER_MODEL_SERVER_WORKERS - Number of workers required to utilize all inferentia cores. For example, on inf1.2xlarge or inf1.xlarge, if the model is compiled for one core,\n",
     "we need 4 workers to utilize all inferentia cores which will load the compiled model in different processes. If the model is compiled for 2 cores, we only need 2 workers to utilize \n",


### PR DESCRIPTION
*Issue #, if available:*
Neuron documentation from Github was removed, they were migrated to ReadTheDocs.  

*Description of changes:*
Updated a link in sagemaker_neo_compilation_jobs/deploy_pytorch_model_on_Inf1_instance/pytorch_torchvision_neo_on_Inf1.ipynb to point to ReadTheDocs page:https://awsdocs-neuron.readthedocs-hosted.com/en/latest/neuron-guide/neuron-frameworks/tensorflow-neuron/tutorials/tutorial-tensorflow-NeuronCore-Group.html .


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
