### PR TITLE
Update Neo XGBoost notebook

### DIFF
--- a/sagemaker_neo_compilation_jobs/xgboost_customer_churn/xgboost_customer_churn_neo.ipynb
+++ b/sagemaker_neo_compilation_jobs/xgboost_customer_churn/xgboost_customer_churn_neo.ipynb
@@ -342,7 +342,7 @@
    "outputs": [],
    "source": [
     "from sagemaker import image_uris\n",
-    "container = image_uris.retrieve(framework='xgboost', region=boto3.Session().region_name, version='1')"
+    "container = image_uris.retrieve(framework='xgboost', region=boto3.Session().region_name, version='1.0-1')"
    ]
   },
   {
@@ -629,7 +629,7 @@
     "                                   input_shape={'data':[1, 69]},\n",
     "                                   role=role,\n",
     "                                   framework='xgboost',\n",
-    "                                   framework_version='0.9',\n",
+    "                                   framework_version='latest',\n",
     "                                   output_path=output_path)"
    ]
   },
@@ -743,7 +743,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.10"
   },
   "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Current XGBoost notebook will fail, because Neo recently upgrade XGBoost version from 0.9 to 1.2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
