### PR TITLE
Update notebook for using EI with compiled model

### DIFF
--- a/sagemaker-python-sdk/tensorflow_serving_using_elastic_inference_with_your_own_model/tensorflow_neo_compiled_model_elastic_inference.ipynb
+++ b/sagemaker-python-sdk/tensorflow_serving_using_elastic_inference_with_your_own_model/tensorflow_neo_compiled_model_elastic_inference.ipynb
@@ -76,13 +76,13 @@
     "import tarfile\n",
     "import os\n",
     "\n",
+    "tf.keras.backend.set_image_data_format('channels_last')\n",
     "pretrained_model = tf.keras.applications.resnet.ResNet50()\n",
-    "saved_model_dir = 'saved_model'\n",
+    "saved_model_dir = '1'\n",
     "tf.saved_model.save(pretrained_model, saved_model_dir)\n",
     "\n",
     "with tarfile.open('model.tar.gz', 'w:gz') as tar:\n",
-    "    for file in os.listdir(saved_model_dir):\n",
-    "        tar.add(os.path.join(saved_model_dir, file), arcname=file)"
+    "    tar.add(saved_model_dir)"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previously, compiled SavedModel will be wrapped into directory `000000/`. However, SageMaker doesn't understand such model version from their recent changes and will fail the endpoint creation. Therefore, this change will wrap the compiled SavedModel into directory `1/` so that SageMaker could correctly parse out the model version.

I've tested the notebook in my personal account, and it's able to compile, deploy and inference against the model.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
