### PR TITLE
Update hpo_image_classification_early_stopping.ipynb to SageMaker SDK v2

### DIFF
--- a/hyperparameter_tuning/image_classification_early_stopping/hpo_image_classification_early_stopping.ipynb
+++ b/hyperparameter_tuning/image_classification_early_stopping/hpo_image_classification_early_stopping.ipynb
@@ -57,13 +57,14 @@
    "source": [
     "import boto3\n",
     "from sagemaker import get_execution_role\n",
-    "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
+    "from sagemaker.image_uris import retrieve\n",
     "\n",
     "role = get_execution_role()\n",
     "\n",
     "bucket = '<<bucket-name>>' # customize to your bucket\n",
     "\n",
-    "training_image = get_image_uri(boto3.Session().region_name, 'image-classification')"
+    "training_image = retrieve('image-classification', boto3.Session().region_name, '1')\n",
+    "print(training_image)"
    ]
   },
   {
@@ -146,8 +147,8 @@
     "s3_output_key = \"image-classification-full-training/output\"\n",
     "s3_output = 's3://{}/{}/'.format(bucket, s3_output_key)\n",
     "\n",
-    "s3_input_train = sagemaker.s3_input(s3_data=s3_train_data, content_type='application/x-recordio')\n",
-    "s3_input_validation = sagemaker.s3_input(s3_data=s3_validation_data, content_type='application/x-recordio')"
+    "s3_input_train = sagemaker.TrainingInput(s3_data=s3_train_data, content_type='application/x-recordio')\n",
+    "s3_input_validation = sagemaker.TrainingInput(s3_data=s3_validation_data, content_type='application/x-recordio')"
    ]
   },
   {
@@ -159,8 +160,8 @@
     "sess = sagemaker.Session()\n",
     "imageclassification = sagemaker.estimator.Estimator(training_image, \n",
     "                                                    role, \n",
-    "                                                    train_instance_count=1,\n",
-    "                                                    train_instance_type='ml.p3.2xlarge',\n",
+    "                                                    instance_count=1,\n",
+    "                                                    instance_type='ml.p3.2xlarge',\n",
     "                                                    output_path=s3_output, \n",
     "                                                    sagemaker_session=sess)\n",
     "\n",
@@ -374,7 +375,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,

--- a/hyperparameter_tuning/image_classification_early_stopping/hpo_image_classification_early_stopping.ipynb
+++ b/hyperparameter_tuning/image_classification_early_stopping/hpo_image_classification_early_stopping.ipynb
@@ -56,12 +56,14 @@
    "outputs": [],
    "source": [
     "import boto3\n",
+    "import sagemaker\n",
     "from sagemaker import get_execution_role\n",
     "from sagemaker.image_uris import retrieve\n",
     "\n",
+    "sess = sagemaker.Session()\n",
     "role = get_execution_role()\n",
     "\n",
-    "bucket = '<<bucket-name>>' # customize to your bucket\n",
+    "bucket=sess.default_bucket()\n",
     "\n",
     "training_image = retrieve('image-classification', boto3.Session().region_name, '1')\n",
     "print(training_image)"
@@ -139,8 +141,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sagemaker\n",
-    "\n",
     "s3_train_data = 's3://{}/{}/'.format(bucket, s3_train_key)\n",
     "s3_validation_data = 's3://{}/{}/'.format(bucket, s3_validation_key)\n",
     "\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Notebooks needed updates to be compatible with the v2 of the SageMaker SDK, which is the new Default SDK version in SageMaker.

Use `instance_count`, `instance_type`, `TrainingInput`, and `retrieve` instead of `train_instance_count`, `train_instance_type`, `s3_input`, and `get_image_uri`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
