### PR TITLE
Change covtype dataset location

### DIFF
--- a/introduction_to_amazon_algorithms/k_nearest_neighbors_covtype/k_nearest_neighbors_covtype.ipynb
+++ b/introduction_to_amazon_algorithms/k_nearest_neighbors_covtype/k_nearest_neighbors_covtype.ipynb
@@ -81,7 +81,7 @@
     "\n",
     "# S3 bucket where the original covtype data is downloaded and stored.\n",
     "downloaded_data_bucket = f\"sagemaker-sample-files\"\n",
-    "downloaded_data_prefix = \"datasets/image/uci-covtype\"\n",
+    "downloaded_data_prefix = \"datasets/tabular/uci_covtype\"\n",
     "s3 = boto3.client(\"s3\")\n",
     "s3.download_file(downloaded_data_bucket, f\"{downloaded_data_prefix}/covtype.data.gz\", \"covtype.data.gz\")"
    ]


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Covtype dataset is actually a tabular dataset, not image. Updating the S3 prefix to reflect correct data location under `tabular` rather than `image` category.

*Testing done:* n/a

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [ ] I have tested my notebook(s) and ensured it runs end-to-end
- [ ] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
