### PR TITLE
Updated keras_pipe_mode_horovod_cifar10.ipynb to SageMaker SDK v2

### DIFF
--- a/aws_sagemaker_studio/frameworks/keras_pipe_mode_horovod/keras_pipe_mode_horovod_cifar10.ipynb
+++ b/aws_sagemaker_studio/frameworks/keras_pipe_mode_horovod/keras_pipe_mode_horovod_cifar10.ipynb
@@ -557,21 +557,21 @@
  "metadata": {
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (TensorFlow CPU Optimized)",
+   "display_name": "conda_tensorflow_p27",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/tensorflow-1.15-cpu-py36"
+   "name": "conda_tensorflow_p27"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.16"
   },
   "notice": "Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved. Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.",
   "pycharm": {

--- a/aws_sagemaker_studio/frameworks/keras_pipe_mode_horovod/keras_pipe_mode_horovod_cifar10.ipynb
+++ b/aws_sagemaker_studio/frameworks/keras_pipe_mode_horovod/keras_pipe_mode_horovod_cifar10.ipynb
@@ -177,8 +177,8 @@
     "                       role=role,\n",
     "                       framework_version='1.15.2',\n",
     "                       py_version='py3',\n",
-    "                       train_instance_count=1,\n",
-    "                       train_instance_type='ml.p3.2xlarge',\n",
+    "                       instance_count=1,\n",
+    "                       instance_type='ml.p3.2xlarge',\n",
     "                       base_job_name='cifar10-tf',\n",
     "                       tags=tags)"
    ]
@@ -279,8 +279,8 @@
     "                                 role=role,\n",
     "                                 framework_version='1.15.2',\n",
     "                                 py_version='py3',\n",
-    "                                 train_instance_count=1,\n",
-    "                                 train_instance_type='ml.p3.2xlarge',\n",
+    "                                 instance_count=1,\n",
+    "                                 instance_type='ml.p3.2xlarge',\n",
     "                                 input_mode='Pipe',\n",
     "                                 base_job_name='cifar10-tf-pipe',\n",
     "                                 tags=tags)"
@@ -368,12 +368,12 @@
     "                            source_dir='source',\n",
     "                            metric_definitions=metric_definitions,\n",
     "                            hyperparameters=hyperparameters,\n",
-    "                            distributions=distribution,\n",
+    "                            distribution=distribution,\n",
     "                            role=role,\n",
     "                            framework_version='1.15.2',\n",
     "                            py_version='py3',\n",
-    "                            train_instance_count=2,\n",
-    "                            train_instance_type='ml.p3.2xlarge',\n",
+    "                            instance_count=2,\n",
+    "                            instance_type='ml.p3.2xlarge',\n",
     "                            base_job_name='cifar10-tf-dist',\n",
     "                            tags=tags)"
    ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Notebooks needed updates to be compatible with the v2 of the SageMaker SDK, which is the new Default SDK version in SageMaker.

Fixed:
Use `instance_count`, `distribution` and `instance_type` instead of `train_instance_count`, `distributions` and `train_instance_type`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
