### PR TITLE
Update aws ecr get credentials

### DIFF
--- a/r_examples/r_byo_r_algo_hpo/tune_r_bring_your_own.ipynb
+++ b/r_examples/r_byo_r_algo_hpo/tune_r_bring_your_own.ipynb
@@ -160,7 +160,7 @@
     "fi\n",
     "\n",
     "# Get the login command from ECR and execute it directly\n",
-    "$(aws ecr get-login --region ${region} --no-include-email)\n",
+    "$(aws ecr get-login-password --region ${region} --no-include-email)\n",
     "\n",
     "# Build the docker image locally with the image name and then push it to ECR\n",
     "# with the full name.\n",


### PR DESCRIPTION
For getting credentials
`aws ecr get-login` is deprecated and hence replacing it with `aws ecr get-login-password`

*Issue #, if available:*

*Description of changes:*
`aws ecr get-login` is deprecated and hence replacing it with `aws ecr get-login-password`

*Testing done:*
done

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
