### PR TITLE
Updated mxnet_mnist_elastic_inference_local.ipynb and mxnet_mnist_elastic_inference.ipynb for SageMaker SDK v2

### DIFF
--- a/sagemaker-python-sdk/mxnet_mnist/mxnet_mnist_elastic_inference.ipynb
+++ b/sagemaker-python-sdk/mxnet_mnist/mxnet_mnist_elastic_inference.ipynb
@@ -41,7 +41,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "isConfigCell": true
    },
    "outputs": [],
@@ -82,7 +81,7 @@
    "source": [
     "The SageMaker ```MXNet``` estimator allows us to run single-machine or distributed training in SageMaker, using CPU or GPU-based instances.\n",
     "\n",
-    "When we create the estimator, we pass in the filename of our training script, the name of our IAM execution role, and the S3 locations we defined in the setup section. We also provide a few other parameters. `train_instance_count` and `train_instance_type` determine the number and type of SageMaker instances that are used for the training job. The `hyperparameters` parameter is a `dict` of values that are passed to your training script. You can see how to access these values in the ``mnist.py`` script above.\n",
+    "When we create the estimator, we pass in the filename of our training script, the name of our IAM execution role, and the S3 locations we defined in the setup section. We also provide a few other parameters. `instance_count` and `instance_type` determine the number and type of SageMaker instances that are used for the training job. The `hyperparameters` parameter is a `dict` of values that are passed to your training script. You can see how to access these values in the ``mnist.py`` script above.\n",
     "\n",
     "For this example, we use one ``ml.m4.xlarge`` instance for our training job."
    ]
@@ -90,17 +89,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sagemaker.mxnet import MXNet\n",
     "\n",
     "mnist_estimator = MXNet(entry_point='mnist.py',\n",
     "                        role=role,\n",
-    "                        train_instance_count=1,\n",
-    "                        train_instance_type='ml.m4.xlarge',\n",
+    "                        instance_count=1,\n",
+    "                        instance_type='ml.m4.xlarge',\n",
     "                        framework_version='1.4.1',\n",
     "                        py_version='py3',\n",
     "                        hyperparameters={'learning-rate': 0.1})"
@@ -246,9 +243,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(\"Endpoint name: \" + predictor.endpoint)"
@@ -257,9 +252,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import sagemaker\n",
@@ -284,7 +277,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.10"
   },
   "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },

--- a/sagemaker-python-sdk/mxnet_mnist/mxnet_mnist_elastic_inference_local.ipynb
+++ b/sagemaker-python-sdk/mxnet_mnist/mxnet_mnist_elastic_inference_local.ipynb
@@ -41,7 +41,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "isConfigCell": true
    },
    "outputs": [],
@@ -55,7 +54,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook shows how to use the SageMaker Python SDK to run your code in a local container before deploying to SageMaker's managed training or hosting environments. Just change your estimator's train_instance_type to local or local_gpu. For more information, see [local mode](https://github.com/aws/sagemaker-python-sdk#local-mode).\n",
+    "This notebook shows how to use the SageMaker Python SDK to run your code in a local container before deploying to SageMaker's managed training or hosting environments. Just change your estimator's instance_type to local or local_gpu. For more information, see [local mode](https://github.com/aws/sagemaker-python-sdk#local-mode).\n",
     "\n",
     "To use Amazon Elastic Inference locally change your `accelerator_type` to `local_sagemaker_notebook` when calling `deploy()`.\n",
     "\n",
@@ -106,25 +105,23 @@
    "source": [
     "The SageMaker ```MXNet``` estimator allows us to run single machine or distributed training in SageMaker, using CPU or GPU-based instances.\n",
     "\n",
-    "When we create the estimator, we pass in the filename of our training script, the name of our IAM execution role, and the S3 locations we defined in the setup section. We also provide a few other parameters. ``train_instance_count`` and ``train_instance_type`` determine the number and type of SageMaker instances that will be used for the training job. The ``hyperparameters`` parameter is a ``dict`` of values that will be passed to your training script -- you can see how to access these values in the ``mnist.py`` script above.\n",
+    "When we create the estimator, we pass in the filename of our training script, the name of our IAM execution role, and the S3 locations we defined in the setup section. We also provide a few other parameters. ``instance_count`` and ``instance_type`` determine the number and type of SageMaker instances that will be used for the training job. The ``hyperparameters`` parameter is a ``dict`` of values that will be passed to your training script -- you can see how to access these values in the ``mnist.py`` script above.\n",
     "\n",
-    "For this example, we will train our model on the local instance this notebook is running on. This is achieved by using `local` for `train_instance_type`. By passing local, training will be done inside of a Docker container on this notebook instance."
+    "For this example, we will train our model on the local instance this notebook is running on. This is achieved by using `local` for `instance_type`. By passing local, training will be done inside of a Docker container on this notebook instance."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sagemaker.mxnet import MXNet\n",
     "\n",
     "mnist_estimator = MXNet(entry_point='mnist.py',\n",
     "                        role=role,\n",
-    "                        train_instance_count=1,\n",
-    "                        train_instance_type='local',\n",
+    "                        instance_count=1,\n",
+    "                        instance_type='local',\n",
     "                        framework_version='1.4.1',\n",
     "                        py_version='py3',\n",
     "                        hyperparameters={'learning-rate': 0.1})"
@@ -287,9 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(\"Endpoint name: \" + predictor.endpoint)"
@@ -298,15 +293,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import sagemaker\n",
     "\n",
     "predictor.delete_endpoint()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -325,7 +325,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.10"
   },
   "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },


### PR DESCRIPTION
Notebook needed updates to be compatible with the v2 of the SageMaker SDK, which is the new Default SDK version in SageMaker.

Issue #, if available:

Description of changes:
Notebook needed updates to be compatible with the v2 of the SageMaker SDK, which is the new Default SDK version in SageMaker.

Fixed:

Use instance_count, instance_type, and distribution instead of train_instance_count, train_instance_type, and distributions.
Fixed typos.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.