### PR TITLE
Refactor File Import in basic_sagemaker_processing.ipynb

### DIFF
--- a/sagemaker_processing/basic_sagemaker_data_processing/basic_sagemaker_processing.ipynb
+++ b/sagemaker_processing/basic_sagemaker_data_processing/basic_sagemaker_processing.ipynb
@@ -47,7 +47,8 @@
     "import pandas as pd\n",
     "\n",
     "input_data = \"s3://sagemaker-sample-data-{}/processing/census/census-income.csv\".format(region)\n",
-    "df = pd.read_csv(input_data, nrows=10)\n",
+    "! aws s3 cp $input_data .\n",
+    "df = pd.read_csv(\"census-income.csv\", nrows=10)\n",
     "df.to_csv(\"dataset.csv\")\n",
     "# df.head(n=10)"
    ]


### PR DESCRIPTION
*Issue #, if available:*
Not in Github, it just fails daily CI

*Description of changes:*
The boto3 version is different in the old container (conda_3 - boto3 1.14) and the studio container (Data Science - boto3 1.20). In this notebook, pd.read-csv uses boto to read straight from S3, which works fine for older version of boto3 but throws `AttributeError:'AioClientCreator' object has no attribute '_register_lazy_block_unknown_fips_pseudo_regions'` for newer versions of boto3. See [this link]() for more details.

As such, I just refactored how the data is imported to work around this issue. Instead of using pd.read_csv directly, I downloaded the file using AWS CLI instead to work around this issue. This solution worked on both versions of boto3.

*Testing done:*
Ran the notebook in both Studio and Notebook Instance end-to-end and it works.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
