### PR TITLE
Update SageMaker-ModelMonitoring.ipynb to fix Issue #2074

### DIFF
--- a/sagemaker_model_monitor/introduction/SageMaker-ModelMonitoring.ipynb
+++ b/sagemaker_model_monitor/introduction/SageMaker-ModelMonitoring.ipynb
@@ -178,7 +178,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This step invokes the endpoint with included sample data for about 2 minutes. Data is captured based on the sampling percentage specified and the capture continues until the data capture option is turned off."
+    "This step invokes the endpoint with included sample data for about 3 minutes. Data is captured based on the sampling percentage specified and the capture continues until the data capture option is turned off."
    ]
   },
   {
@@ -187,22 +187,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sagemaker.predictor import Predictor, csv_serializer\n",
+    "from sagemaker.predictor import Predictor\n",
+    "from sagemaker.serializers import CSVSerializer\n",
     "import time\n",
     "\n",
-    "predictor = Predictor(endpoint_name=endpoint_name, serializer=csv_serializer)\n",
+    "predictor = Predictor(endpoint_name=endpoint_name, serializer=CSVSerializer())\n",
     "\n",
     "# get a subset of test data for a quick test\n",
-    "!head -120 test_data/test-dataset-input-cols.csv > test_data/test_sample.csv\n",
+    "!head -180 test_data/test-dataset-input-cols.csv > test_data/test_sample.csv\n",
     "print(\"Sending test traffic to the endpoint {}. \\nPlease wait...\".format(endpoint_name))\n",
     "\n",
     "with open('test_data/test_sample.csv', 'r') as f:\n",
     "    for row in f:\n",
     "        payload = row.rstrip('\\n')\n",
     "        response = predictor.predict(data=payload)\n",
-    "        time.sleep(0.5)\n",
+    "        time.sleep(1)\n",
     "        \n",
-    "print(\"Done!\")        "
+    "print(\"Done!\")"
    ]
   },
   {
@@ -716,6 +717,13 @@
    "source": [
     "predictor.delete_model()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/sagemaker_model_monitor/introduction/SageMaker-ModelMonitoring.ipynb
+++ b/sagemaker_model_monitor/introduction/SageMaker-ModelMonitoring.ipynb
@@ -126,13 +126,14 @@
    "source": [
     "from time import gmtime, strftime\n",
     "from sagemaker.model import Model\n",
-    "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
+    "from sagemaker.image_uris import retrieve\n",
     "\n",
     "model_name = \"DEMO-xgb-churn-pred-model-monitor-\" + strftime(\"%Y-%m-%d-%H-%M-%S\", gmtime())\n",
     "model_url = 'https://{}.s3-{}.amazonaws.com/{}/xgb-churn-prediction-model.tar.gz'.format(bucket, region, prefix)\n",
-    "image_uri = get_image_uri(boto3.Session().region_name, 'xgboost', '0.90-1')\n",
     "\n",
-    "model = Model(image=image_uri, model_data=model_url, role=role)"
+    "image_uri = retrieve('xgboost', boto3.Session().region_name, '0.90-1')\n",
+    "\n",
+    "model = Model(image_uri=image_uri, model_data=model_url, role=role)"
    ]
   },
   {
@@ -734,7 +735,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.13"
   },
   "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },

--- a/sagemaker_model_monitor/introduction/SageMaker-ModelMonitoring.ipynb
+++ b/sagemaker_model_monitor/introduction/SageMaker-ModelMonitoring.ipynb
@@ -187,10 +187,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sagemaker.predictor import RealTimePredictor\n",
+    "from sagemaker.predictor import Predictor, csv_serializer\n",
     "import time\n",
     "\n",
-    "predictor = RealTimePredictor(endpoint=endpoint_name,content_type='text/csv')\n",
+    "predictor = Predictor(endpoint_name=endpoint_name, serializer=csv_serializer)\n",
     "\n",
     "# get a subset of test data for a quick test\n",
     "!head -120 test_data/test-dataset-input-cols.csv > test_data/test_sample.csv\n",


### PR DESCRIPTION
*Issue #, if available:*
#2074 

*Description of changes:*
- Replaced `get_image_uri` with `retrieve` following SageMaker SDK v2 API.
- Fixed `image=image_uri` with `image_uri=image_uri` following SageMaker SDK v2 API.
- Used `Predictor` instead of `RealTimePredictor`.
- Used `CSVSerializer` instead of `content_type='text/csv')`
- Increased sleep time and amount of samples to avoid exception where there is not any capture data available.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
