### PR TITLE
documentation: adding a note about using liquid elements template

### DIFF
--- a/ground_truth_labeling_jobs/ground_truth_streaming_labeling_jobs/ground_truth_create_chained_streaming_labeling_job.ipynb
+++ b/ground_truth_labeling_jobs/ground_truth_streaming_labeling_jobs/ground_truth_create_chained_streaming_labeling_job.ipynb
@@ -531,6 +531,13 @@
    ]
   },
   {
+   "source": [
+    "**Important**: If you use the following `make_template` function to create and upload a worker task template to Amazon S3, you must add an extra pair of `{}` brackets around each Liquid element. For example, if the template contains `{{ task.input.labels | to_json | escape }}`, this line should look as follows in the `make_template` variable `template`: `{{{{ task.input.labels | to_json | escape }}}}`. "
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -1264,6 +1271,13 @@
     "\n",
     "Ground Trust uses this template to generate your human task UI. "
    ]
+  },
+  {
+   "source": [
+    "**Important**: If you use your own template with the following `make_template` function to create and upload a worker task template to Amazon S3, you must add an extra pair of `{}` brackets around each Liquid element. For example, if the template contains `{{ task.input.labels | to_json | escape }}`, this line should look as follows in the `make_template` variable `template`: `{{{{ task.input.labels | to_json | escape }}}}`. The following semantic segmentation template already includes an extra pair of `{}` brackets around each Liquid element."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",

--- a/ground_truth_labeling_jobs/ground_truth_streaming_labeling_jobs/ground_truth_create_streaming_labeling_job.ipynb
+++ b/ground_truth_labeling_jobs/ground_truth_streaming_labeling_jobs/ground_truth_create_streaming_labeling_job.ipynb
@@ -519,6 +519,13 @@
    ]
   },
   {
+   "source": [
+    "**Important**: If you use the following `make_template` function to create and upload a worker task template to Amazon S3, you must add an extra pair of `{}` brackets around each Liquid element. For example, if the template contains `{{ task.input.labels | to_json | escape }}`, this line should look as follows in the `make_template` variable `template`: `{{{{ task.input.labels | to_json | escape }}}}`. "
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},


### PR DESCRIPTION
*Issue #, if available:*
#1958 

*Description of changes:*
Adding note to tell users to add extra pair of `{}` around liquid elements if uploading one's own template. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
