### PR TITLE
Updated tensorflow_script_mode_training_and_serving.ipynb for SageMaker SDK v2

### DIFF
--- a/sagemaker-python-sdk/tensorflow_script_mode_training_and_serving/tensorflow_script_mode_training_and_serving.ipynb
+++ b/sagemaker-python-sdk/tensorflow_script_mode_training_and_serving/tensorflow_script_mode_training_and_serving.ipynb
@@ -112,11 +112,11 @@
     "\n",
     "mnist_estimator = TensorFlow(entry_point='mnist.py',\n",
     "                             role=role,\n",
-    "                             train_instance_count=2,\n",
-    "                             train_instance_type='ml.p3.2xlarge',\n",
+    "                             instance_count=2,\n",
+    "                             instance_type='ml.p3.2xlarge',\n",
     "                             framework_version='1.15.2',\n",
     "                             py_version='py3',\n",
-    "                             distributions={'parameter_server': {'enabled': True}})"
+    "                             distribution={'parameter_server': {'enabled': True}})"
    ]
   },
   {
@@ -136,11 +136,11 @@
    "source": [
     "mnist_estimator2 = TensorFlow(entry_point='mnist-2.py',\n",
     "                             role=role,\n",
-    "                             train_instance_count=2,\n",
-    "                             train_instance_type='ml.p3.2xlarge',\n",
+    "                             instance_count=2,\n",
+    "                             instance_type='ml.p3.2xlarge',\n",
     "                             framework_version='2.1.0',\n",
     "                             py_version='py3',\n",
-    "                             distributions={'parameter_server': {'enabled': True}})"
+    "                             distribution={'parameter_server': {'enabled': True}})"
    ]
   },
   {
@@ -175,7 +175,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Calling fit to train a model with TensorFlow 2.1 scroipt."
+    "Calling fit to train a model with TensorFlow 2.1 script."
    ]
   },
   {
@@ -308,7 +308,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sagemaker.Session().delete_endpoint(predictor.endpoint)"
+    "predictor.delete_endpoint()"
    ]
   },
   {
@@ -324,8 +324,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sagemaker.Session().delete_endpoint(predictor2.endpoint)"
+    "predictor2.delete_endpoint()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -344,7 +351,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.10"
   },
   "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },


### PR DESCRIPTION
Notebook needed updates to be compatible with the v2 of the SageMaker SDK, which is the new Default SDK version in SageMaker.

Issue #, if available:

Description of changes:
Notebook needed updates to be compatible with the v2 of the SageMaker SDK, which is the new Default SDK version in SageMaker.

Fixed:

Use instance_count, instance_type, and distribution instead of train_instance_count, train_instance_type, and distributions.
Fixed sagemaker.Session().delete_endpoint(predictor.endpoint) to predictor.delete_endpoint().
Fixed typos.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
