### PR TITLE
fix training name conflicts

### DIFF
--- a/r_examples/r_sagemaker_binary_classification_algorithms/R_binary_classification_algorithms_comparison.ipynb
+++ b/r_examples/r_sagemaker_binary_classification_algorithms/R_binary_classification_algorithms_comparison.ipynb
@@ -61,7 +61,7 @@
    "outputs": [],
    "source": [
     "rm(list=ls())\n",
-    "library(reticulate) # be careful not to install reticulate again. since it can cause problems.\n",
+    "library(reticulate)  # be careful not to install reticulate again. since it can cause problems.\n",
     "library(tidyverse)\n",
     "library(pROC)\n",
     "set.seed(1324)"
@@ -314,9 +314,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "write_csv(iris_train, 'iris_train.csv', col_names = FALSE)\n",
-    "write_csv(iris_validate, 'iris_valid.csv', col_names = FALSE)\n",
-    "write_csv(iris_test, 'iris_test.csv', col_names = FALSE)"
+    "write_csv(iris_train, \"iris_train.csv\", col_names=FALSE)\n",
+    "write_csv(iris_validate, \"iris_valid.csv\", col_names=FALSE)\n",
+    "write_csv(iris_test, \"iris_test.csv\", col_names=FALSE)"
    ]
   },
   {

--- a/r_examples/r_sagemaker_binary_classification_algorithms/R_binary_classification_algorithms_comparison.ipynb
+++ b/r_examples/r_sagemaker_binary_classification_algorithms/R_binary_classification_algorithms_comparison.ipynb
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c0a6045c",
+   "id": "2b7bc401",
    "metadata": {},
    "source": [
     "### Load required libraries and initialize variables."
@@ -61,7 +61,7 @@
    "outputs": [],
    "source": [
     "rm(list=ls())\n",
-    "library(reticulate)  # be careful not to install reticulate again. since it can cause problems.\n",
+    "library(reticulate) # be careful not to install reticulate again. since it can cause problems.\n",
     "library(tidyverse)\n",
     "library(pROC)\n",
     "set.seed(1324)"
@@ -314,9 +314,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "write_csv(iris_train, \"iris_train.csv\", col_names=FALSE)\n",
-    "write_csv(iris_validate, \"iris_valid.csv\", col_names=FALSE)\n",
-    "write_csv(iris_test, \"iris_test.csv\", col_names=FALSE)"
+    "write_csv(iris_train, 'iris_train.csv', col_names = FALSE)\n",
+    "write_csv(iris_validate,'iris_valid.csv', col_names = FALSE)\n",
+    "write_csv(iris_test, 'iris_test.csv', col_names = FALSE)"
    ]
   },
   {

--- a/r_examples/r_sagemaker_binary_classification_algorithms/R_binary_classification_algorithms_comparison.ipynb
+++ b/r_examples/r_sagemaker_binary_classification_algorithms/R_binary_classification_algorithms_comparison.ipynb
@@ -491,7 +491,7 @@
     "\n",
     "# train the tuner\n",
     "tuner1$fit(inputs = input_data, \n",
-    "           job_name = paste('sm-tune-xgb', format(Sys.time(), '%Y%m%d-%H-%M-%S'), sep = '-'), \n",
+    "           job_name = paste('tune-xgb', format(Sys.time(), '%Y%m%d-%H-%M-%S'), sep = '-'), \n",
     "           wait=TRUE)"
    ]
   },
@@ -737,7 +737,7 @@
    "outputs": [],
    "source": [
     "# Create a tuning job name\n",
-    "job_name <- paste('linear-tuner', format(Sys.time(), '%Y%m%d-%H-%M-%S'), sep = '-')\n",
+    "job_name <- paste('tune-linear', format(Sys.time(), '%Y%m%d-%H-%M-%S'), sep = '-')\n",
     "\n",
     "# Define the data channels for train and validation datasets\n",
     "input_data <- list('train' = s3_train_input,\n",

--- a/r_examples/r_sagemaker_binary_classification_algorithms/R_binary_classification_algorithms_comparison.ipynb
+++ b/r_examples/r_sagemaker_binary_classification_algorithms/R_binary_classification_algorithms_comparison.ipynb
@@ -3,14 +3,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cf4dc0b3",
+   "id": "37f9f4ba",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "e4fd44cc",
+   "id": "5b5698bb",
    "metadata": {},
    "source": [
     "## Compare built-in Sagemaker classification algorithms for a binary classification problem using Iris dataset"
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69f342df",
+   "id": "14163eab",
    "metadata": {},
    "source": [
     "In the notebook tutorial, we build 3 classification models using HPO and then compare the AUC on test dataset on 3 deployed models\n",
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b7bc401",
+   "id": "c0a6045c",
    "metadata": {},
    "source": [
     "### Load required libraries and initialize variables."
@@ -56,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ae96595e",
+   "id": "173c1e71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7ef8e97",
+   "id": "f97d2e6c",
    "metadata": {},
    "source": [
     "SageMaker needs to be imported using the reticulate library. If this was performed in a local computer, we would have to make sure that Python and appropriate SageMaker libraries are installed, but inside a SageMaker notebook R kernels, these are all pre-loaded and the R user does not have to worry about installing reticulate or Python. \n",
@@ -86,7 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "107a91cb",
+   "id": "7593ba98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "78ac95c7",
+   "id": "53530b5e",
    "metadata": {},
    "source": [
     "### Input the data and basic pre-processing"
@@ -107,7 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e5be74fd",
+   "id": "c24ddf6f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "190824ed",
+   "id": "cbb2c00c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d0391e7e",
+   "id": "7982a1ed",
    "metadata": {},
    "source": [
     "In above, we see that there are 50 flowers of the setosa species, 50 flowers of the versicolor species, and 50 flowers of the virginica species."
@@ -134,7 +134,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32a67ad2",
+   "id": "40d1fcf4",
    "metadata": {},
    "source": [
     "In this case, the target variable is the Species prediction. We are trying to predict the species of the flower given its numerical measurements of Sepal length, sepal width, petal length, and petal width. Since we are trying to do binary classification, we will only take the flower species setosa and versicolor for simplicity. Also we will perform one-hot encoding on the categorical variable Species."
@@ -143,7 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c699c5b2",
+   "id": "75df7ee9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,7 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e338575f",
+   "id": "4ef252ec",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -165,7 +165,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82954ca2",
+   "id": "f97735af",
    "metadata": {},
    "source": [
     "We now obtain some basic descriptive statistics of the features."
@@ -174,7 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c47022b",
+   "id": "ad10f317",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +187,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c3e492f0",
+   "id": "66f9fb2c",
    "metadata": {},
    "source": [
     "In the summary statistics, we observe that mean sepal length is longer than mean petal length for both flowers. "
@@ -195,7 +195,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d7833b26",
+   "id": "070c90a9",
    "metadata": {},
    "source": [
     "### Prepare for modelling"
@@ -203,7 +203,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd7b7a46",
+   "id": "74d1f36b",
    "metadata": {},
    "source": [
     "##### We split the train and test and validate into 70%, 15%, and 15%, using random sampling."
@@ -212,7 +212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f4f6d609",
+   "id": "d87c3fb8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,7 +226,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55124158",
+   "id": "eaf7fa60",
    "metadata": {},
    "source": [
     "##### We do a check of the summary statistics to make sure train, test, validate datasets are appropriately split and have proper class balance."
@@ -235,7 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e4a2cc9",
+   "id": "a99dd5a3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +245,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0b970cf0",
+   "id": "c9ac4ab6",
    "metadata": {},
    "source": [
     "We see that the class balance between 0 and 1 is almost 50% each for the binary classification. We also see that there are 70 rows in the train dataset."
@@ -254,7 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "207d6b36",
+   "id": "6db34e56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,7 +264,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5ba950db",
+   "id": "9d7be948",
    "metadata": {},
    "source": [
     "We see that the class balance in validation dataset between 0 and 1 is almost 50% each for the binary classification. We also see that there are 15 rows in the validation dataset."
@@ -273,7 +273,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d76514ee",
+   "id": "3b31be8c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -283,7 +283,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c2271689",
+   "id": "d2f9975d",
    "metadata": {},
    "source": [
     "We see that the class balance in test dataset between 0 and 1 is almost 50% each for the binary classification. We also see that there are 15 rows in the test dataset."
@@ -291,7 +291,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2307a959",
+   "id": "2d18b6ec",
    "metadata": {},
    "source": [
     "### Write the data to Amazon S3"
@@ -299,7 +299,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55026467",
+   "id": "0fbea1a4",
    "metadata": {},
    "source": [
     "Different algorithms in SageMaker will have different data formats required for training and for testing. These formats are created to make model production easier. csv is the most well known of these formats and has been used here as input in all algorithms to make it consistent.\n",
@@ -310,7 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f25eabdb",
+   "id": "537730b1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,7 +322,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d63db1d8",
+   "id": "c2a7acbd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -341,7 +341,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54df2b27",
+   "id": "53f19015",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -355,7 +355,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2a2542c",
+   "id": "7496e234",
    "metadata": {},
    "source": [
     "To perform Binary classification on Tabular\tdata, SageMaker contains following algorithms:\n",
@@ -368,7 +368,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c01f88a2",
+   "id": "b82df739",
    "metadata": {},
    "source": [
     "## Create model 1: XGBoost model in SageMaker"
@@ -376,7 +376,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d99ff2bc",
+   "id": "dc330102",
    "metadata": {},
    "source": [
     "Use the XGBoost built-in algorithm to build an XGBoost training container as shown in the following code example. You can automatically spot the XGBoost built-in algorithm image URI using the SageMaker image_uris.retrieve API (or the get_image_uri API if using Amazon SageMaker Python SDK version 1). If you want to ensure if the image_uris.retrieve API finds the correct URI, see Common parameters for built-in algorithms and look up XGBoost from the full list of built-in algorithm image URIs and available regions.\n",
@@ -389,7 +389,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29145cfe",
+   "id": "ad09356b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -400,7 +400,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "07325371",
+   "id": "d11386c0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -418,7 +418,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9a7b6207",
+   "id": "9613df5c",
    "metadata": {},
    "source": [
     "How would an untuned model perform compared to a tuned model? Is it worth the effort? Before going deeper into XGBoost model tuning, let’s highlight the reasons why you have to tune your model. The main reason to perform hyper-parameter tuning is to increase predictability of our models by choosing our hyperparameters in a well thought manner. There are 3 ways to perform hyperparameter tuning: grid search, random search, bayesian search. Popular packages like scikit-learn use grid search and random search techniques. SageMaker uses Bayesian search techniques.\n",
@@ -444,7 +444,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c33f178",
+   "id": "f811875a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -463,7 +463,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42771dbc",
+   "id": "13e3449e",
    "metadata": {},
    "source": [
     "The evaluation metric that we will use for our binary classification purpose is validation:auc, but you could use any other metric that is right for your problem. You do have to be careful to change your objective_type to point to the right direction of Maximize or Minimize according to the objective metric you have chosen."
@@ -472,7 +472,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "056f2add",
+   "id": "79e142e7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -491,13 +491,13 @@
     "\n",
     "# train the tuner\n",
     "tuner1$fit(inputs = input_data, \n",
-    "           job_name = paste('sagemaker-tune-xgboost', format(Sys.time(), '%H-%M-%S'), sep = '-'), \n",
+    "           job_name = paste('sm-tune-xgb', format(Sys.time(), '%Y%m%d-%H-%M-%S'), sep = '-'), \n",
     "           wait=TRUE)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "79451cba",
+   "id": "8a9f5a88",
    "metadata": {},
    "source": [
     "The output of the tuning job can be checked in SageMaker if needed."
@@ -505,7 +505,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "278ea863",
+   "id": "326827ad",
    "metadata": {},
    "source": [
     "### Calculate AUC for the test data on model 1"
@@ -513,7 +513,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d1951de",
+   "id": "86a1bb88",
    "metadata": {},
    "source": [
     "SageMaker will automatically recognize the training job with the best evaluation metric and load the hyperparameters associated with that training job when we deploy the model. One of the benefits of SageMaker is that we can easily deploy models in a different instance than the instance in which the notebook is running. So we can deploy into a more powerful instance or a less powerful instance."
@@ -522,7 +522,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a8596325",
+   "id": "1e3793d9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -533,7 +533,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "181de542",
+   "id": "21bac52c",
    "metadata": {},
    "source": [
     "The serializer tells SageMaker what format the model expects data to be input in."
@@ -542,7 +542,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "05d97e07",
+   "id": "d593fd6e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -551,7 +551,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3ec87668",
+   "id": "9a2ac933",
    "metadata": {},
    "source": [
     "We input the `iris_test` dataset without the labels into the model using the `predict` function and check its AUC value."
@@ -560,7 +560,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc3ce0c5",
+   "id": "a38a1ac3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -584,7 +584,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d29c25b7",
+   "id": "7f9ec764",
    "metadata": {},
    "source": [
     "## Create model 2: Linear Learner in SageMaker"
@@ -592,7 +592,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42aa8a6a",
+   "id": "7bcbe089",
    "metadata": {},
    "source": [
     "Linear models are supervised learning algorithms used for solving either classification or regression problems. For input, you give the model labeled examples (x, y). x is a high-dimensional vector and y is a numeric label. For binary classification problems, the label must be either 0 or 1.\n",
@@ -605,7 +605,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c34b9b3d",
+   "id": "3a867f82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -616,7 +616,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ed66e62",
+   "id": "498fa893",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -634,7 +634,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f92dbbdd",
+   "id": "5a02fad2",
    "metadata": {},
    "source": [
     "For the text/csv input type, the first column is assumed to be the label, which is the target variable for prediction."
@@ -642,7 +642,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b2391b3",
+   "id": "632d393e",
    "metadata": {},
    "source": [
     "predictor_type is the only hyperparameter that is required to be pre-defined for tuning. The rest are optional."
@@ -650,7 +650,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9f1a07f5",
+   "id": "72a15930",
    "metadata": {},
    "source": [
     "Normalization, or feature scaling, is an important preprocessing step for certain loss functions that ensures the model being trained on a dataset does not become dominated by the weight of a single feature. Decision trees do not require normalization of their inputs; and since XGBoost is essentially an ensemble algorithm comprised of decision trees, it does not require normalization for the inputs either.\n",
@@ -664,7 +664,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23e49f71",
+   "id": "94170f0f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -674,7 +674,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4eb28cfd",
+   "id": "515f27a0",
    "metadata": {},
    "source": [
     "The tunable hyperparameters for linear learner are:\n",
@@ -692,7 +692,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b79b90bc",
+   "id": "e99913e6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -706,7 +706,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3f777e12",
+   "id": "aedb4f65",
    "metadata": {},
    "source": [
     "The evaluation metric we will be using in our case to compare the models will be the objective loss and is based on the validation dataset. "
@@ -715,7 +715,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9ab03023",
+   "id": "6231b8c6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -732,12 +732,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5803b03b",
+   "id": "903da830",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Create a tuning job name\n",
-    "job_name <- paste('tune-linear-learner', format(Sys.time(), '%H-%M-%S'), sep = '-')\n",
+    "job_name <- paste('linear-tuner', format(Sys.time(), '%Y%m%d-%H-%M-%S'), sep = '-')\n",
     "\n",
     "# Define the data channels for train and validation datasets\n",
     "input_data <- list('train' = s3_train_input,\n",
@@ -749,7 +749,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b7bf6a1",
+   "id": "f9417547",
    "metadata": {},
    "source": [
     "### Calculate AUC for the test data on model 2"
@@ -758,7 +758,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "672ca373",
+   "id": "b8baf008",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -769,7 +769,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "949973bd",
+   "id": "276021e5",
    "metadata": {},
    "source": [
     "For inference, the linear learner algorithm supports the application/json, application/x-recordio-protobuf, and text/csv formats. For more information, https://docs.aws.amazon.com/sagemaker/latest/dg/LL-in-formats.html"
@@ -778,7 +778,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "da8d7f55",
+   "id": "8e92638b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -789,7 +789,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5aed6097",
+   "id": "6935dd8a",
    "metadata": {},
    "source": [
     "In Linear Learner the output inference files are in JSON or RecordIO formats. https://docs.aws.amazon.com/sagemaker/latest/dg/LL-in-formats.html  \n",
@@ -802,7 +802,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dd578e7d",
+   "id": "7cb94971",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -826,7 +826,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f8aff600",
+   "id": "5137331b",
    "metadata": {},
    "source": [
     "## Create model 3: KNN in SageMaker"
@@ -834,7 +834,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48ef375f",
+   "id": "75830886",
    "metadata": {},
    "source": [
     "Amazon SageMaker k-nearest neighbors (k-NN) algorithm is an index-based algorithm. It uses a non-parametric method for classification or regression. For classification problems, the algorithm queries the k points that are closest to the sample point and returns the most frequently used label of their class as the predicted label. For regression problems, the algorithm queries the k closest points to the sample point and returns the average of their feature values as the predicted value.\n",
@@ -847,7 +847,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc3befe5",
+   "id": "658fb307",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -858,7 +858,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8952078c",
+   "id": "ab7692a8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -876,7 +876,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "952cee1b",
+   "id": "34074a56",
    "metadata": {},
    "source": [
     "Hyperparameter `dimension_reduction_target` should not be set when `dimension_reduction_type` is set to its default value, which is `None`. If 'dimension_reduction_target' is set to a certain number without setting `dimension_reduction_type`, then SageMaker will ask us to remove 'dimension_reduction_target' from the specified hyperparameters and try again. In this tutorial, we are not performing dimensionality reduction, since we only have 4 features; so `dimension_reduction_type` is set to its default value of `None`."
@@ -885,7 +885,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37ef7aa7",
+   "id": "18ea1ad8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -898,7 +898,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "484f987c",
+   "id": "46fec60d",
    "metadata": {},
    "source": [
     "Amazon SageMaker k-nearest neighbor model can be tuned  with the following hyperparameters:\n",
@@ -909,7 +909,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a91bd395",
+   "id": "9a34839e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -921,7 +921,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59ad0005",
+   "id": "666fea10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -938,12 +938,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d6d49b48",
+   "id": "91e2c011",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Create a tuning job name\n",
-    "job_name <- paste('tune-knn', format(Sys.time(), '%H-%M-%S'), sep = '-')\n",
+    "job_name <- paste('tune-knn', format(Sys.time(), '%Y%m%d-%H-%M-%S'), sep = '-')\n",
     "\n",
     "# Define the data channels for train and validation datasets\n",
     "input_data <- list('train' = s3_train_input,\n",
@@ -956,7 +956,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0887c62d",
+   "id": "eeef3454",
    "metadata": {},
    "source": [
     "### Calculate AUC for the test data on model 3"
@@ -965,7 +965,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c204889d",
+   "id": "ddf32581",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -976,7 +976,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d4243dba",
+   "id": "608cc246",
    "metadata": {},
    "source": [
     "For inference, the linear learner algorithm supports the application/json, application/x-recordio-protobuf, and text/csv formats. For more information, https://docs.aws.amazon.com/sagemaker/latest/dg/LL-in-formats.html"
@@ -985,7 +985,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "167ced33",
+   "id": "2d17856d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -996,7 +996,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "01ce50fd",
+   "id": "178d3b51",
    "metadata": {},
    "source": [
     "In KNN, the input formats for inference are:\n",
@@ -1023,7 +1023,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "017e7253",
+   "id": "5b4580f3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1037,7 +1037,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66a9203b",
+   "id": "5705e89d",
    "metadata": {},
    "source": [
     "We see that the output is of a deserialized JSON format."
@@ -1046,7 +1046,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d2380e5",
+   "id": "2425a1ea",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1056,7 +1056,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b9c12fab",
+   "id": "cc8418a7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1066,7 +1066,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a755d464",
+   "id": "b9890754",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1082,7 +1082,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d36155c6",
+   "id": "674004bf",
    "metadata": {},
    "source": [
     "## Compare the AUC of 3 models for the test data"
@@ -1090,7 +1090,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af1cca8d",
+   "id": "b723d78a",
    "metadata": {},
    "source": [
     "\n",
@@ -1104,7 +1104,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4e81c277",
+   "id": "18b68631",
    "metadata": {},
    "source": [
     "Based on the AUC metric (the higher the better), both XGBoost and KNN perform equally well and are better than the Linear Learner. We can also explore the 3 models with other binary classification metrics such as accuracy, F1 score, and misclassification error. Comparing only the AUC, in this example, we could chose either the XGBoost model or the KNN model to move onto production and close the other two. The deployed model of our choosing can be passed onto production to generate predictions of flower species given that the user only has its sepal and petal measurements. The performance of the deployed model can also be tracked in Amazon CloudWatch."
@@ -1112,7 +1112,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a9dd325",
+   "id": "fd9fee25",
    "metadata": {},
    "source": [
     "## Clean up "
@@ -1120,7 +1120,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4b7ef60",
+   "id": "0e487180",
    "metadata": {},
    "source": [
     "##### We close the endpoints which we created to free up resources."
@@ -1129,10 +1129,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f27da27",
+   "id": "cc39ec8f",
    "metadata": {},
    "outputs": [],
    "source": [
+    "model_endpoint1$delete_model()\n",
+    "model_endpoint2$delete_model()\n",
+    "model_endpoint3$delete_model()\n",
+    "\n",
     "session$delete_endpoint(model_endpoint1$endpoint)\n",
     "session$delete_endpoint(model_endpoint2$endpoint)\n",
     "session$delete_endpoint(model_endpoint3$endpoint)\n"

--- a/r_examples/r_sagemaker_binary_classification_algorithms/R_binary_classification_algorithms_comparison.ipynb
+++ b/r_examples/r_sagemaker_binary_classification_algorithms/R_binary_classification_algorithms_comparison.ipynb
@@ -3,14 +3,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37f9f4ba",
+   "id": "cf4dc0b3",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "5b5698bb",
+   "id": "e4fd44cc",
    "metadata": {},
    "source": [
     "## Compare built-in Sagemaker classification algorithms for a binary classification problem using Iris dataset"
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14163eab",
+   "id": "69f342df",
    "metadata": {},
    "source": [
     "In the notebook tutorial, we build 3 classification models using HPO and then compare the AUC on test dataset on 3 deployed models\n",
@@ -56,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "173c1e71",
+   "id": "ae96595e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f97d2e6c",
+   "id": "e7ef8e97",
    "metadata": {},
    "source": [
     "SageMaker needs to be imported using the reticulate library. If this was performed in a local computer, we would have to make sure that Python and appropriate SageMaker libraries are installed, but inside a SageMaker notebook R kernels, these are all pre-loaded and the R user does not have to worry about installing reticulate or Python. \n",
@@ -86,7 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7593ba98",
+   "id": "107a91cb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53530b5e",
+   "id": "78ac95c7",
    "metadata": {},
    "source": [
     "### Input the data and basic pre-processing"
@@ -107,7 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c24ddf6f",
+   "id": "e5be74fd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cbb2c00c",
+   "id": "190824ed",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7982a1ed",
+   "id": "d0391e7e",
    "metadata": {},
    "source": [
     "In above, we see that there are 50 flowers of the setosa species, 50 flowers of the versicolor species, and 50 flowers of the virginica species."
@@ -134,7 +134,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40d1fcf4",
+   "id": "32a67ad2",
    "metadata": {},
    "source": [
     "In this case, the target variable is the Species prediction. We are trying to predict the species of the flower given its numerical measurements of Sepal length, sepal width, petal length, and petal width. Since we are trying to do binary classification, we will only take the flower species setosa and versicolor for simplicity. Also we will perform one-hot encoding on the categorical variable Species."
@@ -143,7 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75df7ee9",
+   "id": "c699c5b2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,7 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4ef252ec",
+   "id": "e338575f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -165,7 +165,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f97735af",
+   "id": "82954ca2",
    "metadata": {},
    "source": [
     "We now obtain some basic descriptive statistics of the features."
@@ -174,7 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ad10f317",
+   "id": "1c47022b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +187,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66f9fb2c",
+   "id": "c3e492f0",
    "metadata": {},
    "source": [
     "In the summary statistics, we observe that mean sepal length is longer than mean petal length for both flowers. "
@@ -195,7 +195,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "070c90a9",
+   "id": "d7833b26",
    "metadata": {},
    "source": [
     "### Prepare for modelling"
@@ -203,7 +203,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74d1f36b",
+   "id": "dd7b7a46",
    "metadata": {},
    "source": [
     "##### We split the train and test and validate into 70%, 15%, and 15%, using random sampling."
@@ -212,7 +212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d87c3fb8",
+   "id": "f4f6d609",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,7 +226,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eaf7fa60",
+   "id": "55124158",
    "metadata": {},
    "source": [
     "##### We do a check of the summary statistics to make sure train, test, validate datasets are appropriately split and have proper class balance."
@@ -235,7 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a99dd5a3",
+   "id": "1e4a2cc9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +245,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c9ac4ab6",
+   "id": "0b970cf0",
    "metadata": {},
    "source": [
     "We see that the class balance between 0 and 1 is almost 50% each for the binary classification. We also see that there are 70 rows in the train dataset."
@@ -254,7 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6db34e56",
+   "id": "207d6b36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,7 +264,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d7be948",
+   "id": "5ba950db",
    "metadata": {},
    "source": [
     "We see that the class balance in validation dataset between 0 and 1 is almost 50% each for the binary classification. We also see that there are 15 rows in the validation dataset."
@@ -273,7 +273,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3b31be8c",
+   "id": "d76514ee",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -283,7 +283,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d2f9975d",
+   "id": "c2271689",
    "metadata": {},
    "source": [
     "We see that the class balance in test dataset between 0 and 1 is almost 50% each for the binary classification. We also see that there are 15 rows in the test dataset."
@@ -291,7 +291,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d18b6ec",
+   "id": "2307a959",
    "metadata": {},
    "source": [
     "### Write the data to Amazon S3"
@@ -299,7 +299,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0fbea1a4",
+   "id": "55026467",
    "metadata": {},
    "source": [
     "Different algorithms in SageMaker will have different data formats required for training and for testing. These formats are created to make model production easier. csv is the most well known of these formats and has been used here as input in all algorithms to make it consistent.\n",
@@ -310,7 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "537730b1",
+   "id": "f25eabdb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,7 +322,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c2a7acbd",
+   "id": "d63db1d8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -341,7 +341,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53f19015",
+   "id": "54df2b27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -355,7 +355,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7496e234",
+   "id": "e2a2542c",
    "metadata": {},
    "source": [
     "To perform Binary classification on Tabular\tdata, SageMaker contains following algorithms:\n",
@@ -368,7 +368,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b82df739",
+   "id": "c01f88a2",
    "metadata": {},
    "source": [
     "## Create model 1: XGBoost model in SageMaker"
@@ -376,7 +376,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc330102",
+   "id": "d99ff2bc",
    "metadata": {},
    "source": [
     "Use the XGBoost built-in algorithm to build an XGBoost training container as shown in the following code example. You can automatically spot the XGBoost built-in algorithm image URI using the SageMaker image_uris.retrieve API (or the get_image_uri API if using Amazon SageMaker Python SDK version 1). If you want to ensure if the image_uris.retrieve API finds the correct URI, see Common parameters for built-in algorithms and look up XGBoost from the full list of built-in algorithm image URIs and available regions.\n",
@@ -389,7 +389,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ad09356b",
+   "id": "29145cfe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -400,7 +400,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d11386c0",
+   "id": "07325371",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -418,7 +418,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9613df5c",
+   "id": "9a7b6207",
    "metadata": {},
    "source": [
     "How would an untuned model perform compared to a tuned model? Is it worth the effort? Before going deeper into XGBoost model tuning, let’s highlight the reasons why you have to tune your model. The main reason to perform hyper-parameter tuning is to increase predictability of our models by choosing our hyperparameters in a well thought manner. There are 3 ways to perform hyperparameter tuning: grid search, random search, bayesian search. Popular packages like scikit-learn use grid search and random search techniques. SageMaker uses Bayesian search techniques.\n",
@@ -444,7 +444,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f811875a",
+   "id": "0c33f178",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -463,7 +463,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13e3449e",
+   "id": "42771dbc",
    "metadata": {},
    "source": [
     "The evaluation metric that we will use for our binary classification purpose is validation:auc, but you could use any other metric that is right for your problem. You do have to be careful to change your objective_type to point to the right direction of Maximize or Minimize according to the objective metric you have chosen."
@@ -472,7 +472,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79e142e7",
+   "id": "056f2add",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -497,7 +497,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a9f5a88",
+   "id": "79451cba",
    "metadata": {},
    "source": [
     "The output of the tuning job can be checked in SageMaker if needed."
@@ -505,7 +505,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "326827ad",
+   "id": "278ea863",
    "metadata": {},
    "source": [
     "### Calculate AUC for the test data on model 1"
@@ -513,7 +513,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86a1bb88",
+   "id": "1d1951de",
    "metadata": {},
    "source": [
     "SageMaker will automatically recognize the training job with the best evaluation metric and load the hyperparameters associated with that training job when we deploy the model. One of the benefits of SageMaker is that we can easily deploy models in a different instance than the instance in which the notebook is running. So we can deploy into a more powerful instance or a less powerful instance."
@@ -522,7 +522,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e3793d9",
+   "id": "a8596325",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -533,7 +533,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21bac52c",
+   "id": "181de542",
    "metadata": {},
    "source": [
     "The serializer tells SageMaker what format the model expects data to be input in."
@@ -542,7 +542,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d593fd6e",
+   "id": "05d97e07",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -551,7 +551,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9a2ac933",
+   "id": "3ec87668",
    "metadata": {},
    "source": [
     "We input the `iris_test` dataset without the labels into the model using the `predict` function and check its AUC value."
@@ -560,7 +560,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a38a1ac3",
+   "id": "cc3ce0c5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -584,7 +584,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f9ec764",
+   "id": "d29c25b7",
    "metadata": {},
    "source": [
     "## Create model 2: Linear Learner in SageMaker"
@@ -592,7 +592,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bcbe089",
+   "id": "42aa8a6a",
    "metadata": {},
    "source": [
     "Linear models are supervised learning algorithms used for solving either classification or regression problems. For input, you give the model labeled examples (x, y). x is a high-dimensional vector and y is a numeric label. For binary classification problems, the label must be either 0 or 1.\n",
@@ -605,7 +605,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3a867f82",
+   "id": "c34b9b3d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -616,7 +616,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "498fa893",
+   "id": "2ed66e62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -634,7 +634,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5a02fad2",
+   "id": "f92dbbdd",
    "metadata": {},
    "source": [
     "For the text/csv input type, the first column is assumed to be the label, which is the target variable for prediction."
@@ -642,7 +642,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "632d393e",
+   "id": "6b2391b3",
    "metadata": {},
    "source": [
     "predictor_type is the only hyperparameter that is required to be pre-defined for tuning. The rest are optional."
@@ -650,7 +650,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "72a15930",
+   "id": "9f1a07f5",
    "metadata": {},
    "source": [
     "Normalization, or feature scaling, is an important preprocessing step for certain loss functions that ensures the model being trained on a dataset does not become dominated by the weight of a single feature. Decision trees do not require normalization of their inputs; and since XGBoost is essentially an ensemble algorithm comprised of decision trees, it does not require normalization for the inputs either.\n",
@@ -664,7 +664,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94170f0f",
+   "id": "23e49f71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -674,7 +674,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "515f27a0",
+   "id": "4eb28cfd",
    "metadata": {},
    "source": [
     "The tunable hyperparameters for linear learner are:\n",
@@ -692,7 +692,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e99913e6",
+   "id": "b79b90bc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -706,7 +706,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aedb4f65",
+   "id": "3f777e12",
    "metadata": {},
    "source": [
     "The evaluation metric we will be using in our case to compare the models will be the objective loss and is based on the validation dataset. "
@@ -715,7 +715,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6231b8c6",
+   "id": "9ab03023",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -732,7 +732,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "903da830",
+   "id": "5803b03b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -749,7 +749,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9417547",
+   "id": "2b7bf6a1",
    "metadata": {},
    "source": [
     "### Calculate AUC for the test data on model 2"
@@ -758,7 +758,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b8baf008",
+   "id": "672ca373",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -769,7 +769,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "276021e5",
+   "id": "949973bd",
    "metadata": {},
    "source": [
     "For inference, the linear learner algorithm supports the application/json, application/x-recordio-protobuf, and text/csv formats. For more information, https://docs.aws.amazon.com/sagemaker/latest/dg/LL-in-formats.html"
@@ -778,7 +778,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e92638b",
+   "id": "da8d7f55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -789,7 +789,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6935dd8a",
+   "id": "5aed6097",
    "metadata": {},
    "source": [
     "In Linear Learner the output inference files are in JSON or RecordIO formats. https://docs.aws.amazon.com/sagemaker/latest/dg/LL-in-formats.html  \n",
@@ -802,7 +802,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7cb94971",
+   "id": "dd578e7d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -826,7 +826,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5137331b",
+   "id": "f8aff600",
    "metadata": {},
    "source": [
     "## Create model 3: KNN in SageMaker"
@@ -834,7 +834,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "75830886",
+   "id": "48ef375f",
    "metadata": {},
    "source": [
     "Amazon SageMaker k-nearest neighbors (k-NN) algorithm is an index-based algorithm. It uses a non-parametric method for classification or regression. For classification problems, the algorithm queries the k points that are closest to the sample point and returns the most frequently used label of their class as the predicted label. For regression problems, the algorithm queries the k closest points to the sample point and returns the average of their feature values as the predicted value.\n",
@@ -847,7 +847,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "658fb307",
+   "id": "cc3befe5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -858,7 +858,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ab7692a8",
+   "id": "8952078c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -876,7 +876,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34074a56",
+   "id": "952cee1b",
    "metadata": {},
    "source": [
     "Hyperparameter `dimension_reduction_target` should not be set when `dimension_reduction_type` is set to its default value, which is `None`. If 'dimension_reduction_target' is set to a certain number without setting `dimension_reduction_type`, then SageMaker will ask us to remove 'dimension_reduction_target' from the specified hyperparameters and try again. In this tutorial, we are not performing dimensionality reduction, since we only have 4 features; so `dimension_reduction_type` is set to its default value of `None`."
@@ -885,7 +885,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18ea1ad8",
+   "id": "37ef7aa7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -898,7 +898,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46fec60d",
+   "id": "484f987c",
    "metadata": {},
    "source": [
     "Amazon SageMaker k-nearest neighbor model can be tuned  with the following hyperparameters:\n",
@@ -909,7 +909,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9a34839e",
+   "id": "a91bd395",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -921,7 +921,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "666fea10",
+   "id": "59ad0005",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -938,7 +938,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91e2c011",
+   "id": "d6d49b48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -956,7 +956,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eeef3454",
+   "id": "0887c62d",
    "metadata": {},
    "source": [
     "### Calculate AUC for the test data on model 3"
@@ -965,7 +965,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ddf32581",
+   "id": "c204889d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -976,7 +976,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "608cc246",
+   "id": "d4243dba",
    "metadata": {},
    "source": [
     "For inference, the linear learner algorithm supports the application/json, application/x-recordio-protobuf, and text/csv formats. For more information, https://docs.aws.amazon.com/sagemaker/latest/dg/LL-in-formats.html"
@@ -985,7 +985,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2d17856d",
+   "id": "167ced33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -996,7 +996,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "178d3b51",
+   "id": "01ce50fd",
    "metadata": {},
    "source": [
     "In KNN, the input formats for inference are:\n",
@@ -1023,7 +1023,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5b4580f3",
+   "id": "017e7253",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1037,7 +1037,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5705e89d",
+   "id": "66a9203b",
    "metadata": {},
    "source": [
     "We see that the output is of a deserialized JSON format."
@@ -1046,7 +1046,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2425a1ea",
+   "id": "7d2380e5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1056,7 +1056,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc8418a7",
+   "id": "b9c12fab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1066,7 +1066,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b9890754",
+   "id": "a755d464",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1082,7 +1082,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "674004bf",
+   "id": "d36155c6",
    "metadata": {},
    "source": [
     "## Compare the AUC of 3 models for the test data"
@@ -1090,7 +1090,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b723d78a",
+   "id": "af1cca8d",
    "metadata": {},
    "source": [
     "\n",
@@ -1104,7 +1104,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18b68631",
+   "id": "4e81c277",
    "metadata": {},
    "source": [
     "Based on the AUC metric (the higher the better), both XGBoost and KNN perform equally well and are better than the Linear Learner. We can also explore the 3 models with other binary classification metrics such as accuracy, F1 score, and misclassification error. Comparing only the AUC, in this example, we could chose either the XGBoost model or the KNN model to move onto production and close the other two. The deployed model of our choosing can be passed onto production to generate predictions of flower species given that the user only has its sepal and petal measurements. The performance of the deployed model can also be tracked in Amazon CloudWatch."
@@ -1112,7 +1112,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fd9fee25",
+   "id": "3a9dd325",
    "metadata": {},
    "source": [
     "## Clean up "
@@ -1120,7 +1120,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e487180",
+   "id": "e4b7ef60",
    "metadata": {},
    "source": [
     "##### We close the endpoints which we created to free up resources."
@@ -1129,7 +1129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc39ec8f",
+   "id": "6f27da27",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/r_examples/r_sagemaker_binary_classification_algorithms/R_binary_classification_algorithms_comparison.ipynb
+++ b/r_examples/r_sagemaker_binary_classification_algorithms/R_binary_classification_algorithms_comparison.ipynb
@@ -315,7 +315,7 @@
    "outputs": [],
    "source": [
     "write_csv(iris_train, 'iris_train.csv', col_names = FALSE)\n",
-    "write_csv(iris_validate,'iris_valid.csv', col_names = FALSE)\n",
+    "write_csv(iris_validate, 'iris_valid.csv', col_names = FALSE)\n",
     "write_csv(iris_test, 'iris_test.csv', col_names = FALSE)"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:*
No related Github issue, just that daily CI fails everyday.

*Description of changes:*
This notebook in the daily CI constantly throws the following error:
```
ResourceInUse: An error occurred (ResourceInUse) when calling the CreateHyperParameterTuningJob operation: A hyperparameter tuning job with the name, sagemaker-tune-xgboost-00-12-30, already exists. Choose a different name.
```

This is because only the hour, minute, and second is included in the title. As the CI runs at approximately the same time everyday, naming conflict is inevitable. As such, I changed the name to also include the date, so there would be no naming conflicts.

Additionally, I made the cleanup more thorough, deleting models alongside endpoints.
 

*Testing done:*
Ran the notebook end-to-end and it works

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
