### PR TITLE
Add missing modules to xgboost-census-debugger-rules.ipynb

### DIFF
--- a/sagemaker-debugger/xgboost_census_explanations/xgboost-census-debugger-rules.ipynb
+++ b/sagemaker-debugger/xgboost_census_explanations/xgboost-census-debugger-rules.ipynb
@@ -1,6 +1,27 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
+   },
+   "source": [
+    "# Install dependencies\n",
+    "!pip install -q smdebug\n",
+    "!pip install -q seaborn\n",
+    "!pip install -q plotly\n",
+    "!pip install -q opencv-python\n",
+    "!pip install -q shap\n",
+    "!pip install -q bokeh\n",
+    "!pip install -q imageio\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "toc": true


### PR DESCRIPTION
Link to the notebook:
https://github.com/aws/amazon-sagemaker-examples/blob/master/sagemaker-debugger/xgboost_census_explanations/xgboost-census-debugger-rules.ipynb