### PR TITLE
Updated xgboost_abalone_dist_script_mode.ipynb and xgboost_managed_spot_training.ipynb for SageMaker SDK v2

### DIFF
--- a/aws_sagemaker_studio/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone_dist_script_mode.ipynb
+++ b/aws_sagemaker_studio/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone_dist_script_mode.ipynb
@@ -47,7 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ensure sagemaker version >= 1.35.0\n",
+    "# ensure sagemaker version >= 2.00.0\n",
     "!pip show sagemaker"
    ]
   },
@@ -358,7 +358,7 @@
     "\n",
     "* __entry_point__: The path to the Python script SageMaker runs for training and prediction.\n",
     "* __role__: Role ARN\n",
-    "* __train_instance_type__ *(optional)*: The type of SageMaker instances for training. __Note__: Because Scikit-learn does not natively support GPU training, Sagemaker Scikit-learn does not currently support training on GPU instance types.\n",
+    "* __instance_type__ *(optional)*: The type of SageMaker instances for training. __Note__: Because Scikit-learn does not natively support GPU training, Sagemaker Scikit-learn does not currently support training on GPU instance types.\n",
     "* __sagemaker_session__ *(optional)*: The session used to train on Sagemaker.\n",
     "* __hyperparameters__ *(optional)*: A dictionary passed to the train function as hyperparameters."
    ]
@@ -391,7 +391,7 @@
    "outputs": [],
    "source": [
     "# Open Source distributed script mode\n",
-    "from sagemaker.session import s3_input, Session\n",
+    "from sagemaker.session import TrainingInput, Session\n",
     "from sagemaker.xgboost.estimator import XGBoost\n",
     "\n",
     "boto_session = boto3.Session(region_name=region)\n",
@@ -403,12 +403,12 @@
     "    framework_version='0.90-1', # Note: framework_version is mandatory\n",
     "    hyperparameters=hyperparams,\n",
     "    role=role,\n",
-    "    train_instance_count=2, \n",
-    "    train_instance_type=instance_type,\n",
+    "    instance_count=2, \n",
+    "    instance_type=instance_type,\n",
     "    output_path=output_path)\n",
     "\n",
-    "train_input = s3_input(\"s3://{}/{}/{}/\".format(bucket, prefix, 'train'), content_type=content_type)\n",
-    "validation_input = s3_input(\"s3://{}/{}/{}/\".format(bucket, prefix, 'validation'), content_type=content_type)"
+    "train_input = TrainingInput(\"s3://{}/{}/{}/\".format(bucket, prefix, 'train'), content_type=content_type)\n",
+    "validation_input = TrainingInput(\"s3://{}/{}/{}/\".format(bucket, prefix, 'validation'), content_type=content_type)"
    ]
   },
   {
@@ -449,9 +449,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sagemaker.serializers import CSVSerializer\n",
+    "\n",
     "predictor = xgb_script_mode_estimator.deploy(initial_instance_count=1, \n",
-    "                                             instance_type=\"ml.m5.2xlarge\")\n",
-    "predictor.serializer = str"
+    "                                             instance_type=\"ml.m5.2xlarge\",\n",
+    "                                             serializer=CSVSerializer())"
    ]
   },
   {
@@ -496,6 +498,13 @@
    "source": [
     "xgb_script_mode_estimator.delete_endpoint()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -504,7 +513,7 @@
   "kernelspec": {
    "display_name": "Python 3 (Data Science)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/datascience-1.0"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/datascience-1.0"
   },
   "language_info": {
    "codemirror_mode": {

--- a/aws_sagemaker_studio/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_managed_spot_training.ipynb
+++ b/aws_sagemaker_studio/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_managed_spot_training.ipynb
@@ -91,8 +91,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
-    "container = get_image_uri(region, 'xgboost', '0.90-1')"
+    "from sagemaker.image_uris import retrieve\n",
+    "container = retrieve('xgboost', boto3.Session().region_name, '0.90-1')"
    ]
   },
   {
@@ -108,7 +108,7 @@
     "* __entry_point__: The path to the Python script SageMaker runs for training and prediction.\n",
     "* __role__: Role ARN\n",
     "* __hyperparameters__: A dictionary passed to the train function as hyperparameters.\n",
-    "* __train_instance_type__ *(optional)*: The type of SageMaker instances for training. __Note__: This particular mode does not currently support training on GPU instance types.\n",
+    "* __instance_type__ *(optional)*: The type of SageMaker instances for training. __Note__: This particular mode does not currently support training on GPU instance types.\n",
     "* __sagemaker_session__ *(optional)*: The session used to train on Sagemaker."
    ]
   },
@@ -141,15 +141,15 @@
     "\n",
     "To enable checkpointing for Managed Spot Training using SageMaker XGBoost we need to configure three things: \n",
     "\n",
-    "1. Enable the `train_use_spot_instances` constructor arg - a simple self-explanatory boolean. \n",
+    "1. Enable the `use_spot_instances` constructor arg - a simple self-explanatory boolean. \n",
     "\n",
-    "2. Set the `train_max_wait constructor` arg - this is an int arg representing the amount of time you are willing to wait for Spot infrastructure to become available. Some instance types are harder to get at Spot prices and you may have to wait longer. You are not charged for time spent waiting for Spot infrastructure to become available, you're only charged for actual compute time spent once Spot instances have been successfully procured. \n",
+    "2. Set the `max_wait constructor` arg - this is an int arg representing the amount of time you are willing to wait for Spot infrastructure to become available. Some instance types are harder to get at Spot prices and you may have to wait longer. You are not charged for time spent waiting for Spot infrastructure to become available, you're only charged for actual compute time spent once Spot instances have been successfully procured. \n",
     "\n",
     "3. Setup a `checkpoint_s3_uri` constructor arg - this arg will tell SageMaker an S3 location where to save checkpoints. While not strictly necessary, checkpointing is highly recommended for Manage Spot Training jobs due to the fact that Spot instances can be interrupted with short notice and using checkpoints to resume from the last interruption ensures you don't lose any progress made before the interruption.\n",
     "\n",
-    "Feel free to toggle the `train_use_spot_instances` variable to see the effect of running the same job using regular (a.k.a. \"On Demand\") infrastructure.\n",
+    "Feel free to toggle the `use_spot_instances` variable to see the effect of running the same job using regular (a.k.a. \"On Demand\") infrastructure.\n",
     "\n",
-    "Note that `train_max_wait` can be set if and only if `train_use_spot_instances` is enabled and must be greater than or equal to `train_max_run`."
+    "Note that `max_wait` can be set if and only if `use_spot_instances` is enabled and must be greater than or equal to `max_run`."
    ]
   },
   {
@@ -163,27 +163,27 @@
     "job_name = 'DEMO-xgboost-spot-' + time.strftime(\"%Y-%m-%d-%H-%M-%S\", time.gmtime())\n",
     "print(\"Training job\", job_name)\n",
     "\n",
-    "train_use_spot_instances = True\n",
-    "train_max_run = 3600\n",
-    "train_max_wait = 7200 if train_use_spot_instances else None\n",
-    "checkpoint_s3_uri = ('s3://{}/{}/checkpoints/{}'.format(bucket, prefix, job_name) if train_use_spot_instances \n",
+    "use_spot_instances = True\n",
+    "max_run = 3600\n",
+    "max_wait = 7200 if use_spot_instances else None\n",
+    "checkpoint_s3_uri = ('s3://{}/{}/checkpoints/{}'.format(bucket, prefix, job_name) if use_spot_instances \n",
     "                      else None)\n",
     "print(\"Checkpoint path:\", checkpoint_s3_uri)\n",
     "\n",
     "estimator = sagemaker.estimator.Estimator(container, \n",
     "                                          role, \n",
     "                                          hyperparameters=hyperparameters,\n",
-    "                                          train_instance_count=1, \n",
-    "                                          train_instance_type=instance_type, \n",
-    "                                          train_volume_size=5,         # 5 GB \n",
+    "                                          instance_count=1, \n",
+    "                                          instance_type=instance_type, \n",
+    "                                          volume_size=5,         # 5 GB \n",
     "                                          output_path=output_path, \n",
     "                                          sagemaker_session=sagemaker.Session(),\n",
-    "                                          train_use_spot_instances=train_use_spot_instances, \n",
-    "                                          train_max_run=train_max_run, \n",
-    "                                          train_max_wait=train_max_wait,\n",
+    "                                          use_spot_instances=use_spot_instances, \n",
+    "                                          max_run=max_run, \n",
+    "                                          max_wait=max_wait,\n",
     "                                          checkpoint_s3_uri=checkpoint_s3_uri\n",
     "                                         );\n",
-    "train_input = sagemaker.s3_input(s3_data='s3://{}/{}/{}'.format(bucket, prefix, 'train'), content_type='libsvm')\n",
+    "train_input = sagemaker.TrainingInput(s3_data='s3://{}/{}/{}'.format(bucket, prefix, 'train'), content_type='libsvm')\n",
     "estimator.fit({'train': train_input}, job_name=job_name)"
    ]
   },
@@ -197,7 +197,7 @@
     "- `Training seconds: X` : This is the actual compute-time your training job spent\n",
     "- `Billable seconds: Y` : This is the time you will be billed for after Spot discounting is applied.\n",
     "\n",
-    "If you enabled the `train_use_spot_instances`, then you should see a notable difference between `X` and `Y` signifying the cost savings you will get for having chosen Managed Spot Training. This should be reflected in an additional line:\n",
+    "If you enabled the `use_spot_instances`, then you should see a notable difference between `X` and `Y` signifying the cost savings you will get for having chosen Managed Spot Training. This should be reflected in an additional line:\n",
     "- `Managed Spot Training savings: (1-Y/X)*100 %`"
    ]
   },
@@ -261,22 +261,22 @@
     "\n",
     "job_name = 'DEMO-xgboost-regression-' + time.strftime(\"%Y-%m-%d-%H-%M-%S\", time.gmtime())\n",
     "print(\"Training job\", job_name)\n",
-    "checkpoint_s3_uri = ('s3://{}/{}/checkpoints/{}'.format(bucket, prefix, job_name) if train_use_spot_instances \n",
+    "checkpoint_s3_uri = ('s3://{}/{}/checkpoints/{}'.format(bucket, prefix, job_name) if use_spot_instances \n",
     "                      else None)\n",
     "print(\"Checkpoint path:\", checkpoint_s3_uri)\n",
     "\n",
     "xgb_script_mode_estimator = XGBoost(\n",
     "    entry_point=\"abalone.py\",\n",
     "    hyperparameters=hyperparameters,\n",
-    "    image_name=container,\n",
+    "    image_uri=container,\n",
     "    role=role, \n",
-    "    train_instance_count=1,\n",
-    "    train_instance_type=instance_type,\n",
+    "    instance_count=1,\n",
+    "    instance_type=instance_type,\n",
     "    framework_version=\"0.90-1\",\n",
     "    output_path=\"s3://{}/{}/{}/output\".format(bucket, prefix, \"xgboost-script-mode\"),\n",
-    "    train_use_spot_instances=train_use_spot_instances,\n",
-    "    train_max_run=train_max_run,\n",
-    "    train_max_wait=train_max_wait,\n",
+    "    use_spot_instances=use_spot_instances,\n",
+    "    max_run=max_run,\n",
+    "    max_wait=max_wait,\n",
     "    checkpoint_s3_uri=checkpoint_s3_uri\n",
     ")"
    ]
@@ -296,6 +296,13 @@
    "source": [
     "xgb_script_mode_estimator.fit({'train': train_input, 'validation': train_input}, job_name=job_name)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -304,7 +311,7 @@
   "kernelspec": {
    "display_name": "Python 3 (Data Science)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/datascience-1.0"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/datascience-1.0"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Notebook needed updates to be compatible with the v2 of the SageMaker SDK, which is the new Default SDK version in SageMaker.

Issue #, if available:

Description of changes:
Notebook needed updates to be compatible with the v2 of the SageMaker SDK, which is the new Default SDK version in SageMaker.

Fixed:

Use instance_count, instance_type, retrieve, use_spot_instances, max_wait, use_spot_instances and TrainingInput instead of train_instance_count, train_instance_type, get_image_uri, train_use_spot_instances, train_max_wait, train_use_spot_instances and s3_input.
Fixed typos.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

