### PR TITLE
[SageMaker Experiments] fix MNIST download issue with torchvision

### DIFF
--- a/sagemaker-experiments/mnist-handwritten-digits-classification-experiment/mnist-handwritten-digits-classification-experiment.ipynb
+++ b/sagemaker-experiments/mnist-handwritten-digits-classification-experiment/mnist-handwritten-digits-classification-experiment.ipynb
@@ -156,6 +156,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# TODO: can be removed after upgrade to torchvision==0.9.1\n",
+    "# see github.com/pytorch/vision/issues/1938 and github.com/pytorch/vision/issues/3549\n",
+    "datasets.MNIST.urls = [\n",
+    "    'https://ossci-datasets.s3.amazonaws.com/mnist/train-images-idx3-ubyte.gz',\n",
+    "    'https://ossci-datasets.s3.amazonaws.com/mnist/train-labels-idx1-ubyte.gz',\n",
+    "    'https://ossci-datasets.s3.amazonaws.com/mnist/t10k-images-idx3-ubyte.gz',\n",
+    "    'https://ossci-datasets.s3.amazonaws.com/mnist/t10k-labels-idx1-ubyte.gz'\n",
+    "]\n",
+    "\n",
     "# download the dataset\n",
     "# this will not only download data to ./mnist folder, but also load and transform (normalize) them\n",
     "train_set = datasets.MNIST('mnist', train=True, transform=transforms.Compose([\n",
@@ -529,9 +538,9 @@
  "metadata": {
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-2:429704687514:environment/datascience"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -543,7 +552,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
**Fixes Issue**: #2057 

**Description of changes:**
Fixes the the issue with MNIST download failure in *sagemaker-experiments* example notebook after the original dataset host moved under CloudFlare (github.com/pytorch/vision/issues/1938) thereby breaking the built-in download feature of *torchvision* (github.com/pytorch/vision/issues/3549).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
