### PR TITLE
Fix training name conflict error by adding date in addition to time in r_xgboost_batch_transform.ipynb

### DIFF
--- a/r_examples/r_batch_transform/r_xgboost_batch_transform.ipynb
+++ b/r_examples/r_batch_transform/r_xgboost_batch_transform.ipynb
@@ -390,7 +390,7 @@
    "outputs": [],
    "source": [
     "# Create a training job name\n",
-    "job_name <- paste('sagemaker-r-xgboost', format(Sys.time(), '%H-%M-%S'), sep = '-')\n",
+    "job_name <- paste('sagemaker-r-xgboost', format(Sys.time(), '%Y%m%d-%H-%M-%S'), sep = '-')\n",
     "\n",
     "# Define the data channels for train and validation datasets\n",
     "input_data <- list('train' = s3_train_input,\n",


### PR DESCRIPTION
*Issue #, if available:*
None, but the daily CI fails

*Description of changes:*
The daily CI throws this error:
```
Error in py_call_impl(callable, dots$args, dots$keywords):ResourceInUse: An error occurred (ResourceInUse) when calling the CreateTrainingJob operation: Training job names must be unique within an AWS account and region, and a training job with this name already exists (arn:aws:sagemaker:us-west-2:521695447989:training-job/sagemaker-r-xgboost-00-12-38)
```
This is because only the hour, minute, and second is included in the title. As the CI runs at approximately the same time everyday, naming conflict is inevitable. As such, I changed the name to also include the date, so there would be no naming conflicts.

*Testing done:*
Ran the notebook end-to-end and it works.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
