### PR TITLE
Bugfix to make 'SAMPLE_ONLY = False' work

### DIFF
--- a/introduction_to_amazon_algorithms/object_detection_birds/object_detection_birds.ipynb
+++ b/introduction_to_amazon_algorithms/object_detection_birds/object_detection_birds.ipynb
@@ -246,12 +246,13 @@
     "SIZE_FILE    = BASE_DIR + 'sizes.txt'\n",
     "SPLIT_FILE   = BASE_DIR + 'train_test_split.txt'\n",
     "\n",
-    "TRAIN_LST_FILE = 'birds_ssd_train.lst'\n",
-    "VAL_LST_FILE   = 'birds_ssd_val.lst'\n",
+    "LST_FILE_PRE = 'birds_ssd'\n",
     "\n",
     "if (SAMPLE_ONLY):\n",
-    "    TRAIN_LST_FILE = 'birds_ssd_sample_train.lst'\n",
-    "    VAL_LST_FILE   = 'birds_ssd_sample_val.lst'\n",
+    "    LST_FILE_PRE = 'birds_ssd_sample'\n",
+    "    \n",
+    "TRAIN_LST_FILE = LST_FILE_PRE + '_train.lst'\n",
+    "VAL_LST_FILE   = LST_FILE_PRE + '_val.lst'\n",
     "\n",
     "TRAIN_RATIO     = 0.8\n",
     "CLASS_COLS      = ['class_number','class_id']\n",
@@ -559,7 +560,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python tools/im2rec.py --resize $RESIZE_SIZE --pack-label birds_ssd_sample $BASE_DIR/images/"
+    "!python tools/im2rec.py --resize $RESIZE_SIZE --pack-label $LST_FILE_PRE $BASE_DIR/images/"
    ]
   },
   {
@@ -580,8 +581,8 @@
     "train_channel = prefix + '/train'\n",
     "validation_channel = prefix + '/validation'\n",
     "\n",
-    "sess.upload_data(path='birds_ssd_sample_train.rec', bucket=bucket, key_prefix=train_channel)\n",
-    "sess.upload_data(path='birds_ssd_sample_val.rec', bucket=bucket, key_prefix=validation_channel)\n",
+    "sess.upload_data(path=LST_FILE_PRE+'_train.rec', bucket=bucket, key_prefix=train_channel)\n",
+    "sess.upload_data(path=LST_FILE_PRE+'_val.rec', bucket=bucket, key_prefix=validation_channel)\n",
     "\n",
     "s3_train_data = 's3://{}/{}'.format(bucket, train_channel)\n",
     "s3_validation_data = 's3://{}/{}'.format(bucket, validation_channel)"
@@ -1220,7 +1221,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:* Running the notebook as given does not work if "SAMPLE_ONLY = False" is set. Added a variable "LST_FILE_PRE" as LST file prefix that is used to setup the LST file variables and also when creating/using RecordIO files


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
