### PR TITLE
Fix, clean up image-classification-lst-format

### DIFF
--- a/introduction_to_amazon_algorithms/imageclassification_caltech/Image-classification-lst-format.ipynb
+++ b/introduction_to_amazon_algorithms/imageclassification_caltech/Image-classification-lst-format.ipynb
@@ -7,7 +7,7 @@
     "# Image classification training with image format\n",
     "\n",
     "1. [Introduction](#Introduction)\n",
-    "2. [Prerequisites and Preprocessing](#Prequisites-and-Preprocessing)\n",
+    "2. [Prerequisites and Preprocessing](#Prerequisites-and-Preprocessing)\n",
     "  1. [Permissions and environment variables](#Permissions-and-environment-variables)\n",
     "  2. [Prepare the data](#Prepare-the-data)\n",
     "3. [Fine-tuning The Image Classification Model](#Fine-tuning-the-Image-classification-model)\n",
@@ -29,7 +29,7 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "Welcome to our end-to-end example of the image classification algorithm training with image format. In this demo, we will use the Amazon sagemaker image classification algorithm in transfer learning mode to fine-tune a pre-trained model (trained on imagenet data) to learn to classify a new dataset. In particular, the pre-trained model will be fine-tuned using [caltech-256 dataset](http://www.vision.caltech.edu/Image_Datasets/Caltech256/). \n",
+    "Welcome to our end-to-end example of the image classification algorithm training with image format. In this demo, we will use the Amazon SageMaker image classification algorithm in transfer learning mode to fine-tune a pre-trained model (trained on ImageNet data) to learn to classify a new dataset. In particular, the pre-trained model will be fine-tuned using the [Caltech-256 dataset](http://www.vision.caltech.edu/Image_Datasets/Caltech256/). \n",
     "\n",
     "To get started, we need to set up the environment with a few prerequisite steps, for permissions, configurations, and so on."
    ]
@@ -38,7 +38,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prequisites and Preprocessing\n",
+    "## Prerequisites and Preprocessing\n",
     "\n",
     "### Permissions and environment variables\n",
     "\n",
@@ -46,7 +46,7 @@
     "\n",
     "* The roles used to give learning and hosting access to your data. This will automatically be obtained from the role used to start the notebook\n",
     "* The S3 bucket that you want to use for training and model data\n",
-    "* The Amazon sagemaker image classification docker image which need not be changed"
+    "* The Amazon SageMaker image classification docker image which need not be changed"
    ]
   },
   {
@@ -62,14 +62,17 @@
    "source": [
     "%%time\n",
     "import boto3\n",
+    "import sagemaker\n",
     "from sagemaker import get_execution_role\n",
-    "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
+    "from sagemaker import image_uris\n",
     "\n",
     "role = get_execution_role()\n",
     "\n",
-    "bucket = \"<<bucket-name>>\"  # customize to your bucket\n",
+    "bucket = sagemaker.session.Session().default_bucket()\n",
     "\n",
-    "training_image = get_image_uri(boto3.Session().region_name, \"image-classification\")"
+    "training_image = image_uris.retrieve(\n",
+    "    region=boto3.Session().region_name, framework=\"image-classification\"\n",
+    ")"
    ]
   },
   {
@@ -79,7 +82,7 @@
     "## Fine-tuning the Image classification model\n",
     "\n",
     "### Prepare the data\n",
-    "The caltech 256 dataset consist of images from 257 categories (the last one being a clutter category) and has 30k images with a minimum of 80 images and a maximum of about 800 images per category. \n",
+    "The Caltech-256 dataset consist of images from 257 categories (the last one being a clutter category) and has 30k images with a minimum of 80 images and a maximum of about 800 images per category. \n",
     "\n",
     "The image classification algorithm can take two types of input formats. The first is a [RecordIO format](https://mxnet.incubator.apache.org/tutorials/basic/record_io.html) (content type: application/x-recordio) and the other is a [lst format](https://mxnet.incubator.apache.org/how_to/recordio.html?highlight=im2rec) (content type: application/x-image). Files for both these formats are available at http://data.dmlc.ml/mxnet/data/caltech-256/. In this example, we will use the lst format for training and use the training/validation split [specified here](http://data.dmlc.ml/mxnet/data/caltech-256/)."
    ]
@@ -103,7 +106,12 @@
     "\n",
     "\n",
     "# Caltech-256 image files\n",
-    "download(\"http://www.vision.caltech.edu/Image_Datasets/Caltech256/256_ObjectCategories.tar\")\n",
+    "s3 = boto3.client(\"s3\")\n",
+    "s3.download_file(\n",
+    "    \"sagemaker-sample-files\",\n",
+    "    \"datasets/image/caltech-256/256_ObjectCategories.tar\",\n",
+    "    \"256_ObjectCategories.tar\",\n",
+    ")\n",
     "!tar -xf 256_ObjectCategories.tar\n",
     "\n",
     "# Tool for creating lst file\n",
@@ -188,7 +196,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we have all the data stored in S3 bucket. The image and lst files will be converted to RecordIO file internelly by the image classification algorithm. But if you want do the conversion, the following cell shows how to do it using the [im2rec](https://github.com/apache/incubator-mxnet/blob/master/tools/im2rec.py) tool. Note that this is just an example of creating RecordIO files. We are **_not_** using them for training in this notebook. More details on creating RecordIO files can be found in this [tutorial](https://mxnet.incubator.apache.org/how_to/recordio.html?highlight=im2rec)."
+    "Now we have all the data stored in S3 bucket. The image and lst files will be converted to RecordIO file internally by the image classification algorithm. But if you want do the conversion, the following cell shows how to do it using the [im2rec](https://github.com/apache/incubator-mxnet/blob/master/tools/im2rec.py) tool. Note that this is just an example of creating RecordIO files. We are **_not_** using them for training in this notebook. More details on creating RecordIO files can be found in this [tutorial](https://mxnet.incubator.apache.org/how_to/recordio.html?highlight=im2rec)."
    ]
   },
   {
@@ -215,7 +223,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before training the model, we need to setup the training parameters. The next section will explain the parameters in detail."
+    "Before training the model, we need to set up the training parameters. The next section will explain the parameters in detail."
    ]
   },
   {
@@ -233,10 +241,10 @@
     "\n",
     "Apart from the above set of parameters, there are hyperparameters that are specific to the algorithm. These are:\n",
     "\n",
-    "* **num_layers**: The number of layers (depth) for the network. We use 18 in this samples but other values such as 50, 152 can be used.\n",
+    "* **num_layers**: The number of layers (depth) for the network. We use 18 in this sample but other values such as 50, 152 can be used.\n",
     "* **image_shape**: The input image dimensions,'num_channels, height, width', for the network. It should be no larger than the actual image size. The number of channels should be same as the actual image.\n",
-    "* **num_training_samples**: This is the total number of training samples. It is set to 15240 for caltech dataset with the current split.\n",
-    "* **num_classes**: This is the number of output classes for the new dataset. Imagenet was trained with 1000 output classes but the number of output classes can be changed for fine-tuning. For caltech, we use 257 because it has 256 object categories + 1 clutter class.\n",
+    "* **num_training_samples**: This is the total number of training samples. It is set to 15240 for the Caltech dataset with the current split.\n",
+    "* **num_classes**: This is the number of output classes for the new dataset. ImageNet was trained with 1000 output classes but the number of output classes can be changed for fine-tuning. For Caltech, we use 257 because it has 256 object categories + 1 clutter class.\n",
     "* **mini_batch_size**: The number of training samples used for each mini batch. In distributed training, the number of training samples used per batch will be N * mini_batch_size where N is the number of hosts on which training is run.\n",
     "* **epochs**: Number of training epochs.\n",
     "* **learning_rate**: Learning rate for training.\n",
@@ -250,7 +258,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "isConfigCell": true
    },
    "outputs": [],
@@ -286,7 +293,7 @@
    "metadata": {},
    "source": [
     "### Training\n",
-    "Run the training using Amazon sagemaker CreateTrainingJob API"
+    "Run the training using Amazon SageMaker CreateTrainingJob API"
    ]
   },
   {
@@ -492,7 +499,9 @@
     "model_data = info[\"ModelArtifacts\"][\"S3ModelArtifacts\"]\n",
     "print(model_data)\n",
     "\n",
-    "hosting_image = get_image_uri(boto3.Session().region_name, \"image-classification\")\n",
+    "hosting_image = image_uris.retrieve(\n",
+    "    region=boto3.Session().region_name, framework=\"image-classification\"\n",
+    ")\n",
     "\n",
     "primary_container = {\n",
     "    \"Image\": hosting_image,\n",
@@ -1045,8 +1054,13 @@
    },
    "outputs": [],
    "source": [
-    "!wget -O /tmp/test.jpg http://www.vision.caltech.edu/Image_Datasets/Caltech256/images/008.bathtub/008_0007.jpg\n",
     "file_name = \"/tmp/test.jpg\"\n",
+    "s3.download_file(\n",
+    "    \"sagemaker-sample-files\",\n",
+    "    \"datasets/image/caltech-256/256_ObjectCategories/008.bathtub/008_0007.jpg\",\n",
+    "    file_name,\n",
+    ")\n",
+    "\n",
     "# test image\n",
     "from IPython.display import Image\n",
     "\n",
@@ -1076,6 +1090,7 @@
     "# the result will output the probabilities for all classes\n",
     "# find the class with maximum probability and print the class index\n",
     "index = np.argmax(result)\n",
+    "\n",
     "object_categories = [\n",
     "    \"ak47\",\n",
     "    \"american-flag\",\n",
@@ -1376,7 +1391,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.13"
   },
   "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Clean up notebook for SageMaker V2, AWS-hosted dataset, SageMaker default S3 bucket, fix typos.

Notebook link: https://github.com/aws/amazon-sagemaker-examples/blob/master/introduction_to_amazon_algorithms/imageclassification_caltech/Image-classification-lst-format.ipynb

*Testing done:* Ran end-to-end in notebook instance.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
