### PR TITLE
Fix broken bash/python syntax in pip command

### DIFF
--- a/sagemaker-featurestore/feature_store_introduction.ipynb
+++ b/sagemaker-featurestore/feature_store_introduction.ipynb
@@ -428,8 +428,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%bash -s \"$original_version\"\n",
+    "\n",
     "# preserve original sagemaker version\n",
-    "%pip install 'sagemaker=={}'.format(original_version)"
+    "\n",
+    "pip install sagemaker==$1"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Fix broken bash/python syntax in pip command. The original command was combining Python string substitution with a bash command.

Link to notebook: https://github.com/aws/amazon-sagemaker-examples/blob/master/sagemaker-featurestore/feature_store_introduction.ipynb

*Testing done:* Ran notebook end-to-end.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
