### PR TITLE
Use smp.amp.GradScaler for fp16 training in model-parallel PT BERT

### DIFF
--- a/training/distributed_training/pytorch/model_parallel/bert/smp_bert_tutorial.ipynb
+++ b/training/distributed_training/pytorch/model_parallel/bert/smp_bert_tutorial.ipynb
@@ -262,6 +262,7 @@
     "                   \"use_sequential\": 1,\n",
     "                   \"skip_checkpoint\": 1,\n",
     "                   \"smp\": 1,\n",
+    "                   \"fp16\": 1,\n",
     "                   \"apply_optimizer\": 1}"
    ]
   },


### PR DESCRIPTION
`fp16` training currently does not work properly in the model parallel BERT training example. This PR switches to the built-in `smp.amp.GradScaler` API so that the example works with the flag `fp16: 1`. Also enables `fp16` by default.