### PR TITLE
Add ProcessingStep dependency in fraud end-to-end notebook

### DIFF
--- a/end_to_end/fraud_detection/5-pipeline-e2e.ipynb
+++ b/end_to_end/fraud_detection/5-pipeline-e2e.ipynb
@@ -508,9 +508,10 @@
     "        \"--customers-table-name\",\n",
     "        customers_table,\n",
     "        \"--region\",\n",
-    "        region\n",
+    "        region,\n",
     "    ],\n",
     "    code=create_dataset_script_uri,\n",
+    "    depends_on=[claims_flow_step.name, customers_flow_step.name],\n",
     ")"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-sagemaker-examples/issues/2903

*Description of changes:* Add missing line asserting ProcessingStep dependency

Link to notebook: https://github.com/aws/amazon-sagemaker-examples/blob/master/end_to_end/fraud_detection/5-pipeline-e2e.ipynb

*Testing done:* Manually ran the sequential notebooks since CI can't test them.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
