### PR TITLE
Add higher level page for SageMaker Clarify examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ These examples provide and introduction to SageMaker Debugger which allows debug
 - [Reacting to CloudWatch Events from Rules to take an action based on status with TensorFlow](sagemaker-debugger/tensorflow_action_on_rule/)
 - [Using SageMaker Debugger with a custom PyTorch container](sagemaker-debugger/pytorch_custom_container/)
 
+### Amazon SageMaker Clarify
+
+These examples provide an introduction to SageMaker Clarify which provides machine learning developers with greater visibility into their training data and models so they can identify and limit bias and explain predictions.
+
+* [Fairness and Explainability with SageMaker Clarify](sagemaker_processing/fairness_and_explainability) shows how to use SageMaker Clarify Processor API to measure the pre-training bias of a dataset and post-training bias of a model, and explain the importance of the input features on the model's decision.
+* [Amazon SageMaker Clarify Model Monitors](sagemaker_model_monitor/fairness_and_explainability) shows how to use SageMaker Clarify Model Monitor API to schedule bias monitor to monitor predictions for bias drift on a regular basis, and schedule explainability monitor to monitor predictions for feature attribution drift on a regular basis.
+
 ### Advanced Amazon SageMaker Functionality
 
 These examples that showcase unique functionality available in Amazon SageMaker. They cover a broad range of topics and will utilize a variety of methods, but aim to provide the user with sufficient insight or inspiration to develop within Amazon SageMaker.

--- a/index.rst
+++ b/index.rst
@@ -127,6 +127,7 @@ On SageMaker Studio, you will need to open a terminal, go to your home folder, t
    :maxdepth: 1
    :caption: Advanced examples
 
+   sagemaker-clarify/index
    scientific_details_of_algorithms/index
    aws_marketplace/index
 

--- a/sagemaker-clarify/index.rst
+++ b/sagemaker-clarify/index.rst
@@ -1,0 +1,23 @@
+SageMaker Clarify
+=================================
+
+These examples provide an introduction to SageMaker Clarify which provides machine learning developers with greater visibility into their training data and models so they can identify and limit bias and explain predictions.
+
+SageMaker Clarify Processing
+----------------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   ../sagemaker_processing/fairness_and_explainability/fairness_and_explainability
+   ../sagemaker_processing/fairness_and_explainability/fairness_and_explainability_jsonlines_format
+   ../sagemaker_processing/fairness_and_explainability/fairness_and_explainability_byoc
+   ../sagemaker_processing/fairness_and_explainability/fairness_and_explainability_spark
+
+SageMaker Clarify Model Monitoring
+----------------------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   ../sagemaker_model_monitor/fairness_and_explainability/SageMaker-Model-Monitor-Fairness-and-Explainability

--- a/sagemaker_processing/fairness_and_explainability/fairness_and_explainability_byoc.ipynb
+++ b/sagemaker_processing/fairness_and_explainability/fairness_and_explainability_byoc.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Fairness and Explainability with SageMaker Clarify (Bring Your Own Container)"
+    "# Fairness and Explainability with SageMaker Clarify - Bring Your Own Container"
    ]
   },
   {

--- a/sagemaker_processing/fairness_and_explainability/fairness_and_explainability_jsonlines_format.ipynb
+++ b/sagemaker_processing/fairness_and_explainability/fairness_and_explainability_jsonlines_format.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Fairness and Explainability with SageMaker Clarify (JSONLines Format)"
+    "# Fairness and Explainability with SageMaker Clarify - JSONLines Format"
    ]
   },
   {

--- a/sagemaker_processing/index.rst
+++ b/sagemaker_processing/index.rst
@@ -12,3 +12,4 @@ Processing
    fairness_and_explainability/fairness_and_explainability
    fairness_and_explainability/fairness_and_explainability_jsonlines_format
    fairness_and_explainability/fairness_and_explainability_byoc
+   fairness_and_explainability/fairness_and_explainability_spark


### PR DESCRIPTION
*Description of changes:*

Currently the SageMaker Clarify examples are buried in sections like Processing and Model Monitor. This commit adds a higher level page for them for better visibility. 

Tracking ticket: https://tiny.amazon.com/13ymtk9n

*Testing done:*

* Executed `make html` locally and inspected the generated docs.
* Viewed the README.md by Markdown viewer.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [X] I have tested my notebook(s) and ensured it runs end-to-end
- [X] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
