### PR TITLE
Feature store update notebook - install compatible boto3 version

### DIFF
--- a/sagemaker-featurestore/sagemaker_featurestore_fraud_detection_python_sdk.ipynb
+++ b/sagemaker-featurestore/sagemaker_featurestore_fraud_detection_python_sdk.ipynb
@@ -42,7 +42,7 @@
    "source": [
     "## Setup SageMaker FeatureStore\n",
     "\n",
-    "Let's start by setting up the SageMaker Python SDK and boto client."
+    "Let's start by setting up the SageMaker Python SDK and boto client. Note that this notebook requires a `boto3` version above `1.17.21`"
    ]
   },
   {
@@ -53,8 +53,18 @@
    "source": [
     "import boto3\n",
     "import sagemaker\n",
-    "from sagemaker.session import Session\n",
     "\n",
+    "original_boto3_version = boto3.__version__\n",
+    "%pip install 'boto3>1.17.21'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.session import Session\n",
     "\n",
     "region = boto3.Session().region_name\n",
     "\n",
@@ -437,7 +447,7 @@
     "print(account_id)\n",
     "\n",
     "identity_feature_group_resolved_output_s3_uri = identity_feature_group.describe().get(\"OfflineStoreConfig\").get(\"S3StorageConfig\").get(\"ResolvedOutputS3Uri\")\n",
-    "transaction_feature_group_resolved_output_s3_uri = transaction_feature_group.describe().get(\"OfflineStoreConfig\").get(\"S3StorageConfig\").get(\"ResolvedOutputS3Ur\")\n",
+    "transaction_feature_group_resolved_output_s3_uri = transaction_feature_group.describe().get(\"OfflineStoreConfig\").get(\"S3StorageConfig\").get(\"ResolvedOutputS3Uri\")\n",
     "\n",
     "identity_feature_group_s3_prefix = identity_feature_group_resolved_output_s3_uri.replace(f\"s3://{default_s3_bucket_name}/\", \"\")\n",
     "transaction_feature_group_s3_prefix = transaction_feature_group_resolved_output_s3_uri.replace(f\"s3://{default_s3_bucket_name}/\", \"\")\n",
@@ -781,6 +791,16 @@
    "source": [
     "identity_feature_group.delete()\n",
     "transaction_feature_group.delete()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#restore original boto3 version\n",
+    "%pip install 'boto3=={}'.format(original_boto3_version)"
    ]
   }
  ],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
New API call ResolvedOutputS3Uri requires a boto3 version above 1.17.21. I pip install a version above this and then restore it in the kernel at the end of the notebook. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
