### PR TITLE
Update Tensorflow CNN example links

### DIFF
--- a/sagemaker-python-sdk/tensorflow_script_mode_training_and_serving/tensorflow_script_mode_training_and_serving.ipynb
+++ b/sagemaker-python-sdk/tensorflow_script_mode_training_and_serving/tensorflow_script_mode_training_and_serving.ipynb
@@ -64,7 +64,7 @@
    "source": [
     "# Construct a script for distributed training\n",
     "\n",
-    "This tutorial's training script was adapted from TensorFlow's official [CNN MNIST example](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/tutorials/layers/cnn_mnist.py). We have modified it to handle the ``model_dir`` parameter passed in by SageMaker. This is an S3 path which can be used for data sharing during distributed training and checkpointing and/or model persistence. We have also added an argument-parsing function to handle processing training-related variables.\n",
+    "This tutorial's training script was adapted from an earlier version of TensorFlow's official [CNN MNIST example](https://github.com/tensorflow/tensorflow/blob/95e808ba44075dfe0b7db57bb49d2e64a1977a95/tensorflow/examples/tutorials/layers/cnn_mnist.py). An updated version is available at [Convolutional Neural Network (CNN)](https://github.com/tensorflow/docs/blob/master/site/en/tutorials/images/cnn.ipynb). We have modified the example to handle the ``model_dir`` parameter passed in by SageMaker. This is an S3 path which can be used for data sharing during distributed training and checkpointing and/or model persistence. We have also added an argument-parsing function to handle processing training-related variables.\n",
     "\n",
     "At the end of the training job we have added a step to export the trained model to the path stored in the environment variable ``SM_MODEL_DIR``, which always points to ``/opt/ml/model``. This is critical because SageMaker uploads all the model artifacts in this folder to S3 at end of training.\n",
     "\n",


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-sagemaker-examples/issues/2885

Notebook link: https://github.com/aws/amazon-sagemaker-examples/blob/master/sagemaker-python-sdk/tensorflow_script_mode_training_and_serving/tensorflow_script_mode_training_and_serving.ipynb

*Description of changes:* Fix broken link to old Tensorflow example. Add link to latest content.

*Testing done:* Verified that notebook still runs end-to-end. Tested markdown appearance in notebook.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
