### PR TITLE
Fixes DeepAR electricity notebook

### DIFF
--- a/introduction_to_amazon_algorithms/deepar_electricity/DeepAR-Electricity.ipynb
+++ b/introduction_to_amazon_algorithms/deepar_electricity/DeepAR-Electricity.ipynb
@@ -402,10 +402,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s3_sample = s3.Object(s3_bucket, s3_prefix + '/data/train/train.json').get()['Body'].read()\n",
-    "StringVariable=s3_sample.decode('UTF-8','ignore')\n",
-    "lines = StringVariable.split('\\n')\n",
-    "print(lines[0][:100] + '...')"
+    "s3_sample = s3.Object(s3_bucket, s3_prefix + \"/data/train/train.json\").get()[\"Body\"].read()\n",
+    "StringVariable = s3_sample.decode(\"UTF-8\", \"ignore\")\n",
+    "lines = StringVariable.split(\"\\n\")\n",
+    "print(lines[0][:100] + \"...\")"
    ]
   },
   {

--- a/introduction_to_amazon_algorithms/deepar_electricity/DeepAR-Electricity.ipynb
+++ b/introduction_to_amazon_algorithms/deepar_electricity/DeepAR-Electricity.ipynb
@@ -1154,6 +1154,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "predictor.delete_model()\n",
     "predictor.delete_endpoint()"
    ]
   },
@@ -1163,6 +1164,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "predictor_new_features.delete_model()\n",
     "predictor_new_features.delete_endpoint()"
    ]
   }

--- a/introduction_to_amazon_algorithms/deepar_electricity/DeepAR-Electricity.ipynb
+++ b/introduction_to_amazon_algorithms/deepar_electricity/DeepAR-Electricity.ipynb
@@ -118,9 +118,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "image_name = sagemaker.amazon.amazon_estimator.get_image_uri(region, \"forecasting-deepar\", \"latest\")"
@@ -404,9 +402,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s3filesystem = s3fs.S3FileSystem()\n",
-    "with s3filesystem.open(s3_data_path + \"/train/train.json\", \"rb\") as fp:\n",
-    "    print(fp.readline().decode(\"utf-8\")[:100] + \"...\")"
+    "s3_sample = s3.Object(s3_bucket, s3_prefix + '/data/train/train.json').get()['Body'].read()\n",
+    "StringVariable=s3_sample.decode('UTF-8','ignore')\n",
+    "lines = StringVariable.split('\\n')\n",
+    "print(lines[0][:100] + '...')"
    ]
   },
   {
@@ -818,9 +817,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "# Additional features\n",
     "\n",


### PR DESCRIPTION
*Issue #, if available:*
No known Github issues, but it is failing daily CI

*Description of changes:*
The s3fs library uses boto3. It works on older versions of boto3 (on notebook instances) but fails on newer versions of boto3 (on studio notebooks). You can see [this link](https://github.com/iterative/dvc/issues/7053). Therefore, I refactored the code so it doesn't use s3fs and uses Pythonic S3 instead, which works on both versions of boto3. 

*Testing done:*
Ran the notebooks in both Notebook Instance and Studio notebooks and they both work.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
