### PR TITLE
update pytorch_local_mode_cifar10.ipynb to 1.7.1

### DIFF
--- a/sagemaker-python-sdk/pytorch_cnn_cifar10/pytorch_local_mode_cifar10.ipynb
+++ b/sagemaker-python-sdk/pytorch_cnn_cifar10/pytorch_local_mode_cifar10.ipynb
@@ -199,7 +199,7 @@
     "\n",
     "cifar10_estimator = PyTorch(entry_point='source/cifar10.py',\n",
     "                            role=role,\n",
-    "                            framework_version='1.4.0',\n",
+    "                            framework_version='1.7.1',\n",
     "                            train_instance_count=1,\n",
     "                            train_instance_type=instance_type)\n",
     "\n",

--- a/sagemaker-python-sdk/pytorch_cnn_cifar10/source/cifar10.py
+++ b/sagemaker-python-sdk/pytorch_cnn_cifar10/source/cifar10.py
@@ -1,6 +1,5 @@
 import argparse
 import logging
-import sagemaker_containers
 
 import os
 
@@ -15,6 +14,11 @@ import torchvision
 import torchvision.models
 import torchvision.transforms as transforms
 import torch.nn.functional as F
+
+try:
+    from sagemaker_inference import environment
+except:
+    from sagemaker_training import environment
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -150,7 +154,7 @@ if __name__ == '__main__':
     parser.add_argument('--momentum', type=float, default=0.9, metavar='M', help='momentum (default: 0.9)')
     parser.add_argument('--dist_backend', type=str, default='gloo', help='distributed backend (default: gloo)')
 
-    env = sagemaker_containers.training_env()
+    env = environment.Environment()
     parser.add_argument('--hosts', type=list, default=env.hosts)
     parser.add_argument('--current-host', type=str, default=env.current_host)
     parser.add_argument('--model-dir', type=str, default=env.model_dir)


### PR DESCRIPTION
*Issue #, if available:*
The following pull requests in the SageMaker Python SDK repository are failing due to notebook tests in regards to this notebook:
* https://github.com/aws/sagemaker-python-sdk/pull/2198
* https://github.com/aws/sagemaker-python-sdk/pull/2206

These notebooks are failing, as some of the older PyTorch images starting from 1.4.0 and above have been updated and the sagemaker_containers library was removed unintentionally:
* https://github.com/aws/deep-learning-containers/pull/901

*Description of changes:*
Update pytorch_local_mode_cifar10.ipynb to use the PyTorch 1.7.1 images for training and inference.

Update references for sagemaker_containers to sagemaker_training and sagemaker_inference.

*Testing*
I have attached an html of a successfully run notebook with the changes defined below.

[test.zip](https://github.com/aws/amazon-sagemaker-examples/files/6135625/test.zip)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
