### PR TITLE
Fixed typo in scikit_learn_estimator_example_with_batch_transform.ipynb

### DIFF
--- a/sagemaker-python-sdk/scikit_learn_iris/scikit_learn_estimator_example_with_batch_transform.ipynb
+++ b/sagemaker-python-sdk/scikit_learn_iris/scikit_learn_estimator_example_with_batch_transform.ipynb
@@ -209,7 +209,7 @@
     "\n",
     "* __entry_point__: The path to the Python script SageMaker runs for training and prediction.\n",
     "* __role__: Role ARN\n",
-    "* __train_instance_type__ *(optional)*: The type of SageMaker instances for training. __Note__: Because Scikit-learn does not natively support GPU training, Sagemaker Scikit-learn does not currently support training on GPU instance types.\n",
+    "* __instance_type__ *(optional)*: The type of SageMaker instances for training. __Note__: Because Scikit-learn does not natively support GPU training, Sagemaker Scikit-learn does not currently support training on GPU instance types.\n",
     "* __sagemaker_session__ *(optional)*: The session used to train on Sagemaker.\n",
     "* __hyperparameters__ *(optional)*: A dictionary passed to the train function as hyperparameters.\n",
     "\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixed typo: `instance_type` instead of `train_instance_type`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
