### PR TITLE
Change Neural Topic Modeling minimum document frequency to 2

### DIFF
--- a/introduction_to_applying_machine_learning/ntm_20newsgroups_topic_modeling/ntm_20newsgroups_topic_model.ipynb
+++ b/introduction_to_applying_machine_learning/ntm_20newsgroups_topic_modeling/ntm_20newsgroups_topic_model.ipynb
@@ -261,7 +261,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "With the tokenizer defined we perform token counting next while limiting the vocabulary size to `vocab_size`"
+    "With the tokenizer defined we perform token counting next while limiting the vocabulary size to `vocab_size`. Use a maximum document frequency of 95% of documents (`max_df=0.95`) and a minimum document frequency of 2 documents (`min_df=2`)."
    ]
   },
   {
@@ -279,7 +279,7 @@
     "print('Tokenizing and counting, this may take a few minutes...')\n",
     "start_time = time.time()\n",
     "vectorizer = CountVectorizer(input='content', analyzer='word', stop_words='english',\n",
-    "                             tokenizer=LemmaTokenizer(), max_features=vocab_size, max_df=0.95, min_df=0.2)\n",
+    "                             tokenizer=LemmaTokenizer(), max_features=vocab_size, max_df=0.95, min_df=2)\n",
     "vectors = vectorizer.fit_transform(data)\n",
     "vocab_list = vectorizer.get_feature_names()\n",
     "print('vocab size:', len(vocab_list))\n",


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-sagemaker-examples/issues/2107

*Description of changes:* Reset NTM minimum document frequency to 2 occurrences.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
