### PR TITLE
Internet-free LDA-Introduction

### DIFF
--- a/introduction_to_amazon_algorithms/lda_topic_modeling/LDA-Introduction.ipynb
+++ b/introduction_to_amazon_algorithms/lda_topic_modeling/LDA-Introduction.ipynb
@@ -49,17 +49,6 @@
    },
    "outputs": [],
    "source": [
-    "!conda install -y scipy"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
     "%matplotlib inline\n",
     "\n",
     "import os, re\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Remove conda scipy install from LDA-Introduction to make it internet-free.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
