### PR TITLE
fix miniconda download link

### DIFF
--- a/advanced_functionality/fairseq_translation/Dockerfile
+++ b/advanced_functionality/fairseq_translation/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
      rm -rf /var/lib/apt/lists/*
 
 
-RUN curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
+RUN curl -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \


### PR DESCRIPTION

*Description of changes: Miniconda download link in the Dockerfile was broken as continuum.io was changed to anaconda.com. This PR fixes that.*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
