### PR TITLE
updated dependencies for website builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,155 @@ Please ensure that your notebook runs end-to-end so that it passes our CI.
 The `sagemaker-bot` will comment on your PR with a link for `Build logs`.
 If your PR does not pass CI, you can view the logs to understand how to fix your notebook(s) and code.
 
+
+### Add Your Notebook to the Website
+
+#### Environment Setup
+
+1. Setup your environment. You can use the same Conda environment for multiple related projects. This means you can add a few dependencies and update the environment as needed.
+    1. You can do this by using an environment file to update the environment.
+    2. Or just use conda or pip to install the new deps
+    3. Update the name (the -n arg) to whatever makes sense for you for your project
+    4. Keep an eye out for updates to the dependencies. This project’s dependencies are here: https://github.com/aws/amazon-sagemaker-examples/blob/master/environment.yml
+    5. Fork the repo: https://github.com/aws/amazon-sagemaker-examples.git
+    6. Clone your fork.
+    7. Cd into the fork directory.
+    8. Create and activate your environment. You can likely use a higher version of Python, but RTD is currently building with 3.6 on production.
+
+```
+# Create the env
+conda create -n sagemaker-examples python=3.6
+# Activate it
+conda activate sagemaker-examples
+```
+
+Install dependencies:
+
+```
+# Install deps from environment file
+conda env update -f environment.yml
+```
+
+#### Dependency Notes:
+
+When you build, there’s a bunch of warnings about a python3 lexer not found. Solution is here: https://github.com/spatialaudio/nbsphinx/issues/24
+Although this workaround required add the following to conf.py and pinning prompt-toolkit as it requires a downgrade to work with the IPython package coming from conda.
+`"IPython.sphinxext.ipython_console_highlighting"`
+
+**Follow-up for next round of dependency updates:** Another workaround could be to use the pip IPython package instead of the conda one (there’s mention the conda one might be buggy), then maybe you don’t need to add that to conf.py or fix prompt-toolkit.
+
+#### Build the website locally
+
+1. Test your setup by building the docs. Run the following from the project root to build the docs.
+
+```
+make html
+```
+
+1. It is usual to see a lot of warnings. It’s a good idea to try to address them. Some projects treat warnings as errors and will fail the build.
+2. Serve the content locally:
+3. cd _build/html
+    python -m http.server 8000
+
+1. Open the html file (index.html) in the `_build/html` folder.
+
+1. open index.html
+
+
+#### Add a notebook to the website
+
+You will typically modify an index.rst file and add the notebook by name, minus the extension. For example, if the new notebook is in a subfolder in the `aws_marketplace` folder:
+https://github.com/aws/amazon-sagemaker-examples/blob/master/aws_marketplace/creating_marketplace_products/Bring_Your_Own-Creating_Algorithm_and_Model_Package.ipynb
+You would modify this file: https://github.com/aws/amazon-sagemaker-examples/blob/master/aws_marketplace/index.rst
+
+
+1. Look for the table of contents directive, `toctree` :
+
+```
+
+.. toctree::
+   :maxdepth: 1
+
+```
+
+1. Add an entry for the new notebook:
+
+```
+
+.. toctree::
+   :maxdepth: 1
+
+   creating_marketplace_products/Bring_Your_Own-Creating_Algorithm_and_Model_Package
+```
+
+#### Adjusting navigation
+
+Some pages have nested title elements that will impact the navigation and depth. The following shows the title, using the top and bottom hash marks (####). Then the single line equals sign (====), then the dashes (----). These are equivalent to H1, H2, and H3, respectively.
+
+```
+################
+AWS Marketplace
+################
+
+Publish algorithm on the AWS Marketplace
+===========================================
+
+Create your algorithm and model package
+----------------------------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   creating_marketplace_products/Bring_Your_Own-Creating_Algorithm_and_Model_Package
+```
+
+You can create further depth by using tilda (~~~~~), asterisk (********), and carrot (^^^^^).
+
+Important: the underline must be at least as long as the title you’re underlining.
+
+#### Adjusting content display
+
+Typically you want to use  `:maxdepth: 1`
+
+You can adjust how much detail from a notebook appears on a page by changing `maxdepth`. Zero and one depth are the same, and these will display just the title. This would be the H1 element for the notebook. Setting this to 2 would display the H2 elements (## Some subtitle) as well.
+
+Sometimes you include topics from other folders on one index page. If you include a subfolder’s index in the TOC using maxdepth of 1, you might just get one entry. So this is an instance where updating maxdepth to 2 would yield a better result.
+
+If more than one entry is displayed for the same notebook, this is because the author of the notebook mistakenly used multiple H1’s. You can see this in the notebooks where they do this:
+
+```
+# Main title
+Some content
+
+## Subtitle
+Some content
+
+# Some other section
+Some content
+```
+
+Then you’ll get a two bullets (the extra “Some other section” when there should only be one for the main title.
+
+#### Troubleshooting
+
+* Each notebook should have at least one section title
+
+> /Users/markhama/Development/amazon-sagemaker-examples/r_examples/r_batch_transform/r_xgboost_batch_transform.ipynb:6: WARNING: Each notebook should have at least one section title
+
+This means the author doesn’t have a title in the notebook. The first markdown block should have a title like `# Some fancy title`. In some cases the author used html tags like <h1>. These render fine on GitHub, but will error in the website build causing the notebook to be skipped.
+
+* toctree contains reference to nonexisting document
+
+> ~/Development/amazon-sagemaker-examples/r_examples/index.rst:5: WARNING: toctree contains reference to nonexisting document 'r_examples/r_batch_transform/r_xgboost_batch_tranform'
+
+Check your spelling in the notebook’s path.
+
+
+* Notebook has an entry, but the title seems incorrect.
+
+Check the notebook for the title (# Some title). The author likely didn’t conform to title/subtitle hierarchy in markdown.
+
+
 ### Commit Your Change
 
 Use imperative style and keep things concise but informative. See [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/) for guidance.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,15 +57,16 @@ If your PR does not pass CI, you can view the logs to understand how to fix your
 
 #### Environment Setup
 
-1. Setup your environment. You can use the same Conda environment for multiple related projects. This means you can add a few dependencies and update the environment as needed.
-    1. You can do this by using an environment file to update the environment.
-    2. Or just use conda or pip to install the new deps
-    3. Update the name (the -n arg) to whatever makes sense for you for your project
-    4. Keep an eye out for updates to the dependencies. This project’s dependencies are here: https://github.com/aws/amazon-sagemaker-examples/blob/master/environment.yml
-    5. Fork the repo: https://github.com/aws/amazon-sagemaker-examples.git
-    6. Clone your fork.
-    7. Cd into the fork directory.
-    8. Create and activate your environment. You can likely use a higher version of Python, but RTD is currently building with 3.6 on production.
+You can use the same Conda environment for multiple related projects. This means you can add a few dependencies and update the environment as needed.
+
+1. You can do this by using an environment file to update the environment
+2. Or just use conda or pip to install the new deps
+3. Update the name (the -n arg) to whatever makes sense for you for your project
+4. Keep an eye out for updates to the dependencies. This project’s dependencies are here: https://github.com/aws/amazon-sagemaker-examples/blob/master/environment.yml
+5. Fork the repo: https://github.com/aws/amazon-sagemaker-examples.git
+6. Clone your fork
+7. Cd into the fork directory
+8. Create and activate your environment. You can likely use a higher version of Python, but RTD is currently building with 3.6 on production
 
 ```
 # Create the env
@@ -116,22 +117,22 @@ You would modify this file: https://github.com/aws/amazon-sagemaker-examples/blo
 
 1. Look for the table of contents directive, `toctree` :
 
-```
+   ```
 
-.. toctree::
-   :maxdepth: 1
+   .. toctree::
+      :maxdepth: 1
 
-```
+   ```
 
 1. Add an entry for the new notebook:
 
-```
+   ```
 
-.. toctree::
-   :maxdepth: 1
+   .. toctree::
+      :maxdepth: 1
 
-   creating_marketplace_products/Bring_Your_Own-Creating_Algorithm_and_Model_Package
-```
+      creating_marketplace_products/Bring_Your_Own-Creating_Algorithm_and_Model_Package
+   ```
 
 #### Adjusting navigation
 
@@ -187,7 +188,7 @@ Then you’ll get a two bullets (the extra “Some other section” when there s
 
 > /Users/markhama/Development/amazon-sagemaker-examples/r_examples/r_batch_transform/r_xgboost_batch_transform.ipynb:6: WARNING: Each notebook should have at least one section title
 
-This means the author doesn’t have a title in the notebook. The first markdown block should have a title like `# Some fancy title`. In some cases the author used html tags like <h1>. These render fine on GitHub, but will error in the website build causing the notebook to be skipped.
+This means the author doesn’t have a title in the notebook. The first markdown block should have a title like `# Some fancy title`. In some cases the author used html tags like `<h1>`. These render fine on GitHub, but will error in the website build causing the notebook to be skipped.
 
 * toctree contains reference to nonexisting document
 

--- a/conf.py
+++ b/conf.py
@@ -31,7 +31,7 @@ release = "1.0.0"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "nbsphinx",
+    "nbsphinx", "IPython.sphinxext.ipython_console_highlighting"
 ]
 
 # extension nbsphinx config

--- a/environment.yml
+++ b/environment.yml
@@ -2,9 +2,12 @@ channels:
    - conda-forge
 
 dependencies:
-   - nbsphinx==0.7.1
-   - sphinx==3.1.1
-   - Jinja2==2.11
+   - IPython==7.6.1
+   - sphinx==4.2.0
+   - Jinja2==3.0.2
    - pip
    - pip:
-      - sagemaker==2.15.0
+      - nbsphinx==0.8.7
+      - prompt-toolkit==2.0.10
+      - sagemaker
+      - sphinx-rtd-theme==1.0.0


### PR DESCRIPTION
*Issue #, if available:*
Website build is broken, so updating dependencies to fix.

*Description of changes:*
1. Unpinned `sagemaker` - if newer notebooks require latest features, we need this unpinned
2. Moved `nbsphinx` from conda to pip to get the latest version, v0.8.7.
3. Upgraded `Jinja2` to the latest, v3.0.2.
4. Upgraded `sphinx` to the latest, v4.2.0.
5. Added IPython at latest v7.6.1 from conda, and had to pin prompt-tookit to 2.0.10 to resolve dependency conflicts. IPython was needed to reduce the warnings from a lexer warning from 9k warnings to 1k warnings. (There are still a lot of unrelated warnings, but this reduces the noise by a lot.)
6. Added `sphinx-rtd-theme` - this is needed to setup a vanilla env locally and to get the website to generate locally.
7. Added instructions on how to build the website locally to CONTRIBUTING.md.

*Testing done:*
Local build works.
Also the test build on RTD works: https://readthedocs.org/projects/sagemaker-examples/builds/15236423/

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [ ] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
