### PR TITLE
Use SageMaker-hosted fashion-MNIST dataset

### DIFF
--- a/sagemaker-experiments/track-an-airflow-workflow/track-an-airflow-workflow.ipynb
+++ b/sagemaker-experiments/track-an-airflow-workflow/track-an-airflow-workflow.ipynb
@@ -82,6 +82,7 @@
     "import tensorflow as tf\n",
     "import numpy as np\n",
     "import pandas as pd\n",
+    "import gzip\n",
     "\n",
     "from model import get_model\n",
     "\n",
@@ -145,8 +146,16 @@
    "outputs": [],
    "source": [
     "# download the fashion-mnist dataset\n",
-    "# the dataset will be downloaded to ~/.keras/datasets/fashion-mnist/\n",
-    "(x_train, y_train), (x_test, y_test) = tf.keras.datasets.fashion_mnist.load_data()"
+    "# the dataset will be downloaded to ~/.datasets/\n",
+    "!aws s3 sync s3://sagemaker-sample-files/datasets/image/fashion-MNIST/ ~/.datasets/fashion-mnist/\n",
+    "with gzip.open(os.path.expanduser('~/.datasets/fashion-mnist/train-labels-idx1-ubyte.gz'), 'rb') as y_train_path:\n",
+    "    y_train = np.frombuffer(y_train_path.read(), np.uint8, offset=8)\n",
+    "with gzip.open(os.path.expanduser('~/.datasets/fashion-mnist/train-images-idx3-ubyte.gz'), 'rb') as x_train_path:\n",
+    "    x_train = np.frombuffer(x_train_path.read(), np.uint8, offset=16).reshape(len(y_train), 28, 28)\n",
+    "with gzip.open(os.path.expanduser('~/.datasets/fashion-mnist/t10k-labels-idx1-ubyte.gz'), 'rb') as y_test_path:\n",
+    "    y_test = np.frombuffer(y_test_path.read(), np.uint8, offset=8)\n",
+    "with gzip.open(os.path.expanduser('~/.datasets/fashion-mnist/t10k-images-idx3-ubyte.gz'), 'rb') as x_test_path:\n",
+    "    x_test = np.frombuffer(x_test_path.read(), np.uint8, offset=16).reshape(len(y_test), 28, 28)"
    ]
   },
   {
@@ -190,11 +199,11 @@
    "outputs": [],
    "source": [
     "# upload training data to s3\n",
-    "# you may need to modifiy the path to .keras dir\n",
+    "# you may need to modifiy the path to .datasets dir\n",
     "train_input = S3Uploader.upload(\n",
-    "    local_path=f'{os.path.expanduser(\"~\")}/.keras/datasets/fashion-mnist/', \n",
+    "    local_path=f'{os.path.expanduser(\"~\")}/.datasets/fashion-mnist/',\n",
     "    desired_s3_uri=f\"s3://{bucket}/{prefix}/data/train\",\n",
-    "    session=sagemaker_sess,\n",
+    "    sagemaker_session=sagemaker_sess,\n",
     ")\n",
     "print('train input spec: {}'.format(train_input))"
    ]
@@ -209,7 +218,7 @@
     "test_input = S3Uploader.upload(\n",
     "    local_path='./x_test.csv', \n",
     "    desired_s3_uri=f\"s3://{bucket}/{prefix}/data/test\",\n",
-    "    session=sagemaker_sess,\n",
+    "    sagemaker_session=sagemaker_sess,\n",
     ")\n",
     "print('test input spec: {}'.format(test_input))"
    ]
@@ -563,9 +572,9 @@
  "metadata": {
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "conda_tensorflow_p36",
    "language": "python",
-   "name": "python3"
+   "name": "conda_tensorflow_p36"
   },
   "language_info": {
    "codemirror_mode": {
@@ -577,7 +586,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*  For "Track an Airflow Workflow" notebook, use SageMaker-hosted Fashion MNIST dataset instead of the Tensorflow-hosted dataset. Includes handling unzipping the raw gzip files.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
