### PR TITLE
reset kernel of pyspark_mnist_kmeans.ipynb

### DIFF
--- a/sagemaker-spark/pyspark_mnist/pyspark_mnist_kmeans.ipynb
+++ b/sagemaker-spark/pyspark_mnist/pyspark_mnist_kmeans.ipynb
@@ -549,9 +549,9 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "conda_python3",
+   "display_name": "pysparkkernel",
    "language": "python",
-   "name": "conda_python3"
+   "name": "pysparkkernel"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Fix: #2393

Link to the notebook:
https://github.com/aws/amazon-sagemaker-examples/blob/master/sagemaker-spark/pyspark_mnist/pyspark_mnist_kmeans.ipynb