### PR TITLE
SageMaker Neo compilation fails at 8 min mark

### DIFF
--- a/sagemaker_neo_compilation_jobs/deploy_pytorch_model_on_Inf1_instance/pytorch_torchvision_neo_on_Inf1.ipynb
+++ b/sagemaker_neo_compilation_jobs/deploy_pytorch_model_on_Inf1_instance/pytorch_torchvision_neo_on_Inf1.ipynb
@@ -181,6 +181,7 @@
     "    framework_version=\"1.5.1\",\n",
     "    role=role,\n",
     "    job_name=compilation_job_name,\n",
+    "    compile_max_run=900\n",
     ")"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This particular compilation fails, in certain occasions on the 8 min mark. Hence increasing the compile_max_run from the default of 3 * 60 to 10 * 60. Ref: https://sagemaker.readthedocs.io/en/v2.23.0/api/inference/model.html#sagemaker.model.Model.compile

*Testing done:*

Previously failing compilation succeeds after this change. 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [X ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [ X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [ X] I have tested my notebook(s) and ensured it runs end-to-end
- [ ] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
