### PR TITLE
Updated from Ubuntu 16.04 to 18.04

### DIFF
--- a/advanced_functionality/multi_model_bring_your_own/container/Dockerfile
+++ b/advanced_functionality/multi_model_bring_your_own/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # Set a docker label to advertise multi-model support on the container
 LABEL com.amazonaws.sagemaker.capabilities.multi-models=true


### PR DESCRIPTION
*Issue #, if available:*

Currently this Dockerfile is not successfully built because of the following error. Ubuntu 16.04 uses Python 3.5. I recommend Ubuntu is updated from 16.04 to 18.04.

```
ERROR: This script does not work on Python 3.5 The minimum supported Python version is 3.6. Please use https://bootstrap.pypa.io/pip/3.5/get-pip.py instead.
The command '/bin/sh -c apt-get update &&     apt-get -y install --no-install-recommends     build-essential     ca-certificates     openjdk-8-jdk-headless     python3-dev     curl     vim     && rm -rf /var/lib/apt/lists/*     && curl -O https://bootstrap.pypa.io/get-pip.py     && python3 get-pip.py' returned a non-zero code: 1
````

*Description of changes:*
Updated from Ubuntu 16.04 to 18.04

*Testing done:*
Done on SageMaker notebook instance (notebook-al1-v1)


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
