### PR TITLE
Update generate_cifar10_tfrecords.py to fix errros in low_batch_size and callback_bottleneck notebooks

### DIFF
--- a/sagemaker-debugger/tensorflow_profiling/demo/generate_cifar10_tfrecords.py
+++ b/sagemaker-debugger/tensorflow_profiling/demo/generate_cifar10_tfrecords.py
@@ -78,7 +78,7 @@ def convert_to_tfrecord(input_files, output_file):
 def install_dependencies():
     from subprocess import call
     call(["pip", "install", "--upgrade", "pip"])
-    call(["pip", "install", "tensorflow_datasets"])
+    call(["pip", "install", "tensorflow_datasets==4.1.0"])
     
 def main(data_dir):
     print('Download from {} and extract.'.format(CIFAR_DOWNLOAD_URL))


### PR DESCRIPTION
*Issue #, if available:*
 
In `callback_bottleneck.ipynb` and `low_batch_size.ipynb` notebooks, executing the following line:

`!python demo/generate_cifar10_tfrecords.py --data-dir=./data`

Resulted in exception:
```
Traceback (most recent call last):
  File "demo/generate_cifar10_tfrecords.py", line 117, in <module>
    main(args.data_dir)
  File "demo/generate_cifar10_tfrecords.py", line 86, in main
    extract_dir = download_and_extract(data_dir)
  File "demo/generate_cifar10_tfrecords.py", line 33, in download_and_extract
    extract_dir =  dm.download_and_extract(CIFAR_DOWNLOAD_URL)
  File "/home/ec2-user/anaconda3/envs/tensorflow2_p36/lib/python3.6/site-packages/tensorflow_datasets/core/download/download_manager.py", line 637, in download_and_extract
    return _map_promise(self._download_extract, url_or_urls)
  File "/home/ec2-user/anaconda3/envs/tensorflow2_p36/lib/python3.6/site-packages/tensorflow_datasets/core/download/download_manager.py", line 777, in _map_promise

    res = tf.nest.map_structure(lambda p: p.get(), all_promises)  # Wait promises
  File "/home/ec2-user/anaconda3/envs/tensorflow2_p36/lib/python3.6/site-packages/tensorflow_core/python/util/nest.py", line 568, in map_structure
    structure[0], [func(*x) for x in entries],
  File "/home/ec2-user/anaconda3/envs/tensorflow2_p36/lib/python3.6/site-packages/tensorflow_core/python/util/nest.py", line 568, in <listcomp>
    structure[0], [func(*x) for x in entries],
  File "/home/ec2-user/anaconda3/envs/tensorflow2_p36/lib/python3.6/site-packages/tensorflow_datasets/core/download/download_manager.py", line 777, in <lambda>
    res = tf.nest.map_structure(lambda p: p.get(), all_promises)  # Wait promises
  File "/home/ec2-user/anaconda3/envs/tensorflow2_p36/lib/python3.6/site-packages/promise/promise.py", line 512, in get
    return self._target_settled_value(_raise=True)
  File "/home/ec2-user/anaconda3/envs/tensorflow2_p36/lib/python3.6/site-packages/promise/promise.py", line 516, in _target_settled_value
    return self._target()._settled_value(_raise)
  File "/home/ec2-user/anaconda3/envs/tensorflow2_p36/lib/python3.6/site-packages/promise/promise.py", line 226, in _settled_value
    reraise(type(raise_val), raise_val, self._traceback)
  File "/home/ec2-user/anaconda3/envs/tensorflow2_p36/lib/python3.6/site-packages/six.py", line 703, in reraise
    raise value
  File "/home/ec2-user/anaconda3/envs/tensorflow2_p36/lib/python3.6/site-packages/promise/promise.py", line 87, in try_catch
    return (handler(*args, **kwargs), None)
  File "/home/ec2-user/anaconda3/envs/tensorflow2_p36/lib/python3.6/site-packages/tensorflow_datasets/core/download/download_manager.py", line 366, in <lambda>
    url_path=url_path,
  File "/home/ec2-user/anaconda3/envs/tensorflow2_p36/lib/python3.6/site-packages/tensorflow_datasets/core/download/download_manager.py", line 430, in _register_or_validate_checksums
    url_path=url_path,
  File "/home/ec2-user/anaconda3/envs/tensorflow2_p36/lib/python3.6/site-packages/tensorflow_datasets/core/download/download_manager.py", line 448, in _rename_and_get_final_dl_path
    if path.is_relative_to(self._manual_dir):  # Manually downloaded data
  File "/home/ec2-user/anaconda3/envs/tensorflow2_p36/lib/python3.6/site-packages/tensorflow_datasets/core/utils/type_utils.py", line 103, in is_relative_to
    self.relative_to(*other)
  File "/home/ec2-user/anaconda3/envs/tensorflow2_p36/lib/python3.6/pathlib.py", line 864, in relative_to
    to_drv, to_root, to_parts = self._parse_args(other)
  File "/home/ec2-user/anaconda3/envs/tensorflow2_p36/lib/python3.6/pathlib.py", line 640, in _parse_args
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

This is happening since version 4.2.0 (Jan 7, 2021) of `tensorflow_datasets` that broke this functionality.

*Description of changes:*
Setting `tensorflow_datasets` version to 4.1.0 (Nov 4, 2020) during `pip install` in `generate_cifar10_tfrecords.py` fixed the issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
