### PR TITLE
Added provider path to the config

### DIFF
--- a/sagemaker_edge_manager/sagemaker_edge_example/sagemaker_edge_example.ipynb
+++ b/sagemaker_edge_manager/sagemaker_edge_example/sagemaker_edge_example.ipynb
@@ -1097,6 +1097,7 @@
     "    \"sagemaker_edge_provider_aws_cert_pk_file\": \"/demo/iot-credentials/iot_key.pem.key\",\n",
     "    \"sagemaker_edge_provider_aws_iot_cred_endpoint\": endpoint,\n",
     "    \"sagemaker_edge_provider_provider\": \"Aws\",\n",
+    "    \"sagemaker_edge_provider_provider_path\": \"/demo/lib/libprovider_aws.so\",\n",
     "    \"sagemaker_edge_provider_s3_bucket_name\": bucket,\n",
     "    \"sagemaker_edge_core_capture_data_destination\": \"Cloud\",\n",
     "}"


### PR DESCRIPTION
This is needed so that input/output capture to S3 works. Without that line the capture would silently fail (you would only see in the standard output that capture failed).

*Issue #, if available:*

*Description of changes:*
Added the required line to the edge_config

*Testing done:*
Verified that the input and output tensors were uploaded to S3 after the change.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [ ] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
