### PR TITLE
Updated mxnet_gluon_mnist samples to SageMaker SDK v2

### DIFF
--- a/sagemaker-python-sdk/mxnet_gluon_mnist/mxnet_mnist_with_gluon.ipynb
+++ b/sagemaker-python-sdk/mxnet_gluon_mnist/mxnet_mnist_with_gluon.ipynb
@@ -100,8 +100,8 @@
    "source": [
     "m = MXNet(\"mnist.py\",\n",
     "          role=role,\n",
-    "          train_instance_count=1,\n",
-    "          train_instance_type=\"ml.c4.xlarge\",\n",
+    "          instance_count=1,\n",
+    "          instance_type=\"ml.c4.xlarge\",\n",
     "          framework_version=\"1.6.0\",\n",
     "          py_version=\"py3\",\n",
     "          hyperparameters={'batch-size': 100,\n",

--- a/sagemaker-python-sdk/mxnet_gluon_mnist/mxnet_mnist_with_gluon_local_mode.ipynb
+++ b/sagemaker-python-sdk/mxnet_gluon_mnist/mxnet_mnist_with_gluon_local_mode.ipynb
@@ -132,8 +132,8 @@
    "source": [
     "m = MXNet(\"mnist.py\",\n",
     "          role=role,\n",
-    "          train_instance_count=1,\n",
-    "          train_instance_type=instance_type,\n",
+    "          instance_count=1,\n",
+    "          instance_type=instance_type,\n",
     "          framework_version=\"1.6.0\",\n",
     "          py_version=\"py3\",\n",
     "          hyperparameters={'batch-size': 100,\n",


### PR DESCRIPTION
*Issue #, if available:

*Description of changes:
Notebooks needed updates to be compatible with the v2 of the SageMaker SDK, which is the new Default SDK version in SageMaker.

Fixed:
Use instance_count, and instance_type instead of train_instance_count, and train_instance_type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.