### PR TITLE
Standardize UCI Covertype Dataset data source

### DIFF
--- a/scientific_details_of_algorithms/linear_learner_multiclass_classification/linear_learner_multiclass_classification.ipynb
+++ b/scientific_details_of_algorithms/linear_learner_multiclass_classification/linear_learner_multiclass_classification.ipynb
@@ -97,9 +97,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# download the raw data \n",
+    "# download the raw data\n",
     "s3 = boto3.client(\"s3\")\n",
-    "s3.download_file(f\"sagemaker-sample-files\", \"datasets/tabular/uci_covtype/covtype.data.gz\", \"covtype.data.gz\")"
+    "s3.download_file(\n",
+    "    f\"sagemaker-sample-files\", \"datasets/tabular/uci_covtype/covtype.data.gz\", \"covtype.data.gz\"\n",
+    ")"
    ]
   },
   {

--- a/scientific_details_of_algorithms/linear_learner_multiclass_classification/linear_learner_multiclass_classification.ipynb
+++ b/scientific_details_of_algorithms/linear_learner_multiclass_classification/linear_learner_multiclass_classification.ipynb
@@ -110,7 +110,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# unzip teh raw dataset\n",
+    "# unzip the raw dataset\n",
     "!gunzip covtype.data.gz"
    ]
   },

--- a/scientific_details_of_algorithms/linear_learner_multiclass_classification/linear_learner_multiclass_classification.ipynb
+++ b/scientific_details_of_algorithms/linear_learner_multiclass_classification/linear_learner_multiclass_classification.ipynb
@@ -87,7 +87,8 @@
     "from sklearn.model_selection import train_test_split\n",
     "import pandas as pd\n",
     "import numpy as np\n",
-    "import seaborn as sns"
+    "import seaborn as sns\n",
+    "import boto3"
    ]
   },
   {
@@ -96,8 +97,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# download the raw data and unzip\n",
-    "!wget https://archive.ics.uci.edu/ml/machine-learning-databases/covtype/covtype.data.gz\n",
+    "# download the raw data \n",
+    "s3 = boto3.client(\"s3\")\n",
+    "s3.download_file(f\"sagemaker-sample-files\", \"datasets/tabular/uci_covtype/covtype.data.gz\", \"covtype.data.gz\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# unzip teh raw dataset\n",
     "!gunzip covtype.data.gz"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As part of the effort to make notebooks use resources owned by the Sagemaker Example Notebook Team, these notebooks that import UCI Covertype dataset from external sources were edited to import from sagemaker-sample-files instead.

*Testing done:*
Ran notebooks end-to-end and it works.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
