### PR TITLE
Update fairness_and_explainability.ipynb

### DIFF
--- a/sagemaker_processing/fairness_and_explainability/fairness_and_explainability.ipynb
+++ b/sagemaker_processing/fairness_and_explainability/fairness_and_explainability.ipynb
@@ -621,7 +621,7 @@
     "    \"Example number:\",\n",
     "    selected_example,\n",
     "    \"\\nwith model prediction:\",\n",
-    "    sum(local_explanations_out.iloc[selected_example]) > 0,\n",
+    "    sum(local_explanations_out.iloc[selected_example]) > 0.8,\n",
     ")\n",
     "print(\"\\nFeature values -- Label\", training_data.iloc[selected_example])\n",
     "local_explanations_out.iloc[selected_example].plot(\n",


### PR DESCRIPTION
From working out the values of the post-training metrics from the model predictions, the values do not match the bias report values using the given logic that if the sum of local_explanations_out values (shap values) for given instance is > 0, then the prediction is True. However, they do match if the value of 0 is changed to the probability threshold of 0.8 used in the model.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [ ] I have tested my notebook(s) and ensured it runs end-to-end
- [ ] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
