### PR TITLE
Fix multi-model link in rst for website

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,14 +98,15 @@ Although this workaround required add the following to conf.py and pinning promp
 make html
 ```
 
-1. It is usual to see a lot of warnings. It’s a good idea to try to address them. Some projects treat warnings as errors and will fail the build.
-2. Serve the content locally:
-3. cd _build/html
-    python -m http.server 8000
+2. It is usual to see a lot of warnings. It’s a good idea to try to address them. Some projects treat warnings as errors and will fail the build.
+3. Serve the content locally:
 
-1. Open the html file (index.html) in the `_build/html` folder.
+```
+cd _build/html
+python -m http.server 8000
+```
 
-1. open index.html
+4. Either open the index.html file in the `_build/html` directory, or navigate in the browser to: `http://0.0.0.0:8000/`
 
 
 #### Add a notebook to the website

--- a/inference/index.rst
+++ b/inference/index.rst
@@ -78,14 +78,15 @@ Model monitor
    :maxdepth: 1
 
    ../sagemaker_model_monitor/index
-   
+
+
 Multi-Model Deployment
 ======================
 
 .. toctree::
    :maxdepth: 1
 
-   ../advanced_functionality/multi_model_sklearn_no_cache
+   ../advanced_functionality/multi_model_sklearn_home_value/sklearn_multi_model_endpoint_home_value
 
 
 Nvidia Triton Inference


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Add correct path to multi-model deployment in Inference index.rst file for RTD website. Fix instructions for testing local RTD builds.

*Testing done:* Built locally to preview the website.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [ ] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
