### PR TITLE
Updated pytorch_rnn.ipynb SageMaker SDK v2

### DIFF
--- a/sagemaker-python-sdk/pytorch_lstm_word_language_model/pytorch_rnn.ipynb
+++ b/sagemaker-python-sdk/pytorch_lstm_word_language_model/pytorch_rnn.ipynb
@@ -194,9 +194,10 @@
     "estimator = PyTorch(entry_point='train.py',\n",
     "                    role=role,\n",
     "                    framework_version='1.4.0',\n",
-    "                    train_instance_count=1,\n",
-    "                    train_instance_type='ml.p2.xlarge',\n",
+    "                    instance_count=1,\n",
+    "                    instance_type='ml.p2.xlarge',\n",
     "                    source_dir='pytorch-rnn-scripts',\n",
+    "                    py_version='py3',\n",
     "                    git_config=git_config,\n",
     "                    # available hyperparameters: emsize, nhid, nlayers, lr, clip, epochs, batch_size,\n",
     "                    #                            bptt, dropout, tied, seed, log_interval\n",
@@ -254,11 +255,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sagemaker.predictor import RealTimePredictor, json_serializer, json_deserializer\n",
+    "from sagemaker.predictor import Predictor\n",
+    "from sagemaker.serializers import JSONSerializer\n",
+    "from sagemaker.deserializers import JSONDeserializer\n",
     "\n",
-    "class JSONPredictor(RealTimePredictor):\n",
+    "class JSONPredictor(Predictor):\n",
     "    def __init__(self, endpoint_name, sagemaker_session):\n",
-    "        super(JSONPredictor, self).__init__(endpoint_name, sagemaker_session, json_serializer, json_deserializer)"
+    "        super(JSONPredictor, self).__init__(endpoint_name, sagemaker_session, JSONSerializer(), JSONDeserializer())"
    ]
   },
   {
@@ -284,6 +287,7 @@
     "                     framework_version='1.0.0',\n",
     "                     entry_point='generate.py',\n",
     "                     source_dir='pytorch-rnn-scripts',\n",
+    "                     py_version='py3',\n",
     "                     git_config=git_config,\n",
     "                     predictor_cls=JSONPredictor)"
    ]
@@ -344,27 +348,34 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sagemaker_session.delete_endpoint(predictor.endpoint)"
+    "predictor.delete_endpoint()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Environment (conda_pytorch_p27)",
+   "display_name": "conda_pytorch_p36",
    "language": "python",
-   "name": "conda_pytorch_p27"
+   "name": "conda_pytorch_p36"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.10"
   },
   "notice": "Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Notebook needed updates to be compatible with the v2 of the SageMaker SDK, which is the new Default SDK version in SageMaker.

Fixed:

- Now use `conda_pytorch_p36` instead of the old `conda_pytorch_p27` one.
- Use `instance_count`, and `instance_type` instead of `train_instance_count`, and `train_instance_type`.
- Modify predictor to use `sagemaker.predictor.Predictor`, `sagemaker.serializers.JSONSerializer` and `sagemaker.deserializers.JSONDeserializer` instead of the deprecated `RealTimePredictor`, `json_serializer`, and  `json_deserializer`.
- Use `predictor.delete_endpoint()` instead of `sagemaker_session.delete_endpoint(predictor.endpoint)`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
