### PR TITLE
Fix tensorflow-serving-tfrecord-python-sdk.ipynb Numpy Compatibility Issues

### DIFF
--- a/sagemaker_batch_transform/tensorflow_open-images_tfrecord/tensorflow-serving-tfrecord-python-sdk.ipynb
+++ b/sagemaker_batch_transform/tensorflow_open-images_tfrecord/tensorflow-serving-tfrecord-python-sdk.ipynb
@@ -242,7 +242,6 @@
    "outputs": [],
    "source": [
     "!aws s3 cp s3://sagemaker-sample-data-{region}/batch-transform/open-images/tfrecord/train-00001-of-00100 {download_path}\n",
-    "!pip install tensorflow\n",
     "import tensorflow as tf\n",
     "\n",
     "iterator = tf.compat.v1.python_io.tf_record_iterator(\n",


### PR DESCRIPTION
*Issue #, if available:*
Daily CI fails

*Description of changes:*
The daily Ci throws the following error:
```
RuntimeError: module compiled against API version 0xe but this version of numpy is 0xd
```

The Numpy incompatibility was probably caused by updating Tensorflow using pip install (because that also updates dependencies like Numpy). Therefore, I deleted the line that pip installed/upgraded Tensorflow to fix this issue.

*Testing done:*
Ran notebook end-to-end and it works

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
