### PR TITLE
Added AmazonS3FullAccess to the list of required policies

### DIFF
--- a/sagemaker_edge_manager/sagemaker_edge_example/sagemaker_edge_example.ipynb
+++ b/sagemaker_edge_manager/sagemaker_edge_example/sagemaker_edge_example.ipynb
@@ -92,6 +92,7 @@
     "\n",
     "- AmazonEC2FullAccess \n",
     "- AmazonEC2RoleforSSM \n",
+    "- AmazonS3FullAccess \n",
     "- AmazonSSMManagedInstanceCore \n",
     "- AmazonSSMFullAccess \n",
     "- AWSIoTFullAccess \n",


### PR DESCRIPTION
Without S3 access, the notebook can't be run since it copies data to S3.

*Issue #, if available:*

*Description of changes:*
Changed the text that states which policies the role running the notebook needs to have.

*Testing done:*
Ran the notebook all the way to the end.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x ] I have tested my notebook(s) and ensured it runs end-to-end
- [ ] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
