### PR TITLE
Add a note to remove account ids when reporting bugs with logs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,10 +8,13 @@ assignees: ''
 ---
 
 **Link to the notebook**
-Add the link to the notebook
+Add the link to the notebook.
 
 **Describe the bug**
 A clear and concise description of what the bug is.
+Attach error logs if available.
+For security, make sure you remove or hide your
+12-digit AWS account ID when attaching the logs.
 
 **To Reproduce**
-Steps to reproduce
+Steps to reproduce.


### PR DESCRIPTION
Add a note to remove account ids when reporting bugs with logs
