### PR TITLE
Clarify object detection - update image test set

### DIFF
--- a/sagemaker-clarify/computer_vision/object_detection/object_detection_clarify.ipynb
+++ b/sagemaker-clarify/computer_vision/object_detection/object_detection_clarify.ipynb
@@ -312,6 +312,7 @@
     "import glob\n",
     "\n",
     "test_images = glob.glob(f\"{TEST_IMAGE_DIR}/*.jpg\")\n",
+    "test_images.remove(\"caltech/elephant_0005.jpg\")\n",
     "test_images"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Remove black and white test image from Clarify object detection image test set.

Notebook link: https://github.com/aws/amazon-sagemaker-examples/blob/master/sagemaker-clarify/computer_vision/object_detection/object_detection_clarify.ipynb

*Testing done:* Ran end-to-end in SageMaker notebook instance.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
