### PR TITLE
Fix HPO analysis

### DIFF
--- a/hyperparameter_tuning/analyze_results/HPO_Analyze_TuningJob_Results.ipynb
+++ b/hyperparameter_tuning/analyze_results/HPO_Analyze_TuningJob_Results.ipynb
@@ -34,7 +34,7 @@
     "## The Hyperparameter tuning jobs you have run are listed in the Training section on your SageMaker dashboard.\n",
     "## Copy the name of a completed job you want to analyze from that list.\n",
     "## For example: tuning_job_name = 'mxnet-training-201007-0054'.\n",
-    "tuning_job_name = \"YOUR-HYPERPARAMETER-TUNING-JOB-NAME\""
+    "tuning_job_name = \"<YOUR-HYPERPARAMETER-TUNING-JOB-NAME>\""
    ]
   },
   {
@@ -65,10 +65,9 @@
     "job_count = tuning_job_result[\"TrainingJobStatusCounters\"][\"Completed\"]\n",
     "print(\"%d training jobs have completed\" % job_count)\n",
     "\n",
-    "is_minimize = (\n",
-    "    tuning_job_result[\"TrainingJobDefinitions\"][0][\"TuningObjective\"][\"Type\"] != \"Maximize\"\n",
-    ")\n",
-    "objective_name = tuning_job_result[\"TrainingJobDefinitions\"][0][\"TuningObjective\"][\"MetricName\"]"
+    "objective = tuning_job_result[\"HyperParameterTuningJobConfig\"][\"HyperParameterTuningJobObjective\"]\n",
+    "is_minimize = objective[\"Type\"] != \"Maximize\"\n",
+    "objective_name = objective[\"MetricName\"]"
    ]
   },
   {
@@ -114,7 +113,7 @@
     "        df = df.sort_values(\"FinalObjectiveValue\", ascending=is_minimize)\n",
     "        print(\"Number of training jobs with valid objective: %d\" % len(df))\n",
     "        print({\"lowest\": min(df[\"FinalObjectiveValue\"]), \"highest\": max(df[\"FinalObjectiveValue\"])})\n",
-    "        pd.set_option(\"display.max_colwidth\", -1)  # Don't truncate TrainingJobName\n",
+    "        pd.set_option(\"display.max_colwidth\", None)  # Don't truncate TrainingJobName\n",
     "    else:\n",
     "        print(\"No training jobs have reported valid results yet.\")\n",
     "\n",
@@ -154,7 +153,7 @@
     "            (\"FinalObjectiveValue\", \"@FinalObjectiveValue\"),\n",
     "            (\"TrainingJobName\", \"@TrainingJobName\"),\n",
     "        ]\n",
-    "        for k in self.tuner.tuning_ranges[tuning_job_name].keys():\n",
+    "        for k in self.tuner.tuning_ranges.keys():\n",
     "            tooltips.append((k, \"@{%s}\" % k))\n",
     "\n",
     "        ht = HoverTool(tooltips=tooltips)\n",
@@ -189,7 +188,7 @@
    },
    "outputs": [],
    "source": [
-    "ranges = tuner.tuning_ranges[tuning_job_name]\n",
+    "ranges = tuner.tuning_ranges\n",
     "figures = []\n",
     "for hp_name, hp_range in ranges.items():\n",
     "    categorical_args = {}\n",
@@ -243,7 +242,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.13"
   },
   "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-sagemaker-examples/issues/2911

Link to notebook: https://github.com/aws/amazon-sagemaker-examples/blob/master/hyperparameter_tuning/analyze_results/HPO_Analyze_TuningJob_Results.ipynb

*Description of changes:* Undo previous PR that introduced errors: https://github.com/aws/amazon-sagemaker-examples/pull/980. Also a couple small fixes to improve clarity and handle a Pandas deprecation.

*Testing done:* Successfully ran end-to-end on two different hyperparameter tuning jobs.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
