### PR TITLE
Remove hard-coded region

### DIFF
--- a/training/distributed_training/pytorch/data_parallel/maskrcnn/build_and_push.sh
+++ b/training/distributed_training/pytorch/data_parallel/maskrcnn/build_and_push.sh
@@ -34,7 +34,7 @@ if [ $? -ne 0 ]; then
     aws ecr create-repository --region ${region} --repository-name "${image}" > /dev/null
 fi
 
-$(aws ecr get-login --no-include-email --region us-west-2  --registry-ids 763104351884)
+$(aws ecr get-login --no-include-email --region ${region}  --registry-ids 763104351884)
 docker build ${DIR}/ -t ${image} -f ${DIR}/Dockerfile  --build-arg region=${region}
 docker tag ${image} ${fullname}
 


### PR DESCRIPTION
The [`pytorch_smdataparallel_maskrcnn_demo`](https://github.com/aws/amazon-sagemaker-examples/blob/master/training/distributed_training/pytorch/data_parallel/maskrcnn/build_and_push.sh) example contains one small error.

In `bulid_and_push.sh`, the authentication to Deep Learning Repository fails on regions other than us-west-2 because the region is hard coded on Line 37.

The example notebook does not work outside of us-west-2 without this fix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.