### PR TITLE
Correct the response content type of the SageMaker Clarify example BYOC

### DIFF
--- a/sagemaker_processing/fairness_and_explainability/container/serve
+++ b/sagemaker_processing/fairness_and_explainability/container/serve
@@ -97,7 +97,7 @@ def predict():
                 "score": prediction}) for prediction in predictions]
     # For batch request, Clarify job expects the same number of result lines as the number of samples in the request.
     output = "\n".join(predictions)
-    return Response(response=output, status=200)
+    return Response(response=output, status=200, headers=[("Content-Type", accept_type)])
 
 
 def main():


### PR DESCRIPTION

*Issue #, if available:*

Currently the response content type of the SageMaker Clarify example BYOC container is always "text/html", although the response payload is either CSV data or JSONLines data.

*Description of changes:*

This commit corrects the problem and set the content type to "text/csv" for CSV data, and "application/jsonlines" for JSONLines data.

*Testing done:*

Tested the example notebook that uses the BYOC container: [Fairness and Explainability with SageMaker Clarify - Bring Your Own Container](https://github.com/aws/amazon-sagemaker-examples/blob/master/sagemaker_processing/fairness_and_explainability/fairness_and_explainability_byoc.ipynb)

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [X] I have tested my notebook(s) and ensured it runs end-to-end
- [X] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
