### PR TITLE
Edit code to make sure model training finishes in r_xgboost_hpo_batch_transform.ipynb 

### DIFF
--- a/r_examples/r_xgboost_hpo_batch_transform/r_xgboost_hpo_batch_transform.ipynb
+++ b/r_examples/r_xgboost_hpo_batch_transform/r_xgboost_hpo_batch_transform.ipynb
@@ -968,9 +968,9 @@
    "mimetype": "text/x-r-source",
    "name": "R",
    "pygments_lexer": "r",
-   "version": "4.1.2"
+   "version": "4.0.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }

--- a/r_examples/r_xgboost_hpo_batch_transform/r_xgboost_hpo_batch_transform.ipynb
+++ b/r_examples/r_xgboost_hpo_batch_transform/r_xgboost_hpo_batch_transform.ipynb
@@ -935,6 +935,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "model_endpoint$delete_model()\n",
     "session$delete_endpoint(model_endpoint$endpoint)"
    ]
   },

--- a/r_examples/r_xgboost_hpo_batch_transform/r_xgboost_hpo_batch_transform.ipynb
+++ b/r_examples/r_xgboost_hpo_batch_transform/r_xgboost_hpo_batch_transform.ipynb
@@ -531,20 +531,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Get the status of the tuning job\n",
     "status <- sm$describe_hyper_parameter_tuning_job(\n",
     "    HyperParameterTuningJobName=tuner$latest_tuning_job$job_name)\n",
     "\n",
-    "cat('Hyperparameter Tuning Job Name: ', job_name,'\\n')\n",
-    "cat('Hyperparameter Tuning Job Status: ', status$HyperParameterTuningJobStatus,'\\n')\n",
-    "cat('Succeeded Models:', status$ObjectiveStatusCounters$Succeeded,'\\n')\n",
-    "cat('InProgress Modles:', status$ObjectiveStatusCounters$Pending,'\\n')\n",
-    "cat('Failed Modles:', status$ObjectiveStatusCounters$Failed,'\\n')\n"
+    "message(cat('Hyperparameter Tuning Job Name: ', job_name,'\\n'))\n",
+    "while (status$HyperParameterTuningJobStatus != \"Completed\") {\n",
+    "    message(cat('Hyperparameter Tuning Job Status: ', status$HyperParameterTuningJobStatus,'\\n'))\n",
+    "    message(cat('Succeeded Models:', status$ObjectiveStatusCounters$Succeeded, ' InProgress Models: ', status$ObjectiveStatusCounters$Pending, ' Failed Models: ', status$ObjectiveStatusCounters$Failed, '\\n'))\n",
+    "    Sys.sleep(120)\n",
+    "    status <- sm$describe_hyper_parameter_tuning_job(\n",
+    "    HyperParameterTuningJobName=tuner$latest_tuning_job$job_name)    \n",
+    "}\n"
    ]
   },
   {
@@ -722,9 +723,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Get the status of Batch Transform\n",

--- a/r_examples/r_xgboost_hpo_batch_transform/r_xgboost_hpo_batch_transform.ipynb
+++ b/r_examples/r_xgboost_hpo_batch_transform/r_xgboost_hpo_batch_transform.ipynb
@@ -542,7 +542,7 @@
     "while (status$HyperParameterTuningJobStatus != \"Completed\") {\n",
     "    message(cat('Hyperparameter Tuning Job Status: ', status$HyperParameterTuningJobStatus,'\\n'))\n",
     "    message(cat('Succeeded Models:', status$ObjectiveStatusCounters$Succeeded, ' InProgress Models: ', status$ObjectiveStatusCounters$Pending, ' Failed Models: ', status$ObjectiveStatusCounters$Failed, '\\n'))\n",
-    "    Sys.sleep(120)\n",
+    "    Sys.sleep(60)\n",
     "    status <- sm$describe_hyper_parameter_tuning_job(\n",
     "    HyperParameterTuningJobName=tuner$latest_tuning_job$job_name)    \n",
     "}\n"
@@ -958,9 +958,9 @@
    "mimetype": "text/x-r-source",
    "name": "R",
    "pygments_lexer": "r",
-   "version": "4.0.3"
+   "version": "4.1.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/r_examples/r_xgboost_hpo_batch_transform/r_xgboost_hpo_batch_transform.ipynb
+++ b/r_examples/r_xgboost_hpo_batch_transform/r_xgboost_hpo_batch_transform.ipynb
@@ -944,6 +944,15 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": [
+    "transformer$delete_model()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],


### PR DESCRIPTION
*Issue #, if available:*
No existing issues, just that daily CI fails everyday. 

*Description of changes:*
This notebook is throwing the following error:
```
Parameter validation failed:Invalid type for parameter TrainingJobName, value: None, type: <class 'NoneType'>, valid types: <class 'str'>
```
After some investigation, it is discovered that the CI is moving onto the next cell before model training is complete. As there is no model/data for the next cells to process yet, this error is thrown.

Also, did more thorough cleanup, making sure to delete the model along with the endpoint.

*Testing done:* Ran the notebook end-to-end and it worked with no errors.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
