### PR TITLE
Update kmeans_mnist.ipynb with SageMaker SDK v2 

### DIFF
--- a/sagemaker-python-sdk/1P_kmeans_highlevel/kmeans_mnist.ipynb
+++ b/sagemaker-python-sdk/1P_kmeans_highlevel/kmeans_mnist.ipynb
@@ -289,18 +289,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sagemaker\n",
-    "\n",
-    "sagemaker.Session().delete_endpoint(kmeans_predictor.endpoint)"
+    "kmeans_predictor.delete_endpoint()"
    ]
   }
  ],
  "metadata": {
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science)",
+   "display_name": "conda_python3",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/datascience-1.0"
+   "name": "conda_python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -312,7 +310,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.10"
   },
   "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating delete_endpoint API call to SageMaker SDK v2.

Replaced `sagemaker.Session().delete_endpoint(kmeans_predictor.endpoint)` with new SageMaker SDK v2 API call `kmeans_predictor.delete_endpoint()`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
