### PR TITLE
Improve model monitor feature naming

### DIFF
--- a/sagemaker_model_monitor/introduction/preprocessor.py
+++ b/sagemaker_model_monitor/introduction/preprocessor.py
@@ -11,9 +11,9 @@ def preprocess_handler(inference_record):
     input_data = {}
     output_data = {}
 
-    input_data["feature0"] = random.randint(1, 3)
-    input_data["feature1"] = random.uniform(0, 1.6)
-    input_data["feature2"] = random.uniform(0, 1.6)
+    input_data["feature000"] = random.randint(1, 3)
+    input_data["feature001"] = random.uniform(0, 1.6)
+    input_data["feature002"] = random.uniform(0, 1.6)
 
     output_data["prediction0"] = random.uniform(1, 30)
 

--- a/sagemaker_model_monitor/tensorflow/SageMaker-Model-Monitor-tensorflow.ipynb
+++ b/sagemaker_model_monitor/tensorflow/SageMaker-Model-Monitor-tensorflow.ipynb
@@ -518,7 +518,7 @@
     "\n",
     "def preprocess_handler(inference_record):\n",
     "    input_data = json.loads(inference_record.endpoint_input.data)\n",
-    "    input_data = {f\"feature{i}\": val for i, val in enumerate(input_data)}\n",
+    "    input_data = {f\"feature{str(i).zfill(10)}\": val for i, val in enumerate(input_data)}\n",
     "\n",
     "    output_data = json.loads(inference_record.endpoint_output.data)[\"predictions\"][0][0]\n",
     "    output_data = {\"prediction0\": output_data}\n",


### PR DESCRIPTION
*Description of changes:*

The preprocessor handler returns features in lexigraphical order to the monitoring spark job. This means that for features named 0-9 it will behave as expected, but if you have more than 10 features then you will incorrectly associate the columns with their data. Since lexigraphical order would be:

feature0, feature1, feature10, feature11, feature12 ... 

This is difficult to troubleshoot and so we should make our examples safe for this type of issue. In the docs we use this strategy:
https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor-pre-and-post-processing.html

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
