### PR TITLE
Add missing modules to 2-metastases-detection-lineage-registry.ipynb

### DIFF
--- a/use-cases/computer_vision/2-metastases-detection-lineage-registry.ipynb
+++ b/use-cases/computer_vision/2-metastases-detection-lineage-registry.ipynb
@@ -1,6 +1,27 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
+   },
+   "source": [
+    "# Install dependencies\n",
+    "!pip install -q smdebug\n",
+    "!pip install -q seaborn\n",
+    "!pip install -q plotly\n",
+    "!pip install -q opencv-python\n",
+    "!pip install -q shap\n",
+    "!pip install -q bokeh\n",
+    "!pip install -q imageio\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
Link to the notebook:
https://github.com/aws/amazon-sagemaker-examples/blob/master/use-cases/computer_vision/2-metastases-detection-lineage-registry.ipynb