### PR TITLE
New notebook to showcase how SageMaker Clarify works with BYOC

### DIFF
--- a/sagemaker_processing/fairness_and_explainability/container/Dockerfile
+++ b/sagemaker_processing/fairness_and_explainability/container/Dockerfile
@@ -1,0 +1,10 @@
+FROM continuumio/miniconda3:latest
+
+RUN pip install flask
+RUN pip install pandas
+RUN pip install scikit-learn
+
+COPY train /usr/local/bin
+COPY serve /usr/local/bin
+
+EXPOSE 8080

--- a/sagemaker_processing/fairness_and_explainability/container/serve
+++ b/sagemaker_processing/fairness_and_explainability/container/serve
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+import argparse
+import csv
+import logging
+import os
+from enum import Enum
+
+import joblib
+import json
+from flask import Flask, Response, request
+
+
+# This container supports the same types as Clarify job does.
+class SupportedMimeTypes(Enum):
+    CSV = "text/csv"
+    JSONLINES = "application/jsonlines"
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+supported_mime_types = [item.value for item in SupportedMimeTypes]
+
+# load model
+parser = argparse.ArgumentParser()
+parser.add_argument("--model_dir", type=str, default="/opt/ml/model/")
+args = parser.parse_args()
+model_file = os.path.join(args.model_dir, "model.joblib")
+estimator = joblib.load(model_file)
+
+
+# HTTP Server
+app = Flask(__name__)
+
+
+@app.route("/ping", methods=["GET"])
+def ping():
+    return Response(response="\n", status=200)
+
+
+@app.route("/invocations", methods=["POST"])
+def predict():
+    # input validation
+    if request.content_type not in supported_mime_types:
+        error_message = f"Unsupported content type '{request.content_type}'. Please use one of {supported_mime_types}"
+        logger.exception(error_message)
+        return Response(response=error_message, status=400)
+    accept_type = request.accept_mimetypes.best_match(supported_mime_types)
+    if accept_type not in supported_mime_types:
+        error_message = f"Unsupported accept type. Please use one of {supported_mime_types}"
+        logger.exception(error_message)
+        return Response(response=error_message, status=400)
+
+    # Clarify job may send batch request to the container for better efficiency,
+    # i.e. the payload can have multiple lines and each is a sample.
+    lines = request.data.decode().splitlines()
+    if not lines:
+        error_message = "Payload is empty. Please post at least one sample."
+        logger.exception(error_message)
+        return Response(response=error_message, status=400)
+
+    # parse payload
+    try:
+        if request.content_type == SupportedMimeTypes.CSV.value:
+            data = list(csv.reader(lines))
+        else:  # SupportedMimeTypes.JSONLINES.value
+            # "features" is a self-defined key in your Clarify job analysis config `predictor.content_template`.
+            # It is used by the container to extract the list of features from a JSON line. The key is a contract
+            # between the Clarify job and the container, here you can change it to something else, like "attributes",
+            # but remember to update the `predictor.content_template` configuration accordingly.
+            data = [json.loads(jsonline)["features"] for jsonline in lines]
+    except ValueError as e:
+        error_message = f"Parsing request payload failed with error '{e}'"
+        logger.exception(error_message)
+        return Response(response=error_message, status=400)
+
+    # do prediction
+    try:
+        # Here get the probability score
+        predictions = estimator.predict_proba(data)[:, 1]
+    except ValueError as e:
+        error_message = f"Prediction failed with error '{e}'"
+        logger.exception(error_message)
+        return Response(response=error_message, status=400)
+
+    # format output
+    if accept_type == SupportedMimeTypes.CSV.value:
+        # output scores for CSV accept type
+        predictions = [str(prediction) for prediction in predictions]
+    else:  # SupportedMimeTypes.JSONLINES.value
+        # "predicted_label" and "score" are self-defined keys in your Clarify job analysis config `predictor.label`
+        # and `predictor.probability`. They are used by the Clarify job to extract predictions from container response.
+        # The keys are contracts between the Clarify job and the container, here you can change them to something else,
+        # but remember to update the analysis configuration accordingly.
+        predictions = [json.dumps({
+                "predicted_label": 1 if prediction > 0.5 else 0,
+                "score": prediction}) for prediction in predictions]
+    # For batch request, Clarify job expects the same number of result lines as the number of samples in the request.
+    output = "\n".join(predictions)
+    return Response(response=output, status=200)
+
+
+def main():
+    # start server
+    app.run(host="0.0.0.0", port=8080)
+
+
+if __name__ == "__main__":
+    main()

--- a/sagemaker_processing/fairness_and_explainability/container/train
+++ b/sagemaker_processing/fairness_and_explainability/container/train
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+
+import argparse
+import logging
+import os
+
+import joblib
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def parse_args():
+    """
+    Load training job parameters.
+    # SageMaker passes parameters to training job by environment variables (see [1]).
+    # Here we add argument parser to ease passing parameters during local debugging.
+    # [1] https://github.com/aws/sagemaker-training-toolkit/blob/master/ENVIRONMENT_VARIABLES.md
+
+    :return:
+        train_dir: training data folder,
+        model_dir: model output folder
+    """
+    parser = argparse.ArgumentParser()
+    # "train" is the name of training dataset channel specified to the fit() method on client side.
+    parser.add_argument("--train_dir", type=str, default="/opt/ml/input/data/train")
+    parser.add_argument("--model_dir", type=str, default="/opt/ml/model")
+    args = parser.parse_args()
+    return args
+
+
+def load_train_data(train_dir):
+    """
+    Load training data.
+
+    :param train_dir: Train data dir
+    :return: A tuple of (features DataFrame, label Series)
+    """
+    data_files = [os.path.join(train_dir, file) for file in os.listdir(train_dir)]
+    if len(data_files) == 0:
+        error_message = f"There are no files in {train_dir}. Please specify channel 'train' correctly."
+        logger.exception(error_message)
+        raise ValueError(error_message)
+    # assume that data files are CSV without header
+    raw_data = [pd.read_csv(file, header=None) for file in data_files]
+    train_data = pd.concat(raw_data)
+
+    # assume that the first column is the label column
+    label = train_data.iloc[:, 0]
+    features = train_data.iloc[:, 1:]
+    return features, label
+
+
+def train(features, label):
+    """
+    Train the model
+    :param features: features DataFrame
+    :param label: label Series
+    :return: The fitted estimator
+    """
+    estimator = LogisticRegression(solver="newton-cg")
+    estimator.fit(features, label)
+    return estimator
+
+
+def dump_model_file(estimator, model_dir):
+    """
+    Dump the estimator to a model file.
+    :param estimator: The fitted estimator
+    :param model_dir: Directory to store the model file
+    :return: None
+    """
+    # Note that the same model file name is used by `serve` to load the model.
+    joblib.dump(estimator, os.path.join(model_dir, "model.joblib"))
+
+
+def main():
+    args = parse_args()
+    features, label = load_train_data(args.train_dir)
+    estimator = train(features, label)
+    dump_model_file(estimator, args.model_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/sagemaker_processing/fairness_and_explainability/fairness_and_explainability_byoc.ipynb
+++ b/sagemaker_processing/fairness_and_explainability/fairness_and_explainability_byoc.ipynb
@@ -1,0 +1,1308 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Fairness and Explainability with SageMaker Clarify (Bring Your Own Container)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "1. [Overview](#Overview)\n",
+    "1. [Prerequisites and Data](#Prerequisites-and-Data)\n",
+    "    1. [Initialize SageMaker](#Initialize-SageMaker)\n",
+    "    1. [Download data](#Download-data)\n",
+    "    1. [Loading the data: Adult Dataset](#Loading-the-data:-Adult-Dataset) \n",
+    "    1. [Data inspection](#Data-inspection) \n",
+    "    1. [Encode and Upload the Dataset](#Encode-and-Upload-the-Dataset)\n",
+    "    1. [Samples for Inference](#Samples-for-Inference)\n",
+    "1. [Build Container](#Build-Container)\n",
+    "    1. [Container Source Code](#Container-Source-Code)\n",
+    "        1. [The Dockerfile](#The-Dockerfile)\n",
+    "        1. [The train Script](#The-train-Script)\n",
+    "        1. [The serve Script](#The-serve-Script)\n",
+    "    1. [Local Debugging](#Local-Debugging)\n",
+    "    1. [Build and Push](#Build-and-Push)\n",
+    "1. [Train Model](#Train-Model)\n",
+    "    1. [Train](#Train)\n",
+    "    1. [Deploy](#Deploy)\n",
+    "    1. [Verification](#Verification)\n",
+    "1. [Amazon SageMaker Clarify](Amazon-SageMaker-Clarify)\n",
+    "    1. [Detecting Bias](#Detecting-Bias)\n",
+    "        1. [Writing DataConfig](#Writing-DataConfig)\n",
+    "        1. [Writing ModelConfig](#Writing-ModelConfig)\n",
+    "        1. [Writing BiasConfig](#Writing-BiasConfig)\n",
+    "        1. [Writing ModelPredictedLabelConfig](#Writing-ModelPredictedLabelConfig)\n",
+    "        1. [Pre-training Bias](#Pre-training-Bias)\n",
+    "        1. [Post-training Bias](#Post-training-Bias)\n",
+    "        1. [Viewing the Bias Report](#Viewing-the-Bias-Report)\n",
+    "    1. [Explaining Predictions](#Explaining-Predictions)\n",
+    "        1. [Viewing the Explainability Report](#Viewing-the-Explainability-Report)\n",
+    "1. [Clean Up](#Clean-Up)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Overview\n",
+    "\n",
+    "Amazon SageMaker Clarify helps improve your machine learning models by detecting potential bias and helping explain how these models make predictions. The fairness and explainability functionality provided by SageMaker Clarify takes a step towards enabling AWS customers to build trustworthy and understandable machine learning models. The product comes with the tools to help you with the following tasks.\n",
+    "\n",
+    "* Measure biases that can occur during each stage of the ML lifecycle (data collection, model training and tuning, and monitoring of ML models deployed for inference).\n",
+    "* Generate model governance reports targeting risk and compliance teams and external regulators.\n",
+    "* Provide explanations of the data, models, and monitoring used to assess predictions.\n",
+    "\n",
+    "In order to compute post-training bias metrics and explainability, SageMaker Clarify needs to get inferences from the SageMaker model provided by the `model_name` parameter of Clarify [analysis configuration](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-configure-processing-jobs.html#clarify-processing-job-configure-analysis) (or the same parameter of the [ModelConfig](https://sagemaker.readthedocs.io/en/stable/api/training/processing.html?highlight=Processor#sagemaker.clarify.ModelConfig) if you use [SageMakerClarifyProcessor](https://sagemaker.readthedocs.io/en/stable/api/training/processing.html#sagemaker.clarify.SageMakerClarifyProcessor) API). To accomplish this, the Clarify job creates an ephemeral endpoint with the model, known as a shadow endpoint. The model and the Clarify job should follow certain contracts so that they can work together smoothly.\n",
+    "\n",
+    "This sample notebook introduces key terms and concepts needed to understand SageMaker Clarify, and it walks you through an end-to-end data science workflow demonstrating how to **build your own model and container that can work seamlessly with your Clarify jobs**, use the model and SageMaker Clarify to measure bias, explain the importance of the various input features on the model's decision and then access the reports through SageMaker Studio if you have an instance set up."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites and Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Initialize SageMaker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import json\n",
+    "import os\n",
+    "import sagemaker\n",
+    "import urllib\n",
+    "\n",
+    "session = sagemaker.Session()\n",
+    "bucket = session.default_bucket()\n",
+    "prefix = \"sagemaker/DEMO-sagemaker-clarify-byoc\"\n",
+    "\n",
+    "role = sagemaker.get_execution_role()\n",
+    "account_id = role.split(\":\")[4]\n",
+    "region = session.boto_region_name\n",
+    "if region.startswith(\"cn-\"):\n",
+    "    uri_suffix = \"amazonaws.com.cn\"\n",
+    "    arn_partition = \"aws-cn\"\n",
+    "else:\n",
+    "    uri_suffix = \"amazonaws.com\"\n",
+    "    arn_partition = \"aws\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Download data\n",
+    "Data Source: [https://archive.ics.uci.edu/ml/machine-learning-databases/adult/](https://archive.ics.uci.edu/ml/machine-learning-databases/adult/)\n",
+    "\n",
+    "Let's __download__ the data and save it in the local folder with the name adult.data and adult.test from UCI repository$^{[2]}$.\n",
+    "\n",
+    "$^{[2]}$Dua Dheeru, and Efi Karra Taniskidou. \"[UCI Machine Learning Repository](http://archive.ics.uci.edu/ml)\". Irvine, CA: University of California, School of Information and Computer Science (2017)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adult_columns = [\n",
+    "    \"Age\",\n",
+    "    \"Workclass\",\n",
+    "    \"fnlwgt\",\n",
+    "    \"Education\",\n",
+    "    \"Education-Num\",\n",
+    "    \"Marital Status\",\n",
+    "    \"Occupation\",\n",
+    "    \"Relationship\",\n",
+    "    \"Ethnic group\",\n",
+    "    \"Sex\",\n",
+    "    \"Capital Gain\",\n",
+    "    \"Capital Loss\",\n",
+    "    \"Hours per week\",\n",
+    "    \"Country\",\n",
+    "    \"Target\",\n",
+    "]\n",
+    "if not os.path.isfile(\"adult.data\"):\n",
+    "    urllib.request.urlretrieve(\n",
+    "        \"https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.data\", \"adult.data\"\n",
+    "    )\n",
+    "    print(\"adult.data saved!\")\n",
+    "else:\n",
+    "    print(\"adult.data already on disk.\")\n",
+    "\n",
+    "if not os.path.isfile(\"adult.test\"):\n",
+    "    urllib.request.urlretrieve(\n",
+    "        \"https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.test\", \"adult.test\"\n",
+    "    )\n",
+    "    print(\"adult.test saved!\")\n",
+    "else:\n",
+    "    print(\"adult.test already on disk.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Loading the data: Adult Dataset\n",
+    "From the UCI repository of machine learning datasets, this database contains 14 features concerning demographic characteristics of 45,222 rows (32,561 for training and 12,661 for testing). The task is to predict whether a person has a yearly income that is more or less than $50,000.\n",
+    "\n",
+    "Here are the features and their possible values:\n",
+    "1. **Age**: continuous.\n",
+    "1. **Workclass**: Private, Self-emp-not-inc, Self-emp-inc, Federal-gov, Local-gov, State-gov, Without-pay, Never-worked.\n",
+    "1. **Fnlwgt**: continuous (the number of people the census takers believe that observation represents).\n",
+    "1. **Education**: Bachelors, Some-college, 11th, HS-grad, Prof-school, Assoc-acdm, Assoc-voc, 9th, 7th-8th, 12th, Masters, 1st-4th, 10th, Doctorate, 5th-6th, Preschool.\n",
+    "1. **Education-num**: continuous.\n",
+    "1. **Marital-status**: Married-civ-spouse, Divorced, Never-married, Separated, Widowed, Married-spouse-absent, Married-AF-spouse.\n",
+    "1. **Occupation**: Tech-support, Craft-repair, Other-service, Sales, Exec-managerial, Prof-specialty, Handlers-cleaners, Machine-op-inspct, Adm-clerical, Farming-fishing, Transport-moving, Priv-house-serv, Protective-serv, Armed-Forces.\n",
+    "1. **Relationship**: Wife, Own-child, Husband, Not-in-family, Other-relative, Unmarried.\n",
+    "1. **Ethnic group**: White, Asian-Pac-Islander, Amer-Indian-Eskimo, Other, Black.\n",
+    "1. **Sex**: Female, Male.\n",
+    "    * **Note**: this data is extracted from the 1994 Census and enforces a binary option on Sex\n",
+    "1. **Capital-gain**: continuous.\n",
+    "1. **Capital-loss**: continuous.\n",
+    "1. **Hours-per-week**: continuous.\n",
+    "1. **Native-country**: United-States, Cambodia, England, Puerto-Rico, Canada, Germany, Outlying-US(Guam-USVI-etc), India, Japan, Greece, South, China, Cuba, Iran, Honduras, Philippines, Italy, Poland, Jamaica, Vietnam, Mexico, Portugal, Ireland, France, Dominican-Republic, Laos, Ecuador, Taiwan, Haiti, Columbia, Hungary, Guatemala, Nicaragua, Scotland, Thailand, Yugoslavia, El-Salvador, Trinadad&Tobago, Peru, Hong, Holand-Netherlands.\n",
+    "\n",
+    "Next, we specify our binary prediction task:  \n",
+    "15. **Target**: <=50,000, >$50,000."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "training_data = pd.read_csv(\n",
+    "    \"adult.data\", names=adult_columns, sep=r\"\\s*,\\s*\", engine=\"python\", na_values=\"?\"\n",
+    ").dropna()\n",
+    "\n",
+    "testing_data = pd.read_csv(\n",
+    "    \"adult.test\", names=adult_columns, sep=r\"\\s*,\\s*\", engine=\"python\", na_values=\"?\", skiprows=1\n",
+    ").dropna()\n",
+    "\n",
+    "training_data.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Data inspection\n",
+    "Plotting histograms for the distribution of the different features is a good way to visualize the data. Let's plot a few of the features that can be considered _sensitive_.  \n",
+    "Let's take a look specifically at the Sex feature of a census respondent. In the first plot we see that there are fewer Female respondents as a whole but especially in the positive outcomes, where they form ~$\\frac{1}{7}$th of respondents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "training_data[\"Sex\"].value_counts().sort_values().plot(kind=\"bar\", title=\"Counts of Sex\", rot=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "training_data[\"Sex\"].where(training_data[\"Target\"] == \">50K\").value_counts().sort_values().plot(\n",
+    "    kind=\"bar\", title=\"Counts of Sex earning >$50K\", rot=0\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Encode and Upload the Dataset\n",
+    "Here we encode the training and test data. Encoding input data is not necessary for SageMaker Clarify, but is necessary for the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn import preprocessing\n",
+    "\n",
+    "\n",
+    "def number_encode_features(df):\n",
+    "    result = df.copy()\n",
+    "    encoders = {}\n",
+    "    for column in result.columns:\n",
+    "        if result.dtypes[column] == np.object:\n",
+    "            encoders[column] = preprocessing.LabelEncoder()\n",
+    "            #  print('Column:', column, result[column])\n",
+    "            result[column] = encoders[column].fit_transform(result[column].fillna(\"None\"))\n",
+    "    return result, encoders\n",
+    "\n",
+    "\n",
+    "training_data = pd.concat([training_data[\"Target\"], training_data.drop([\"Target\"], axis=1)], axis=1)\n",
+    "training_data, _ = number_encode_features(training_data)\n",
+    "training_data.to_csv(\"train_data.csv\", index=False, header=False)\n",
+    "\n",
+    "testing_data, _ = number_encode_features(testing_data)\n",
+    "test_features = testing_data.drop([\"Target\"], axis=1)\n",
+    "test_target = testing_data[\"Target\"]\n",
+    "test_features.to_csv(\"test_features.csv\", index=False, header=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A quick note about our encoding: the \"Female\" Sex value has been encoded as 0 and \"Male\" as 1."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "training_data.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lastly, let's upload the data to S3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.s3 import S3Uploader\n",
+    "from sagemaker.inputs import TrainingInput\n",
+    "\n",
+    "train_uri = S3Uploader.upload(\"train_data.csv\", \"s3://{}/{}\".format(bucket, prefix))\n",
+    "train_input = TrainingInput(train_uri, content_type=\"csv\")\n",
+    "test_uri = S3Uploader.upload(\"test_features.csv\", \"s3://{}/{}\".format(bucket, prefix))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Samples for Inference\n",
+    "\n",
+    "Pick up some samples from the test dataset, later they will be used to test the real-time inference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample = test_features.loc[0, :].values.tolist()\n",
+    "samples = test_features.loc[0:5, :].values.tolist()\n",
+    "\n",
+    "\n",
+    "def convert_to_csv_payload(samples):\n",
+    "    return \"\\n\".join([\",\".join([str(feature) for feature in sample]) for sample in samples])\n",
+    "\n",
+    "\n",
+    "def convert_to_jsonlines_payload(samples):\n",
+    "    return \"\\n\".join(\n",
+    "        [json.dumps({\"features\": sample}, separators=(\",\", \":\")) for sample in samples]\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "command_parameters = [\n",
+    "    [\"text/csv\", convert_to_csv_payload([sample])],\n",
+    "    [\"text/csv\", convert_to_csv_payload(samples)],  # for batch request\n",
+    "    [\"application/jsonlines\", convert_to_jsonlines_payload([sample])],\n",
+    "    [\"application/jsonlines\", convert_to_jsonlines_payload(samples)],  # for batch request\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build Container\n",
+    "\n",
+    "This section introduces how to build your custom container. For simplicity, a single container is built to serve two purposes: it can be used by SageMaker Training job for training your custom model, as well as being deployed by SageMaker Hosting service for real-time inference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Container Source Code\n",
+    "\n",
+    "There are three source files in the container subfolder."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### The Dockerfile\n",
+    "\n",
+    "The Dockerfile describes the image that you want to build. You can think of it as describing the complete operating system installation of the system that you want to run. A Docker container running is quite a bit lighter than a full operating system, however, because it takes advantage of Linux on the host machine for the basic operations.\n",
+    "\n",
+    "The following Dockerfile starts from a [miniconda3 image](https://hub.docker.com/r/continuumio/miniconda3) and runs the normal tools to install `scikit-learn` and `pandas` for data science operations, and install `flask` for building a simple web application to serve real-time inference. Then it adds the code that implements the training algorithm and the real-time inference logic, and informs Docker that the container listens on the specified network ports at runtime."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!echo\n",
+    "!cat container/Dockerfile | sed 's/^/    /'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### The train Script\n",
+    "\n",
+    "The `train` script implements the training algorithm. It is packaged to docker image which will be pushed to ECR (Elastic Container Registry) under your account. When triggering a SageMaker training job, your requested SageMaker instance will pull that image from your ECR and execute it with the data you specified in an S3 URI.\n",
+    "\n",
+    "It is important to know how SageMaker runs your image. For training job, SageMaker runs your image like\n",
+    "\n",
+    "    docker run <image> train\n",
+    "\n",
+    "This is why your image needs to have the executable `train` to start the model training process. See [Use Your Own Training Algorithms\n",
+    "](https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-training-algo.html) for more explanations on how Amazon SageMaker interacts with a Docker container that runs your custom training algorithm. \n",
+    "\n",
+    "The following script does the follow steps in sequence,\n",
+    "\n",
+    "* Parses command line parameters. In training job environment, SageMaker downloads data files and save them to local directory `/opt/ml/input`. For example, if the training dataset channel specified to the fit() method on client side is `train`, then the training dataset will be saved to folder `/opt/ml/input/train`. The model output directory is always `/opt/ml/model`.\n",
+    "* Load training dataset. Here assume that the data files are in CSV format, and the first column is the label column.\n",
+    "* Train a [sklearn.linear_model.LogisticRegression](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html) estimator.\n",
+    "* Dump the estimator's model to a model file.\n",
+    "\n",
+    "The script is built from scratch for demonstration purpose, so it has to take care of many details. For example, if you want to get [hyperparameters specified on client side](https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html#sagemaker.estimator.Estimator.set_hyperparameters), then the script should be updated to read them from `/opt/ml/input/config/hyperparameters.json`. One option to get rid of the details and focus on algorithms is integrating [SageMaker Training Toolkit](https://github.com/aws/sagemaker-training-toolkit) to your image, the toolkit gives you tools to create SageMaker-compatible Docker containers, and has additional tools for letting you create Frameworks (SageMaker-compatible Docker containers that can run arbitrary Python or shell scripts)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!echo\n",
+    "!cat container/train | sed 's/^/    /'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### The serve Script\n",
+    "\n",
+    "The `serve` script implements the real-time inference logic. When SageMaker deploys your image to a real-time inference instance, it runs your image as,\n",
+    "\n",
+    "    docker run <image> serve\n",
+    "\n",
+    "The script is supposed to set up a web server that responds to `/invocations` and `/ping` on port 8080. See [Use Your Own Inference Code with Hosting Services](https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-inference-code.html) for more explanations on how Amazon SageMaker interacts with a Docker container that runs your own inference code for hosting services.\n",
+    "\n",
+    "The following script uses [flask](https://github.com/pallets/flask) to implement a simple web server,\n",
+    "\n",
+    "* At container startup, the script initializes an estimator using the model file provided by the client side deploy() method. The model directory and model file name are the same as in the `train` script.\n",
+    "* Once started, the server is ready to serve inference requests. The logic resides in the `predict` method,\n",
+    "    * Input validation. The example container supports the same MIME types as Clarify job does, i.e., `text/csv` and `application/jsonlines`.\n",
+    "    * Parse payload. Clarify job may send **batch requests** to the container for better efficiency, i.e., the payload can have multiple lines and each is a sample. So, the method decodes request payload and then split lines, then loads the lines according to the content type. For JSONLines content, the method uses a key \"features\" to extract the list of features from a JSON line. The key shall be the same as the one defined in your Clarify job analysis configuration `predictor.content_template`. It is a **contract** between the Clarify job and the container, here you can change it to something else, like \"attributes\", but remember to update the `predictor.content_template` configuration accordingly.\n",
+    "    * Do prediction. The method gets the probability scores instead of binary labels, because scores are better for feature explainability.\n",
+    "    * Format output. For a **batch request**, Clarify job expects the same number of result lines as the number of samples in the request. So, the method encodes each prediction and then join them by line-break. For JSONLines accept type, the method uses two keys \"predicted_label\" and \"score\" to indicate the prediction. The keys shall be the same as your Clarify job analysis configuration `predictor.label` and `predictor.probability`, and they are used by the Clarify job to extract predictions from container response payload. The keys are **contracts** between the Clarify job and the container, here you can change them to something else, but remember to update the analysis configuration accordingly.\n",
+    "\n",
+    "Similarly, the script is built from scratch for demonstration purpose. In a real project, you can utilize [SageMaker Inference Toolkit](https://github.com/aws/sagemaker-inference-toolkit) which implements a model serving stack built on [Multi Model Server](https://github.com/awslabs/multi-model-server), and it can serve your own models or those you trained on SageMaker using Machine Learning frameworks with native SageMaker support."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!echo\n",
+    "!cat container/serve | sed 's/^/    /'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Local Debugging\n",
+    "\n",
+    "This section has some tips for debugging the container code locally. Considering that image build, push and deployment take time to complete, it is important to first test the container code thoroughly locally to save time. (Although you can safely skip it in this exercise because the container code is already functional.)\n",
+    "\n",
+    "As an example, you can download the container folder and dataset files to your local machine, setup Python development environment and install necessary dependencies (found in the Dockerfile), then import the code to your favorite IDE for editing/debugging."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `train` script can be executed as,\n",
+    "\n",
+    "```\n",
+    "python train --train_dir <dataset folder> --model_dir <model folder>\n",
+    "```\n",
+    "\n",
+    "Upon successful execution, the script should generate a model file `model.joblib` to the model folder."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And then the `serve` script can be executed as,\n",
+    "\n",
+    "```\n",
+    "python serve --model_dir <model folder>\n",
+    "```\n",
+    "\n",
+    "Upon successful execution, the script should be listening on local host port `8080` for inference requests. The following cell generates a few CURL commands to send inference requests (both CSV and JSONLines) to the port. You can copy&paste them to your local terminal for execution, to hit the port and trigger the inference code. For a single sample request, the command should output only one result, and for a batch request, the command should output the same number of results (lines) as the number of samples in the request."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"\\n\")\n",
+    "for mime_type, payload in command_parameters:\n",
+    "    command = f\"    curl -X POST -H 'Content-Type: {mime_type}' -H 'Accept: {mime_type}' -d ${repr(payload)} http://0.0.0.0:8080/invocations\"\n",
+    "    print(command)\n",
+    "    print(\"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you have Docker installed locally, you can build image like this (the -t option specifies image repository and tag),\n",
+    "\n",
+    "```\n",
+    "docker build container -t bring-your-own-container:latest\n",
+    "```\n",
+    "\n",
+    "Then run the image for training (the -v option maps a folder of your local machine to the docker container),\n",
+    "\n",
+    "```\n",
+    "docker run -v /Local/Machine/Folder:/BYOC bring-your-own-container:latest train --train_dir /BYOC/dataset --model_dir /BYOC/model\n",
+    "```\n",
+    "\n",
+    "And then run it for inferring (the -p option maps a local machine port to the docker container),\n",
+    "\n",
+    "```\n",
+    "docker run -v /Local/Machine/Folder:/BYOC -p 8080:8080 bring-your-own-container:latest serve --model_dir /BYOC/model\n",
+    "```\n",
+    "\n",
+    "The docker image can be pushed to ECR manually, see [Building your own algorithm container](https://github.com/aws/amazon-sagemaker-examples/blob/master/advanced_functionality/scikit_bring_your_own/scikit_bring_your_own.ipynb) for more details."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Build and Push\n",
+    "\n",
+    "To avoid manual operations in your local development environment. This notebook will use [SageMaker Docker Build CLI](https://github.com/aws-samples/sagemaker-studio-image-build-cli) to automatically build and push the container to ECR for you. The tool uses ECR and AWS CodeBuild, so it requires that the role to execute the tool has the necessary policies and permissions attached. For simplicity, you can update the SageMaker Execution Role attached to this notebook with the required permissions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "role"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Ensure that the role has the following permissions before you continue!**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Add or merge below policy to the Trust relationships of the role\n",
+    "\n",
+    "```\n",
+    "{\n",
+    "    \"Version\": \"2012-10-17\",\n",
+    "    \"Statement\": [\n",
+    "        {\n",
+    "            \"Effect\": \"Allow\",\n",
+    "            \"Principal\": {\n",
+    "                \"Service\": [\n",
+    "                    \"codebuild.amazonaws.com\"\n",
+    "                ]\n",
+    "            },\n",
+    "            \"Action\": \"sts:AssumeRole\"\n",
+    "        }\n",
+    "    ]\n",
+    "}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Add an inline policy to the role (execute the cell below to view the policy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from string import Template\n",
+    "\n",
+    "template = Template(\n",
+    "    \"\"\"{\n",
+    "    \"Version\": \"2012-10-17\",\n",
+    "    \"Statement\": [\n",
+    "        {\n",
+    "            \"Effect\": \"Allow\",\n",
+    "            \"Action\": [\n",
+    "                \"codebuild:DeleteProject\",\n",
+    "                \"codebuild:CreateProject\",\n",
+    "                \"codebuild:BatchGetBuilds\",\n",
+    "                \"codebuild:StartBuild\"\n",
+    "            ],\n",
+    "            \"Resource\": \"arn:$partition:codebuild:*:*:project/sagemaker-studio*\"\n",
+    "        },\n",
+    "        {\n",
+    "            \"Effect\": \"Allow\",\n",
+    "            \"Action\": \"logs:CreateLogStream\",\n",
+    "            \"Resource\": \"arn:$partition:logs:*:*:log-group:/aws/codebuild/sagemaker-studio*\"\n",
+    "        },\n",
+    "        {\n",
+    "            \"Effect\": \"Allow\",\n",
+    "            \"Action\": [\n",
+    "                \"logs:GetLogEvents\",\n",
+    "                \"logs:PutLogEvents\"\n",
+    "            ],\n",
+    "            \"Resource\": \"arn:$partition:logs:*:*:log-group:/aws/codebuild/sagemaker-studio*:log-stream:*\"\n",
+    "        },\n",
+    "        {\n",
+    "            \"Effect\": \"Allow\",\n",
+    "            \"Action\": \"logs:CreateLogGroup\",\n",
+    "            \"Resource\": \"*\"\n",
+    "        },\n",
+    "        {\n",
+    "            \"Effect\": \"Allow\",\n",
+    "            \"Action\": [\n",
+    "                \"ecr:CreateRepository\",\n",
+    "                \"ecr:BatchGetImage\",\n",
+    "                \"ecr:CompleteLayerUpload\",\n",
+    "                \"ecr:DescribeImages\",\n",
+    "                \"ecr:DescribeRepositories\",\n",
+    "                \"ecr:UploadLayerPart\",\n",
+    "                \"ecr:ListImages\",\n",
+    "                \"ecr:InitiateLayerUpload\",\n",
+    "                \"ecr:BatchCheckLayerAvailability\",\n",
+    "                \"ecr:PutImage\"\n",
+    "            ],\n",
+    "            \"Resource\": \"arn:$partition:ecr:*:*:repository/sagemaker-studio*\"\n",
+    "        },\n",
+    "        {\n",
+    "            \"Effect\": \"Allow\",\n",
+    "            \"Action\": \"ecr:GetAuthorizationToken\",\n",
+    "            \"Resource\": \"*\"\n",
+    "        },\n",
+    "        {\n",
+    "            \"Effect\": \"Allow\",\n",
+    "            \"Action\": [\n",
+    "                \"s3:GetObject\",\n",
+    "                \"s3:DeleteObject\",\n",
+    "                \"s3:PutObject\"\n",
+    "            ],\n",
+    "            \"Resource\": \"arn:$partition:s3:::sagemaker-*/*\"\n",
+    "        },\n",
+    "        {\n",
+    "            \"Effect\": \"Allow\",\n",
+    "            \"Action\": [\n",
+    "                \"s3:CreateBucket\"\n",
+    "            ],\n",
+    "            \"Resource\": \"arn:$partition:s3:::sagemaker*\"\n",
+    "        },\n",
+    "        {\n",
+    "            \"Effect\": \"Allow\",\n",
+    "            \"Action\": [\n",
+    "                \"iam:GetRole\",\n",
+    "                \"iam:ListRoles\"\n",
+    "            ],\n",
+    "            \"Resource\": \"*\"\n",
+    "        },\n",
+    "        {\n",
+    "            \"Effect\": \"Allow\",\n",
+    "            \"Action\": \"iam:PassRole\",\n",
+    "            \"Resource\": \"arn:$partition:iam::*:role/*\",\n",
+    "            \"Condition\": {\n",
+    "                \"StringLikeIfExists\": {\n",
+    "                    \"iam:PassedToService\": \"codebuild.amazonaws.com\"\n",
+    "                }\n",
+    "            }\n",
+    "        }\n",
+    "    ]\n",
+    "}\"\"\"\n",
+    ")\n",
+    "permissions_policy = template.substitute(partition=arn_partition)\n",
+    "print(permissions_policy)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once the permissions are attached to the role, install the tool by,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install sagemaker-studio-image-build --quiet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now define the ECR repository and tag, note that **the repository name must have the prefix sagemaker-studio** which is covered by above permissions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "byoc_repository = \"sagemaker-studio-byoc\"\n",
+    "byoc_tag = \"latest\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then the build and push can be done by a single command,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!sm-docker build container --repository $byoc_repository:$byoc_tag --no-logs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The command should have pushed the image to below URI,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "byoc_image_uri = \"{}.dkr.ecr.{}.{}/{}:{}\".format(\n",
+    "    account_id, region, uri_suffix, byoc_repository, byoc_tag\n",
+    ")\n",
+    "print(f\"Image URI: {byoc_image_uri}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Train\n",
+    "\n",
+    "Now you have a docker image that includes the logic of your model training, and the training data are available to SageMaker on S3. It is high time to train the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "estimator = sagemaker.estimator.Estimator(\n",
+    "    image_uri=byoc_image_uri,\n",
+    "    role=role,\n",
+    "    instance_count=1,\n",
+    "    instance_type=\"ml.m5.xlarge\",\n",
+    "    sagemaker_session=session,\n",
+    ")\n",
+    "estimator.fit({\"train\": train_input}, logs=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The trained model should have been uploaded to S3 as,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Model file: {estimator.model_data}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Deploy\n",
+    "\n",
+    "The model file should be deployed as a SageMaker Model which can be used in Clarify post-training bias analysis and feature explanation. The following code creates the model, and then deploys it to an inference host/endpoint for verification."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "endpoint_name = \"DEMO-clarify-byoc-endpoint\"\n",
+    "model_name = \"DEMO-clarify-byoc-model\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictor = estimator.deploy(\n",
+    "    initial_instance_count=1,\n",
+    "    instance_type=\"ml.m5.xlarge\",\n",
+    "    endpoint_name=endpoint_name,\n",
+    "    model_name=model_name,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Verification\n",
+    "\n",
+    "A verification is necessary to make sure that the custom model and container follow the contracts with your Clarify jobs. The [AWS CLI](https://aws.amazon.com/cli/) tool is recommended for the test, it is preinstalled in SageMaker Studio and can be used to invoke the endpoint directly with raw payload, avoid intermediate processing steps in wrapper APIs like the [SageMaker Python SDK Predictor class](https://sagemaker.readthedocs.io/en/stable/api/inference/predictors.html).\n",
+    "\n",
+    "The following code generates a few AWS CLI commands to send inference requests to the endpoint, and also executes them in the notebook to get the results. You can copy&paste the commands to a Studio Terminal (File > New > Terminal), or to your local terminal, for execution and double-check the results. You can see, for a single sample request, the command outputs only one result, and for a batch request, the command outputs the same number of results (lines) as the number of samples in the request.\n",
+    "\n",
+    "Some tips:\n",
+    "* If you use AWS CLI v2, then an additional parameter `--cli-binary-format raw-in-base64-out` should be added to the command. See [cli_binary_format](https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-cli_binary_format.html#setting-cli_binary_format-alternatives) for the reason.\n",
+    "* To send batch requests, add `$` before the payload (`--body`) string to unescape the line-break character ('\\n')."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import subprocess\n",
+    "import re\n",
+    "\n",
+    "aws_cli_version = subprocess.run([\"aws\", \"--version\"], capture_output=True, text=True).stdout\n",
+    "aws_cli_major_version = re.match(\"aws-cli/(\\d+).+\", aws_cli_version).group(1)\n",
+    "\n",
+    "if aws_cli_major_version == \"1\":\n",
+    "    cli_binary_format = \"\"\n",
+    "else:\n",
+    "    # https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-cli_binary_format.html\n",
+    "    cli_binary_format = \"--cli-binary-format raw-in-base64-out\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from string import Template\n",
+    "\n",
+    "for mime_type, payload in command_parameters:\n",
+    "    template = Template(\n",
+    "        f\"aws sagemaker-runtime invoke-endpoint --endpoint-name {endpoint_name} --content-type {mime_type} --accept {mime_type} --body $payload {cli_binary_format} /dev/stderr 1>/dev/null\"\n",
+    "    )\n",
+    "    command = template.substitute(payload=f\"${repr(payload)}\")\n",
+    "    print(command)\n",
+    "    command = template.substitute(payload=f\"'{payload}'\")\n",
+    "    output = subprocess.run(command, shell=True, capture_output=True, text=True).stderr\n",
+    "    print(output)\n",
+    "    print(\"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once the verification is done, you can delete endpoint, but keep the model for Clarify jobs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictor.delete_endpoint()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Amazon SageMaker Clarify\n",
+    "\n",
+    "Now that you have your own model and container set up. Let's say hello to SageMaker Clarify!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker import clarify\n",
+    "\n",
+    "clarify_processor = clarify.SageMakerClarifyProcessor(\n",
+    "    role=role, instance_count=1, instance_type=\"ml.m5.xlarge\", sagemaker_session=session\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are three scenarios where Clarify handles data types, and they all support both CSV (`text/csv`) and JSONLines (`application/jsonlines`).\n",
+    "\n",
+    "* dataset type: the MIME type of the dataset and SHAP baseline.\n",
+    "* content type: the MIME type of the shadow endpoint request payload\n",
+    "* accept type: the MIME type of the shadow endpoint response payload\n",
+    "\n",
+    "The Clarify jobs in this notebook always uses CSV for dataset type, but you can choose for the other two. The following code chose JSONLines for both, but it is fine if you change one of them or both of them to CSV, because CSV and JSONLines are supported by the customer container as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "content_type = \"application/jsonlines\"  # could be 'text/csv'\n",
+    "accept_type = \"application/jsonlines\"  # could be 'text/csv'\n",
+    "\n",
+    "if content_type == \"text/csv\":\n",
+    "    content_template = None\n",
+    "else:  # 'application/jsonlines'\n",
+    "    content_template = '{\"features\":$features}'\n",
+    "\n",
+    "probability_threshold = 0.4\n",
+    "if accept_type == \"text/csv\":\n",
+    "    probability = None\n",
+    "else:  # 'application/jsonlines'\n",
+    "    probability = \"score\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Detecting Bias\n",
+    "\n",
+    "SageMaker Clarify helps you detect possible pre- and post-training biases using a variety of metrics.\n",
+    "\n",
+    "#### Writing DataConfig\n",
+    "\n",
+    "A [DataConfig](https://sagemaker.readthedocs.io/en/stable/api/training/processing.html#sagemaker.clarify.DataConfig) object communicates some basic information about data I/O to SageMaker Clarify. We specify where to find the input dataset, where to store the output, the target column (`label`), the header names, and the dataset type."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bias_report_output_path = \"s3://{}/{}/clarify-bias\".format(bucket, prefix)\n",
+    "bias_data_config = clarify.DataConfig(\n",
+    "    s3_data_input_path=train_uri,\n",
+    "    s3_output_path=bias_report_output_path,\n",
+    "    label=\"Target\",\n",
+    "    headers=training_data.columns.to_list(),\n",
+    "    dataset_type=\"text/csv\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Writing ModelConfig\n",
+    "\n",
+    "A [ModelConfig](https://sagemaker.readthedocs.io/en/stable/api/training/processing.html#sagemaker.clarify.ModelConfig) object communicates information about your trained model. To avoid additional traffic to your production models, SageMaker Clarify sets up and tears down a dedicated endpoint when processing.\n",
+    "* `instance_type` and `instance_count` specify your preferred instance type and instance count used to run your model on during SageMaker Clarify's processing. The testing dataset is small so a single standard instance is good enough to run this example. If you have a large complex dataset, you may want to use a better instance type to speed up, or add more instances to enable Spark parallelization.\n",
+    "* `accept_type` denotes the endpoint response payload format, and `content_type` denotes the payload format of request to the endpoint.\n",
+    "* `content_template` is used by SageMaker Clarify to compose the request payload if the content type is JSONLines. To be more specific, the placeholder `$features` will be replaced by the features list from samples. For example, the first sample of the test dataset is `25,2,226802,1,7,4,6,3,2,1,0,0,40,37`, so the corresponding request payload is `'{\"features\":[25,2,226802,1,7,4,6,3,2,1,0,0,40,37]}'`, which conforms to [SageMaker JSONLines dense format](https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-inference.html#common-in-formats)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_config = clarify.ModelConfig(\n",
+    "    model_name=model_name,\n",
+    "    instance_type=\"ml.m5.xlarge\",\n",
+    "    instance_count=1,\n",
+    "    accept_type=accept_type,\n",
+    "    content_type=content_type,\n",
+    "    content_template=content_template,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Writing ModelPredictedLabelConfig\n",
+    "\n",
+    "A [ModelPredictedLabelConfig](https://sagemaker.readthedocs.io/en/stable/api/training/processing.html#sagemaker.clarify.ModelPredictedLabelConfig) provides information on the format of your predictions.\n",
+    "* `probability` is used by SageMaker Clarify to locate the probability score in endpoint response if the accept type is JSONLines. In this case, the response payload for a single sample request looks like `'{\"predicted_label\": 0, \"score\": 0.026494730307781475}'`, so SageMaker Clarify can find the score `0.026494730307781475` by JSONPath `'score'`.\n",
+    "* `probability_threshold` is used by SageMaker Clarify to convert the probability to binary labels for bias analysis. Prediction above the threshold is interpreted as label value 1 and below or equal as label value 0."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictions_config = clarify.ModelPredictedLabelConfig(\n",
+    "    probability=probability, probability_threshold=probability_threshold\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Writing BiasConfig\n",
+    "SageMaker Clarify also needs information on what the sensitive columns (`facets`) are, what the sensitive features (`facet_values_or_threshold`) may be, and what the desirable outcomes are (`label_values_or_threshold`).\n",
+    "SageMaker Clarify can handle both categorical and continuous data for `facet_values_or_threshold` and for `label_values_or_threshold`. In this case we are using categorical data.\n",
+    "\n",
+    "We specify this information in the [BiasConfig](https://sagemaker.readthedocs.io/en/stable/api/training/processing.html#sagemaker.clarify.BiasConfig) API. Here that the positive outcome is earning >$50,000, Sex is a sensitive category, and Female respondents are the sensitive group. `group_name` is used to form subgroups for the measurement of Conditional Demographic Disparity in Labels (CDDL) and Conditional Demographic Disparity in Predicted Labels (CDDPL) with regard to Simpson’s paradox."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bias_config = clarify.BiasConfig(\n",
+    "    label_values_or_threshold=[1], facet_name=\"Sex\", facet_values_or_threshold=[0], group_name=\"Age\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Pre-training Bias\n",
+    "Bias can be present in your data before any model training occurs. Inspecting your data for bias before training begins can help detect any data collection gaps, inform your feature engineering, and help you understand what societal biases the data may reflect.\n",
+    "\n",
+    "Computing pre-training bias metrics does not require a trained model.\n",
+    "\n",
+    "#### Post-training Bias\n",
+    "Computing post-training bias metrics does require a trained model.\n",
+    "\n",
+    "Unbiased training data (as determined by concepts of fairness measured by bias metric) may still result in biased model predictions after training. Whether this occurs depends on several factors including hyperparameter choices.\n",
+    "\n",
+    "\n",
+    "You can run these options separately with `run_pre_training_bias()` and `run_post_training_bias()` or at the same time with `run_bias()` as shown below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clarify_processor.run_bias(\n",
+    "    data_config=bias_data_config,\n",
+    "    bias_config=bias_config,\n",
+    "    model_config=model_config,\n",
+    "    model_predicted_label_config=predictions_config,\n",
+    "    pre_training_methods=\"all\",\n",
+    "    post_training_methods=\"all\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Viewing the Bias Report\n",
+    "In Studio, you can view the results under the experiments tab.\n",
+    "\n",
+    "<img src=\"./recordings/bias_report.gif\">\n",
+    "\n",
+    "Each bias metric has detailed explanations with examples that you can explore.\n",
+    "\n",
+    "<img src=\"./recordings/bias_detail.gif\">\n",
+    "\n",
+    "You could also summarize the results in a handy table!\n",
+    "\n",
+    "<img src=\"./recordings/bias_report_chart.gif\">\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you're not a Studio user yet, you can access the bias report in pdf, html and ipynb formats in the following S3 bucket:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bias_report_output_path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For example, you can download a copy of the html report and view it in-place,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!aws s3 cp {bias_report_output_path}/report.html ./bias-report.html"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import IPython\n",
+    "\n",
+    "IPython.display.HTML(filename=\"bias-report.html\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Explaining Predictions\n",
+    "There are expanding business needs and legislative regulations that require explanations of _why_ a model made the decision it did. SageMaker Clarify uses SHAP to explain the contribution that each input feature makes to the final decision."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Kernel SHAP algorithm requires a baseline (also known as background dataset). Baseline dataset type shall be the same as `dataset_type` of `DataConfig`, and baseline samples shall only include features. By definition, `baseline` should either be a S3 URI to the baseline dataset file, or an in-place list of samples. In this case we chose the latter, and put the first sample of the test dataset to the list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shap_config = clarify.SHAPConfig(\n",
+    "    baseline=[test_features.iloc[0].values.tolist()],\n",
+    "    num_samples=15,\n",
+    "    agg_method=\"mean_abs\",\n",
+    "    save_local_shap_values=False,\n",
+    ")\n",
+    "\n",
+    "explainability_output_path = \"s3://{}/{}/clarify-explainability\".format(bucket, prefix)\n",
+    "explainability_data_config = clarify.DataConfig(\n",
+    "    s3_data_input_path=train_uri,\n",
+    "    s3_output_path=explainability_output_path,\n",
+    "    label=\"Target\",\n",
+    "    headers=training_data.columns.to_list(),\n",
+    "    dataset_type=\"text/csv\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clarify_processor.run_explainability(\n",
+    "    data_config=explainability_data_config,\n",
+    "    model_config=model_config,\n",
+    "    explainability_config=shap_config,\n",
+    "    model_scores=probability,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Viewing the Explainability Report\n",
+    "As with the bias report, you can view the explainability report in Studio under the experiments tab\n",
+    "\n",
+    "\n",
+    "<img src=\"./recordings/explainability_detail.gif\">\n",
+    "\n",
+    "The Model Insights tab contains direct links to the report and model insights."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you're not a Studio user yet, as with the Bias Report, you can access this report at the following S3 bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "explainability_output_path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For example, you can download a copy of the html report and view it in-place,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!aws s3 cp {explainability_output_path}/report.html ./explainability-report.html"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import IPython\n",
+    "\n",
+    "IPython.display.HTML(filename=\"explainability-report.html\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Clean Up\n",
+    "Finally, don't forget to clean up the resources we set up and used for this demo!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "session.delete_model(model_name)"
+   ]
+  }
+ ],
+ "metadata": {
+  "instance_type": "ml.t3.medium",
+  "kernelspec": {
+   "display_name": "Python 3 (Data Science)",
+   "language": "python",
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/datascience-1.0"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/sagemaker_processing/index.rst
+++ b/sagemaker_processing/index.rst
@@ -11,3 +11,4 @@ Processing
    spark_distributed_data_processing/sagemaker-spark-processing
    fairness_and_explainability/fairness_and_explainability
    fairness_and_explainability/fairness_and_explainability_jsonlines_format
+   fairness_and_explainability/fairness_and_explainability_byoc


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

As indicated from customer feedback, a customer pain-point of using SageMaker Clarify is how to properly connect SageMaker Clarify jobs with their own containers. Without fully understanding the contracts between them, it is time-consuming for customers to run Clarify job successfully by trial-and-error. This commit adds a new notebook to demonstrate how to build a custom container that can work seamlessly with SageMaker Clarify jobs. Hope this can settle customers' doubts.

**Testing Done**

* Tested the new notebook by manual full-run in us-west-2 and us-east-1.
* Built doc locally and checked that the new notebook shows up in the "Processing" page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
