### PR TITLE
Add missing modules to sagemaker-countycensusclustering.ipynb

### DIFF
--- a/introduction_to_applying_machine_learning/US-census_population_segmentation_PCA_Kmeans/sagemaker-countycensusclustering.ipynb
+++ b/introduction_to_applying_machine_learning/US-census_population_segmentation_PCA_Kmeans/sagemaker-countycensusclustering.ipynb
@@ -1,6 +1,27 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
+   },
+   "source": [
+    "# Install dependencies\n",
+    "!pip install -q smdebug\n",
+    "!pip install -q seaborn\n",
+    "!pip install -q plotly\n",
+    "!pip install -q opencv-python\n",
+    "!pip install -q shap\n",
+    "!pip install -q bokeh\n",
+    "!pip install -q imageio\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "nbpresent": {


### PR DESCRIPTION
Link to the notebook:
https://github.com/aws/amazon-sagemaker-examples/blob/master/introduction_to_applying_machine_learning/US-census_population_segmentation_PCA_Kmeans/sagemaker-countycensusclustering.ipynb