### PR TITLE
fix: xgboost model using EI although not supported

### DIFF
--- a/sagemaker-pipelines/tabular/abalone_build_train_deploy/sagemaker-pipelines-preprocess-train-evaluate-batch-transform.ipynb
+++ b/sagemaker-pipelines/tabular/abalone_build_train_deploy/sagemaker-pipelines-preprocess-train-evaluate-batch-transform.ipynb
@@ -733,7 +733,6 @@
     "\n",
     "inputs = CreateModelInput(\n",
     "    instance_type=\"ml.m5.large\",\n",
-    "    accelerator_type=\"ml.eia1.medium\",\n",
     ")\n",
     "step_create_model = CreateModelStep(\n",
     "    name=\"AbaloneCreateModel\",\n",


### PR DESCRIPTION
in this example the xgboost model was created for batch transform with an accelerator defined although this is not supported by the algorithm. 
It is not failing however, it is misleading. 
According to this: https://docs.aws.amazon.com/sagemaker/latest/dg/ei.html
as well as this: https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/xgboost/model.py#L136 
we can deduce that ei accelerators are not supported by xgboost models


*Description of changes:*
deleted the addition of "accelerator_type" parameter for model definition

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
