### PR TITLE
Fix: wait for profiler framework metrics before retrieving

### DIFF
--- a/sagemaker-debugger/debugger_interactive_analysis_profiling/interactive_analysis_profiling_data.ipynb
+++ b/sagemaker-debugger/debugger_interactive_analysis_profiling/interactive_analysis_profiling_data.ipynb
@@ -194,7 +194,8 @@
     "\n",
     "tj = TrainingJob(training_job_name, region)\n",
     "\n",
-    "tj.wait_for_sys_profiling_data_to_be_available()"
+    "tj.wait_for_sys_profiling_data_to_be_available()\n",
+    "tj.wait_for_framework_profiling_data_to_be_available()"
    ]
   },
   {


### PR DESCRIPTION
Will close this PR and merge https://github.com/aws/amazon-sagemaker-examples/pull/2914 instead, since the new one fixes the issues in both CI and debugger notebook.

*Issue #, if available:*
N/A

*Description of changes:*
Fix SageMaker debugger pandas frame analysis notebook, adding the code to wait for the profiler framework metrics to be available in S3 before retrieving it. 

*Testing done:*
Tested the change on SageMaker

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
