### PR TITLE
New SageMaker Clarify notebook to showcase supports for JSONLines format

### DIFF
--- a/sagemaker_processing/fairness_and_explainability/fairness_and_explainability_jsonlines_format.ipynb
+++ b/sagemaker_processing/fairness_and_explainability/fairness_and_explainability_jsonlines_format.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Fairness and Explainability with SageMaker Clarify"
+    "# Fairness and Explainability with SageMaker Clarify (JSONLines Format)"
    ]
   },
   {
@@ -18,7 +18,7 @@
     "    1. [Loading the data: Adult Dataset](#Loading-the-data:-Adult-Dataset) \n",
     "    1. [Data inspection](#Data-inspection) \n",
     "    1. [Data encoding and upload to S3](#Encode-and-Upload-the-Data) \n",
-    "1. [Train and Deploy XGBoost Model](#Train-XGBoost-Model)\n",
+    "1. [Train and Deploy Linear Learner Model](#Train-Linear-Learner-Model)\n",
     "    1. [Train Model](#Train-Model)\n",
     "    1. [Deploy Model to Endpoint](#Deploy-Model)\n",
     "1. [Amazon SageMaker Clarify](#Amazon-SageMaker-Clarify)\n",
@@ -44,7 +44,7 @@
     "1. Explaining the importance of the various input features on the model's decision\n",
     "1. Accessing the reports through SageMaker Studio if you have an instance set up.\n",
     "\n",
-    "In doing so, the notebook will first train a [SageMaker XGBoost](https://docs.aws.amazon.com/sagemaker/latest/dg/xgboost.html) model using training dataset, then use SageMaker Clarify to analyze a testing dataset in CSV format. SageMaker Clarify also supports analyzing dataset in [SageMaker JSONLines dense format](https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-inference.html#common-in-formats), which is illustrated in [another notebook](https://github.com/aws/amazon-sagemaker-examples/blob/master/sagemaker_processing/fairness_and_explainability/fairness_and_explainability_jsonlines_format.ipynb)."
+    "In doing so, the notebook will first train a [SageMaker Linear Learner](https://docs.aws.amazon.com/sagemaker/latest/dg/linear-learner.html) model using training dataset, then use SageMaker Clarify to analyze a testing dataset in [SageMaker JSONLines dense format](https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-inference.html#common-in-formats). SageMaker Clarify also supports analyzing CSV dataset, which is illustrated in [another notebook](https://github.com/aws/amazon-sagemaker-examples/blob/master/sagemaker_processing/fairness_and_explainability/fairness_and_explainability.ipynb)."
    ]
   },
   {
@@ -64,7 +64,7 @@
     "from sagemaker import Session\n",
     "session = Session()\n",
     "bucket = session.default_bucket()\n",
-    "prefix = 'sagemaker/DEMO-sagemaker-clarify'\n",
+    "prefix = 'sagemaker/DEMO-sagemaker-clarify-jsonlines'\n",
     "region = session.boto_region_name\n",
     "# Define IAM role\n",
     "from sagemaker import get_execution_role\n",
@@ -220,14 +220,33 @@
     "            result[column] = encoders[column].fit_transform(result[column].fillna('None'))\n",
     "    return result, encoders\n",
     "\n",
-    "training_data = pd.concat([training_data['Target'], training_data.drop(['Target'], axis=1)], axis=1)\n",
     "training_data, _ = number_encode_features(training_data)\n",
-    "training_data.to_csv('train_data.csv', index=False, header=False)\n",
-    "\n",
-    "testing_data, _ = number_encode_features(testing_data)\n",
-    "test_features = testing_data.drop(['Target'], axis = 1)\n",
-    "test_target = testing_data['Target']\n",
-    "test_features.to_csv('test_features.csv', index=False, header=False)"
+    "testing_data, _ = number_encode_features(testing_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then save the testing dataset to a JSONLines file. The file conforms to [SageMaker JSONLines dense format](https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-inference.html#common-in-formats), with an additional field to hold the ground truth label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "def dump_to_jsonlines_file(df, filename):\n",
+    "    with open(filename, 'w') as f:\n",
+    "        for _, row in df.iterrows():\n",
+    "            sample = {\n",
+    "                'features': row[0:-1].tolist(),\n",
+    "                'label': int(row[-1])\n",
+    "            }\n",
+    "            print(json.dumps(sample), file=f)\n",
+    "dump_to_jsonlines_file(testing_data, 'test_data.jsonl')"
    ]
   },
   {
@@ -243,7 +262,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "training_data.head()"
+    "!head -n 5 test_data.jsonl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "testing_data.head()"
    ]
   },
   {
@@ -260,20 +288,17 @@
    "outputs": [],
    "source": [
     "from sagemaker.s3 import S3Uploader\n",
-    "from sagemaker.inputs import TrainingInput\n",
     "\n",
-    "train_uri = S3Uploader.upload('train_data.csv', 's3://{}/{}'.format(bucket, prefix))\n",
-    "train_input = TrainingInput(train_uri, content_type='csv')\n",
-    "test_uri = S3Uploader.upload('test_features.csv', 's3://{}/{}'.format(bucket, prefix))"
+    "test_data_uri = S3Uploader.upload('test_data.jsonl', 's3://{}/{}'.format(bucket, prefix))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Train XGBoost Model\n",
+    "### Train Linear Learner Model\n",
     "#### Train Model\n",
-    "Since our focus is on understanding how to use SageMaker Clarify, we keep it simple by using a standard XGBoost model."
+    "Since our focus is on understanding how to use SageMaker Clarify, we keep it simple by using a standard Linear Learner model."
    ]
   },
   {
@@ -283,25 +308,16 @@
    "outputs": [],
    "source": [
     "from sagemaker.image_uris import retrieve\n",
-    "from sagemaker.estimator import Estimator\n",
+    "from sagemaker.amazon.linear_learner import LinearLearner\n",
     "\n",
-    "container = retrieve('xgboost', region, version='1.2-1')\n",
-    "xgb = Estimator(container,\n",
-    "                role,\n",
-    "                instance_count=1,\n",
-    "                instance_type='ml.m5.xlarge',\n",
-    "                disable_profiler=True,\n",
-    "                sagemaker_session=session)\n",
-    "\n",
-    "xgb.set_hyperparameters(max_depth=5,\n",
-    "                        eta=0.2,\n",
-    "                        gamma=4,\n",
-    "                        min_child_weight=6,\n",
-    "                        subsample=0.8,\n",
-    "                        objective='binary:logistic',\n",
-    "                        num_round=800)\n",
-    "\n",
-    "xgb.fit({'train': train_input}, logs=False)"
+    "ll = LinearLearner(role,\n",
+    "                  instance_count=1,\n",
+    "                  instance_type='ml.m5.xlarge',\n",
+    "                  predictor_type='binary_classifier',\n",
+    "                  sagemaker_session=session)\n",
+    "training_target = training_data['Target'].to_numpy().astype(np.float32)\n",
+    "training_features = training_data.drop(['Target'], axis = 1).to_numpy().astype(np.float32)\n",
+    "ll.fit(ll.record_set(training_features, training_target), logs=False)"
    ]
   },
   {
@@ -318,8 +334,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_name = 'DEMO-clarify-model'\n",
-    "model = xgb.create_model(name=model_name)\n",
+    "model_name = 'DEMO-clarify-ll-model'\n",
+    "model = ll.create_model(name=model_name)\n",
     "container_def = model.prepare_container_def()\n",
     "session.create_model(model_name,\n",
     "                     role,\n",
@@ -354,7 +370,16 @@
     "### Detecting Bias\n",
     "SageMaker Clarify helps you detect possible pre- and post-training biases using a variety of metrics.\n",
     "#### Writing DataConfig and ModelConfig\n",
-    "A `DataConfig` object communicates some basic information about data I/O to SageMaker Clarify. We specify where to find the input dataset, where to store the output, the target column (`label`), the header names, and the dataset type."
+    "A `DataConfig` object communicates some basic information about data I/O to SageMaker Clarify. We specify where to find the input dataset, where to store the output, the target column (`label`), the header names, and the dataset type.\n",
+    "\n",
+    "Some special things to note about this configuration for the JSONLines dataset,\n",
+    "* Argument `features` or `label` is **NOT** header string. Instead, it is a [JSONPath string](https://jmespath.org/specification.html) to locate the features list or label in the dataset. For example, for a sample like below, `features` should be 'data.features.values', and `label` should be 'data.label'. \n",
+    "\n",
+    "```\n",
+    "{\"data\": {\"features\": {\"values\": [25, 2, 226802, 1, 7, 4, 6, 3, 2, 1, 0, 0, 40, 37]}, \"label\": 0}}\n",
+    "```\n",
+    "\n",
+    "* SageMaker Clarify will load the JSONLines dataset into tabular representation for further analysis, and argument `headers` is the list of column names. The label header shall be the last one in the headers list, and the order of feature headers shall be the same as the order of features in a sample."
    ]
   },
   {
@@ -364,11 +389,12 @@
    "outputs": [],
    "source": [
     "bias_report_output_path = 's3://{}/{}/clarify-bias'.format(bucket, prefix)\n",
-    "bias_data_config = clarify.DataConfig(s3_data_input_path=train_uri,\n",
+    "bias_data_config = clarify.DataConfig(s3_data_input_path=test_data_uri,\n",
     "                                      s3_output_path=bias_report_output_path,\n",
-    "                                      label='Target',\n",
-    "                                      headers=training_data.columns.to_list(),\n",
-    "                                      dataset_type='text/csv')"
+    "                                      features='features',\n",
+    "                                      label='label',\n",
+    "                                      headers=testing_data.columns.to_list(),\n",
+    "                                      dataset_type='application/jsonlines')"
    ]
   },
   {
@@ -377,7 +403,8 @@
    "source": [
     "A `ModelConfig` object communicates information about your trained model. To avoid additional traffic to your production models, SageMaker Clarify sets up and tears down a dedicated endpoint when processing.\n",
     "* `instance_type` and `instance_count` specify your preferred instance type and instance count used to run your model on during SageMaker Clarify's processing. The testing dataset is small so a single standard instance is good enough to run this example. If your have a large complex dataset, you may want to use a better instance type to speed up, or add more instances to enable Spark parallelization.\n",
-    "* `accept_type` denotes the endpoint response payload format, and `content_type` denotes the payload format of request to the endpoint."
+    "* `accept_type` denotes the endpoint response payload format, and `content_type` denotes the payload format of request to the endpoint.\n",
+    "* `content_template` is used by SageMaker Clarify to compose the request payload if the content type is JSONLines. To be more specific, the placeholder `$features` will be replaced by the features list from samples. The request payload of a sample from the testing dataset happens to be similar to the sample itself, like `'{\"features\": [25, 2, 226802, 1, 7, 4, 6, 3, 2, 1, 0, 0, 40, 37]}'`, because both the dataset and the model input conform to [SageMaker JSONLines dense format](https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-inference.html#common-in-formats)."
    ]
   },
   {
@@ -389,15 +416,16 @@
     "model_config = clarify.ModelConfig(model_name=model_name,\n",
     "                                   instance_type='ml.m5.xlarge',\n",
     "                                   instance_count=1,\n",
-    "                                   accept_type='text/csv',\n",
-    "                                   content_type='text/csv')"
+    "                                   accept_type='application/jsonlines',\n",
+    "                                   content_type='application/jsonlines',\n",
+    "                                   content_template='{\"features\":$features}')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A `ModelPredictedLabelConfig` provides information on the format of your predictions. XGBoost model outputs probabilities of samples, so SageMaker Clarify invokes the endpoint then uses `probability_threshold` to convert the probability to binary labels for bias analysis. Prediction above the threshold is interpreted as label value `1` and below or equal as label value `0`."
+    "A `ModelPredictedLabelConfig` provides information on the format of your predictions. The argument `label` is a JSONPath string to locate the predicted label in endpoint response. In this case, the response payload for a single sample request looks like `'{\"predicted_label\": 0, \"score\": 0.013525663875043}'`, so SageMaker Clarify can find predicted label `0` by JSONPath `'predicted_label'`. There is also probability score in the response, so it is possible to use another combination of arguments to decide the predicted label by a custom threshold, for example `probability='score'` and `probability_threshold=0.8`."
    ]
   },
   {
@@ -406,7 +434,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "predictions_config = clarify.ModelPredictedLabelConfig(probability_threshold=0.8)"
+    "predictions_config = clarify.ModelPredictedLabelConfig(label='predicted_label')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you are building your own model, then you may choose a different JSONLines format, as long as it has the key elements like label and features list, and request payload built using `content_template` is supported by the model (you can customize the template but the placeholder of features list must be `$features`). Also, `dataset_type`, `accept_type` and `content_type` don't have to be the same, for example, a use case may use CSV dataset and content type, but JSONLines accept type."
    ]
   },
   {
@@ -519,17 +554,49 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "shap_config = clarify.SHAPConfig(baseline=[test_features.iloc[0].values.tolist()],\n",
+    "# pick up the first line, load as JSON, then exclude the label (i.e., only keep the features)\n",
+    "with open('test_data.jsonl') as f:\n",
+    "    baseline_sample = json.loads(f.readline())\n",
+    "del baseline_sample['label']\n",
+    "baseline_sample"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Similarly, excluding label header from headers list\n",
+    "headers = testing_data.columns.to_list()\n",
+    "headers.remove('Target')\n",
+    "print(headers)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shap_config = clarify.SHAPConfig(baseline=[baseline_sample],\n",
     "                                 num_samples=15,\n",
     "                                 agg_method='mean_abs',\n",
     "                                 save_local_shap_values=False)\n",
     "\n",
     "explainability_output_path = 's3://{}/{}/clarify-explainability'.format(bucket, prefix)\n",
-    "explainability_data_config = clarify.DataConfig(s3_data_input_path=train_uri,\n",
+    "explainability_data_config = clarify.DataConfig(s3_data_input_path=test_data_uri,\n",
     "                                s3_output_path=explainability_output_path,\n",
-    "                                label='Target',\n",
-    "                                headers=training_data.columns.to_list(),\n",
-    "                                dataset_type='text/csv')"
+    "                                features='features',\n",
+    "                                headers=headers,\n",
+    "                                dataset_type='application/jsonlines')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run the explainability job, note that Kernel SHAP algorithm requires probability prediction, so JSONPath `\"score\"` is used to extract the probability."
    ]
   },
   {
@@ -540,7 +607,8 @@
    "source": [
     "clarify_processor.run_explainability(data_config=explainability_data_config,\n",
     "                                     model_config=model_config,\n",
-    "                                     explainability_config=shap_config)"
+    "                                     explainability_config=shap_config,\n",
+    "                                     model_scores='score')"
    ]
   },
   {

--- a/sagemaker_processing/index.rst
+++ b/sagemaker_processing/index.rst
@@ -9,3 +9,5 @@ Processing
    feature_transformation_with_sagemaker_processing/feature_transformation_with_sagemaker_processing
    scikit_learn_data_processing_and_model_evaluation/scikit_learn_data_processing_and_model_evaluation
    spark_distributed_data_processing/sagemaker-spark-processing
+   fairness_and_explainability/fairness_and_explainability
+   fairness_and_explainability/fairness_and_explainability_jsonlines_format


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

SageMaker Clarify supports CSV format and JSONLines format; its existing example notebook uses CSV format. This commit adds a new notebook which is essentially the same as the old one but use JSONLines format instead. A few updates are applied to the old one as well for cross-reference and to fix minor issues.

Both notebooks are appended to sagemaker_processing/index.rst so that they will show up [in the doc](https://sagemaker-examples.readthedocs.io/en/latest/sagemaker_processing/index.html).

**Testing Done**

* Tested both notebooks by full-run in us-west-2 and us-east-1.
* Built doc locally and checked that the two notebooks show up in the "Processing" page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
