### PR TITLE
Wait for in-service endpoint before deletion

### DIFF
--- a/sagemaker-pipelines/tabular/lambda-step/sagemaker-pipelines-lambda-step.ipynb
+++ b/sagemaker-pipelines/tabular/lambda-step/sagemaker-pipelines-lambda-step.ipynb
@@ -814,6 +814,20 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a SageMaker client\n",
+    "sm_client = boto3.client(\"sagemaker\")\n",
+    "\n",
+    "# Wait for the endpoint to be in service\n",
+    "waiter = sm_client.get_waiter(\"endpoint_in_service\")\n",
+    "waiter.wait(EndpointName=endpoint_name)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -833,9 +847,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create a SageMaker client\n",
-    "sm_client = boto3.client(\"sagemaker\")\n",
-    "\n",
     "# Get the model name from the EndpointCofig. The CreateModelStep properties are not available outside the Pipeline execution context\n",
     "# so `step_create_model.properties.ModelName` can not be used while deleting the model.\n",
     "model_name = sm_client.describe_endpoint_config(EndpointConfigName=endpoint_config_name)[\n",


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* This notebook deletes all resources created by the Pipeline, but the endpoint was still in-progress by the time the deletion was attempted, causing a failure. To fix, wait for the endpoint to be in-service before deleting it.

*Testing done:* Ran end-to-end in notebook instance.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
