### PR TITLE
Use SageMaker-hosted Abalone train/test/val data

### DIFF
--- a/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb
+++ b/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb
@@ -65,18 +65,26 @@
     "\n",
     "role = sagemaker.get_execution_role()\n",
     "region = boto3.Session().region_name\n",
+    "s3_client = boto3.client(\"s3\")\n",
+    "\n",
     "\n",
     "# S3 bucket where the training data is located.\n",
-    "# Feel free to specify a different bucket and prefix\n",
-    "data_bucket = f\"jumpstart-cache-prod-{region}\"\n",
-    "data_prefix = \"1p-notebooks-datasets/abalone/libsvm\"\n",
+    "data_bucket = f\"sagemaker-sample-files\"\n",
+    "data_prefix = \"datasets/tabular/uci_abalone\"\n",
     "data_bucket_path = f\"s3://{data_bucket}\"\n",
     "\n",
     "# S3 bucket for saving code and model artifacts.\n",
     "# Feel free to specify a different bucket and prefix\n",
     "output_bucket = sagemaker.Session().default_bucket()\n",
     "output_prefix = \"sagemaker/DEMO-xgboost-abalone-default\"\n",
-    "output_bucket_path = f\"s3://{output_bucket}\""
+    "output_bucket_path = f\"s3://{output_bucket}\"\n",
+    "\n",
+    "for data_category in [\"train\", \"test\", \"validation\"]:\n",
+    "    data_key = \"{0}/{1}/abalone.{1}\".format(data_prefix, data_category)\n",
+    "    output_key = \"{0}/{1}/abalone.{1}\".format(output_prefix, data_category)\n",
+    "    data_filename = \"abalone.{}\".format(data_category)\n",
+    "    s3_client.download_file(data_bucket, data_key, data_filename)\n",
+    "    s3_client.upload_file(data_filename, output_bucket, output_key)"
    ]
   },
   {
@@ -135,7 +143,7 @@
     "            \"DataSource\": {\n",
     "                \"S3DataSource\": {\n",
     "                    \"S3DataType\": \"S3Prefix\",\n",
-    "                    \"S3Uri\": f\"{data_bucket_path}/{data_prefix}/train\",\n",
+    "                    \"S3Uri\": f\"{output_bucket_path}/{output_prefix}/train\",\n",
     "                    \"S3DataDistributionType\": \"FullyReplicated\",\n",
     "                }\n",
     "            },\n",
@@ -147,7 +155,7 @@
     "            \"DataSource\": {\n",
     "                \"S3DataSource\": {\n",
     "                    \"S3DataType\": \"S3Prefix\",\n",
-    "                    \"S3Uri\": f\"{data_bucket_path}/{data_prefix}/validation\",\n",
+    "                    \"S3Uri\": f\"{output_bucket_path}/{output_prefix}/validation\",\n",
     "                    \"S3DataDistributionType\": \"FullyReplicated\",\n",
     "                }\n",
     "            },\n",
@@ -599,7 +607,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* For XGBoost Abalone notebook, use `sagemaker-sample-files` S3 bucket instead of `jumpstart-cache-prod`. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
