### PR TITLE
Update hpo_mxnet_mnist.ipynb to SageMaker SDK v2

### DIFF
--- a/hyperparameter_tuning/mxnet_mnist/hpo_mxnet_mnist.ipynb
+++ b/hyperparameter_tuning/mxnet_mnist/hpo_mxnet_mnist.ipynb
@@ -146,8 +146,8 @@
    "source": [
     "estimator = MXNet(entry_point='mnist.py',\n",
     "                  role=role,\n",
-    "                  train_instance_count=1,\n",
-    "                  train_instance_type='ml.m4.xlarge',\n",
+    "                  instance_count=1,\n",
+    "                  instance_type='ml.m4.xlarge',\n",
     "                  sagemaker_session=sagemaker.Session(),\n",
     "                  py_version='py3',\n",
     "                  framework_version='1.4.1',\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Notebooks needed updates to be compatible with the v2 of the SageMaker SDK, which is the new Default SDK version in SageMaker.

Use `instance_count`, and `instance_type` instead of `train_instance_count`, and `train_instance_type`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
