### PR TITLE
Switch to official S3 bucket for higgs_boson_detection.ipynb

### DIFF
--- a/sagemaker-debugger/xgboost_training_report/higgs_boson_detection.ipynb
+++ b/sagemaker-debugger/xgboost_training_report/higgs_boson_detection.ipynb
@@ -102,8 +102,7 @@
    "outputs": [],
    "source": [
     "# Download the data from CERN\n",
-    "! wget -N http://opendata.cern.ch/record/328/files/atlas-higgs-challenge-2014-v2.csv.gz\n",
-    "! gunzip -f atlas-higgs-challenge-2014-v2.csv.gz\n",
+    "! aws s3 cp s3://sagemaker-sample-files/datasets/tabular/atlas_higgs_boson_2014/atlas-higgs-challenge-2014-v2.csv .\n",
     "df = pd.read_csv(\"atlas-higgs-challenge-2014-v2.csv\")"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
To avoid dependencies on third-party data sources (which can be unreliable and may be removed without our knowledge), we switch the data source from the original source to an official S3 bucket managed by the Sagemaker notebook team where a copy of the data is placed.

*Testing done:*
Ran through the notebook end-to-end and there were no issues.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
