### PR TITLE
Add Notebook for using Elastic Inference with compiled model on SageM…

### DIFF
--- a/sagemaker-python-sdk/tensorflow_serving_using_elastic_inference_with_your_own_model/tensorflow_neo_compiled_model_elastic_inference.ipynb
+++ b/sagemaker-python-sdk/tensorflow_serving_using_elastic_inference_with_your_own_model/tensorflow_neo_compiled_model_elastic_inference.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Using Amazon Elastic Inference with Neo-compiled TensorFlow model on SageMaker\n",
     "\n",
-    "This notebook demonstrates how to compile a pre-trained TensorFlow model using Amazon SageMaker Neo, and deploy this compiled model on SageMaker with Elastic Inference.\n",
+    "This notebook demonstrates how to compile a pre-trained TensorFlow model using Amazon SageMaker Neo and how to deploy this model to a SageMaker Endpoint with Elastic Inference\n",
     "\n",
     "Amazon Elastic Inference (EI) allows you to add inference acceleration to an Amazon SageMaker hosted endpoint for a fraction of the cost of using a full GPU instance. Running Neo-compiled models on EI provides a performance boost by optimizing the model to produce low latency inferences. This would increase inference throughput and further reduce costs. For more information please visit: https://docs.aws.amazon.com/sagemaker/latest/dg/ei.html\n",
     "\n",
@@ -33,7 +33,8 @@
     "Let's start by creating a SageMaker session and specifying:\n",
     "\n",
     "* The S3 bucket that you want to use for model data. This should be within the same region as the Notebook Instance, Neo compilation, and SageMaker hosting.\n",
-    "* The IAM role arn used to give compilation and hosting access to your data. See the [documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-roles.html) for how to create these. Note, if more than one role is required for notebook instances, compilation, and hosting, please replace the sagemaker.get_execution_role() with a the appropriate full IAM role arn string(s)."
+    "* The IAM role arn used to give compilation and hosting access to your data. See the [documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-roles.html) for how to create these. \n",
+    "**Note: If more than one role is required for notebook instances, compilation, and hosting, please replace the sagemaker.get_execution_role() with a the appropriate full IAM role arn string(s).**"
    ]
   },
   {
@@ -45,9 +46,8 @@
     "import sagemaker\n",
     "\n",
     "session = sagemaker.Session()\n",
-    "role = sagemaker.get_execution_role()\n",
-    "region = session.boto_region_name\n",
-    "bucket = session.default_bucket()"
+    "bucket = session.default_bucket()\n",
+    "role = sagemaker.get_execution_role()"
    ]
   },
   {
@@ -111,7 +111,7 @@
    "metadata": {},
    "source": [
     "## Compile model for EI accelerator using Neo\n",
-    "Now the model is ready to be compiled by Neo. Note that `ml_eia2` needs to be set for `target_isntance_family` field in order for the model to be optimized for EI accelerator. If you want to compile your own model for EI accelerataor, refer to [Neo compilation API](https://sagemaker.readthedocs.io/en/stable/api/inference/model.html#sagemaker.model.Model.compile) to provide the proper `input_shape` and optional `compiler_options` according to your model.\n",
+    "Now the model is ready to be compiled by Neo. Note that `ml_eia2` needs to be set for `target_instance_family` field in order for the model to be optimized for EI accelerator. If you want to compile your own model for EI accelerataor, refer to [Neo compilation API](https://sagemaker.readthedocs.io/en/stable/api/inference/model.html#sagemaker.model.Model.compile) to provide the proper `input_shape` and optional `compiler_options` according to your model.\n",
     "\n",
     "**Important: If the following command result in a permission error, scroll up and locate the value of execution role returned by get_execution_role(). The role must have access to the S3 bucket specified in output_path.**"
    ]
@@ -144,7 +144,7 @@
    "metadata": {},
    "source": [
     "## Deploy compiled model to SageMaker Endpoint with EI accelerator attached\n",
-    "There is no difference between deploying Neo-compiled model and uncompiled model to EI-attached SageMaker endpoint.\n",
+    "The same methods are used to deploy a model to a SageMaker Endpoint with EI regardless of whether or not the model is compiled or not compiled by Neo.\n",
     "\n",
     "The only change required for utilizing EI is to provide an `accelerator_type` parameter, which determines the type of EI accelerator to be attached to your endpoint. The supported types of accelerators can be found here: https://aws.amazon.com/machine-learning/elastic-inference/pricing/"
    ]

--- a/sagemaker-python-sdk/tensorflow_serving_using_elastic_inference_with_your_own_model/tensorflow_neo_compiled_model_elastic_inference.ipynb
+++ b/sagemaker-python-sdk/tensorflow_serving_using_elastic_inference_with_your_own_model/tensorflow_neo_compiled_model_elastic_inference.ipynb
@@ -1,0 +1,227 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using Amazon Elastic Inference with Neo-compiled TensorFlow model on SageMaker\n",
+    "\n",
+    "This notebook demonstrates how to compile a pre-trained TensorFlow model using Amazon SageMaker Neo, and deploy this compiled model on SageMaker with Elastic Inference.\n",
+    "\n",
+    "Amazon Elastic Inference (EI) allows you to add inference acceleration to an Amazon SageMaker hosted endpoint for a fraction of the cost of using a full GPU instance. Running Neo-compiled models on EI provides a performance boost by optimizing the model to produce low latency inferences. This would increase inference throughput and further reduce costs. For more information please visit: https://docs.aws.amazon.com/sagemaker/latest/dg/ei.html\n",
+    "\n",
+    "This notebook is an adaption of the [Deploy pre-trained TensorFlow model to SageMaker with Elastic Inference](https://github.com/aws/amazon-sagemaker-examples/blob/master/sagemaker-python-sdk/tensorflow_serving_using_elastic_inference_with_your_own_model/tensorflow_serving_pretrained_model_elastic_inference.ipynb) notebook, with modifications showing the changes needed to deploy Neo-compiled models on SageMaker with EI.\n",
+    "\n",
+    "For this example, we will use the SageMaker Python SDK, which makes it easy to compile and deploy your model on SageMaker. \n",
+    "\n",
+    "1. [Set up the environment](#Set-up-the-environment)\n",
+    "1. [Get pre-trained model for compilation](#Get-pre-trained-model-for-compilation)\n",
+    "    1. [Import ResNet50 model from Keras](#Import-ResNet50-model-from-Keras)\n",
+    "    1. [Upload model artifact to S3 bucket](#Upload-model-artifact-to-S3-bucket)\n",
+    "1. [Compile model for EI accelerator using Neo](#Compile-model-for-EI-accelerator-using-Neo)\n",
+    "1. [Deploy compiled model to SageMaker Endpoint with EI accelerator attached](#Deploy-compiled-model-to-SageMaker-Endpoint-with-EI-accelerator-attached)\n",
+    "1. [Make an inference request to the endpoint](#Make-an-inference-request-to-the-endpoint)\n",
+    "1. [Delete the endpoint](#Delete-the-endpoint)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up the environment\n",
+    "Let's start by creating a SageMaker session and specifying:\n",
+    "\n",
+    "* The S3 bucket that you want to use for model data. This should be within the same region as the Notebook Instance, Neo compilation, and SageMaker hosting.\n",
+    "* The IAM role arn used to give compilation and hosting access to your data. See the [documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-roles.html) for how to create these. Note, if more than one role is required for notebook instances, compilation, and hosting, please replace the sagemaker.get_execution_role() with a the appropriate full IAM role arn string(s)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sagemaker\n",
+    "\n",
+    "session = sagemaker.Session()\n",
+    "role = sagemaker.get_execution_role()\n",
+    "region = session.boto_region_name\n",
+    "bucket = session.default_bucket()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get pre-trained model for compilation\n",
+    "Amazon SageMaker Neo supports compiling TensorFlow models in SavedModel format and frozen graph format for EI accelerators. We would be using a ResNet50 model in SavedModel format from Keras in this example."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Import ResNet50 model from Keras\n",
+    "We will import [ResNet50 model](https://arxiv.org/abs/1512.03385) from Keras and create a model artifact `model.tar.gz`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "import tarfile\n",
+    "import os\n",
+    "\n",
+    "pretrained_model = tf.keras.applications.resnet.ResNet50()\n",
+    "saved_model_dir = 'saved_model'\n",
+    "tf.saved_model.save(pretrained_model, saved_model_dir)\n",
+    "\n",
+    "with tarfile.open('model.tar.gz', 'w:gz') as tar:\n",
+    "    for file in os.listdir(saved_model_dir):\n",
+    "        tar.add(os.path.join(saved_model_dir, file), arcname=file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Upload model artifact to S3 bucket\n",
+    "Amazon SageMaker Neo expects a path to the model artifact in Amazon S3, so we will upload the model artifact to be compiled to S3 bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.utils import name_from_base\n",
+    "\n",
+    "compilation_job_name = name_from_base('Keras-ResNet50')\n",
+    "input_model_path = session.upload_data(path='model.tar.gz', bucket=bucket, key_prefix=compilation_job_name)\n",
+    "print('S3 path for input model: {}'.format(input_model_path))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compile model for EI accelerator using Neo\n",
+    "Now the model is ready to be compiled by Neo. Note that `ml_eia2` needs to be set for `target_isntance_family` field in order for the model to be optimized for EI accelerator. If you want to compile your own model for EI accelerataor, refer to [Neo compilation API](https://sagemaker.readthedocs.io/en/stable/api/inference/model.html#sagemaker.model.Model.compile) to provide the proper `input_shape` and optional `compiler_options` according to your model.\n",
+    "\n",
+    "**Important: If the following command result in a permission error, scroll up and locate the value of execution role returned by get_execution_role(). The role must have access to the S3 bucket specified in output_path.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.tensorflow import TensorFlowModel\n",
+    "\n",
+    "# Create a TensorFlow SageMaker model\n",
+    "tensorflow_model = TensorFlowModel(model_data=input_model_path,\n",
+    "                                   role=role,\n",
+    "                                   framework_version='2.3')\n",
+    "\n",
+    "# Compile the model for EI accelerator in SageMaker Neo\n",
+    "output_path = '/'.join(input_model_path.split('/')[:-1])\n",
+    "tensorflow_model.compile(target_instance_family='ml_eia2',\n",
+    "                         input_shape={\"input_1\": [1, 224, 224, 3]},\n",
+    "                         output_path=output_path,\n",
+    "                         role=role,\n",
+    "                         job_name=compilation_job_name,\n",
+    "                         framework='tensorflow')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Deploy compiled model to SageMaker Endpoint with EI accelerator attached\n",
+    "There is no difference between deploying Neo-compiled model and uncompiled model to EI-attached SageMaker endpoint.\n",
+    "\n",
+    "The only change required for utilizing EI is to provide an `accelerator_type` parameter, which determines the type of EI accelerator to be attached to your endpoint. The supported types of accelerators can be found here: https://aws.amazon.com/machine-learning/elastic-inference/pricing/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictor = tensorflow_model.deploy(initial_instance_count=1,\n",
+    "                                    instance_type='ml.m5.xlarge',\n",
+    "                                    accelerator_type='ml.eia2.large')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Make an inference request to the endpoint\n",
+    "Now that the endpoint is deployed with our compiled model and we have a predictor object, we can use it to send inference request.\n",
+    "Note that the first inference call would usually take longer time, this is known as the warm-up inference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "import numpy as np\n",
+    "\n",
+    "random_input = np.random.rand(1, 224, 224, 3)\n",
+    "prediction = predictor.predict({'inputs': random_input.tolist()})\n",
+    "print(prediction)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Delete the endpoint\n",
+    "\n",
+    "Having an endpoint running will incur some costs. Therefore, we would delete the endpoint to release the resources after finishing this example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "session.delete_endpoint(predictor.endpoint_name)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "conda_tensorflow2_p36",
+   "language": "python",
+   "name": "conda_tensorflow2_p36"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.13"
+  },
+  "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
* Add notebook for running Neo compiled model with Elastic Inference on SageMaker endpoint, since EI recently released such support. 

Note that this notebook shouldn't be merged until this SageMaker SDK changes are in. https://github.com/aws/sagemaker-python-sdk/pull/2242

I've tested this notebook on my SageMaker Notebook instance successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
