### PR TITLE
Fix mnist dataset download error for PyTorch Data Parallel notebook

### DIFF
--- a/training/distributed_training/pytorch/data_parallel/mnist/code/train_pytorch_smdataparallel_mnist.py
+++ b/training/distributed_training/pytorch/data_parallel/mnist/code/train_pytorch_smdataparallel_mnist.py
@@ -12,6 +12,11 @@
 # language governing permissions and limitations under the License.
 
 from __future__ import print_function
+# Hack to add mnist dataset download https://github.com/pytorch/vision/issues/3497
+from six.moves import urllib
+opener = urllib.request.build_opener()
+opener.addheaders = [('User-agent', 'Mozilla/5.0')]
+urllib.request.install_opener(opener)
 
 import os
 import argparse


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
SMDDP MNIST PyTorch script currently errors out with the following error : 
```[1,0]<stdout>:Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz to /tmp/data/MNIST/raw/train-labels-idx1-ubyte.gz
[1,0]<stdout>:Extracting /tmp/data/MNIST/raw/train-labels-idx1-ubyte.gz to /tmp/data/MNIST/raw
[1,0]<stdout>:Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz to /tmp/data/MNIST/raw/t10k-images-idx3-ubyte.gz
[1,0]<stdout>:Extracting /tmp/data/MNIST/raw/t10k-images-idx3-ubyte.gz to /tmp/data/MNIST/raw
[1,0]<stdout>:Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz to /tmp/data/MNIST/raw/t10k-labels-idx1-ubyte.gz
[1,5]<stdout>:Traceback (most recent call last):
[1,5]<stdout>:  File "/opt/conda/lib/python3.6/runpy.py", line 193, in _run_module_as_main
[1,5]<stdout>:    "__main__", mod_spec)
[1,5]<stdout>:  File "/opt/conda/lib/python3.6/runpy.py", line 85, in _run_code
[1,5]<stdout>:    exec(code, run_globals)
[1,5]<stdout>:  File "/opt/conda/lib/python3.6/site-packages/mpi4py/__main__.py", line 7, in <module>
[1,5]<stdout>:    main()
[1,5]<stdout>:  File "/opt/conda/lib/python3.6/site-packages/mpi4py/run.py", line 196, in main
[1,5]<stdout>:    run_command_line(args)
[1,5]<stdout>:  File "/opt/conda/lib/python3.6/site-packages/mpi4py/run.py", line 47, in run_command_line
[1,5]<stdout>:    run_path(sys.argv[0], run_name='__main__')
[1,5]<stdout>:  File "/opt/conda/lib/python3.6/runpy.py", line 263, in run_path
[1,5]<stdout>:    pkg_name=pkg_name, script_name=fname)
[1,5]<stdout>:  File "/opt/conda/lib/python3.6/runpy.py", line 96, in _run_module_code
[1,5]<stdout>:    mod_name, mod_spec, pkg_name, script_name)
[1,5]<stdout>:  File "/opt/conda/lib/python3.6/runpy.py", line 85, in _run_code
[1,5]<stdout>:    exec(code, run_globals)
[1,5]<stdout>:  File "smdataparallel_mnist.py", line 177, in <module>
[1,5]<stdout>:    main()
[1,5]<stdout>:  File "smdataparallel_mnist.py", line 139, in main
[1,5]<stdout>:    transforms.Normalize((0.1307,), (0.3081,))
[1,5]<stdout>:  File "/opt/conda/lib/python3.6/site-packages/torchvision/datasets/mnist.py", line 83, in __init__
[1,5]<stdout>:    ' You can use download=True to download it')
[1,5]<stdout>:RuntimeError: Dataset not found. You can use download=True to download it
```

This is due to a recent breakage in PyTorch : https://github.com/pytorch/vision/issues/3497
This PR fixes that. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
