### PR TITLE
Use Sagemaker SDK instead of boto3 to get region_name

### DIFF
--- a/introduction_to_applying_machine_learning/xgboost_customer_churn/xgboost_customer_churn.ipynb
+++ b/introduction_to_applying_machine_learning/xgboost_customer_churn/xgboost_customer_churn.ipynb
@@ -674,7 +674,7 @@
    },
    "outputs": [],
    "source": [
-    "container = sagemaker.image_uris.retrieve(\"xgboost\", boto3.Session().region_name, \"latest\")\n",
+    "container = sagemaker.image_uris.retrieve(\"xgboost\", sess.boto_region_name, \"latest\")\n",
     "display(container)"
    ]
   },

--- a/sagemaker-pipelines/tabular/abalone_build_train_deploy/sagemaker-pipelines-preprocess-train-evaluate-batch-transform.ipynb
+++ b/sagemaker-pipelines/tabular/abalone_build_train_deploy/sagemaker-pipelines-preprocess-train-evaluate-batch-transform.ipynb
@@ -93,8 +93,8 @@
     "import sagemaker\n",
     "\n",
     "\n",
-    "region = boto3.Session().region_name\n",
     "sagemaker_session = sagemaker.session.Session()\n",
+    "region = sagemaker_session.boto_region_name\n",
     "role = sagemaker.get_execution_role()\n",
     "default_bucket = sagemaker_session.default_bucket()\n",
     "model_package_group_name = f\"AbaloneModelPackageGroupName\""
@@ -836,9 +836,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "### Define a Fail Step to Terminate the Pipeline Execution and Mark it as Failed\n",
     "\n",
@@ -853,6 +851,9 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
@@ -870,9 +871,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "![Define a Fail Step to Terminate the Execution in Failed State](img/pipeline-8.png)"
    ]
@@ -1180,9 +1179,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "Apart from that, you might also want to adjust the MSE threshold to a smaller value and raise the bar for the accuracy of the registered model. In this case you can override the MSE threshold like the following:"
    ]
@@ -1192,6 +1189,9 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
@@ -1203,9 +1203,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "If the MSE threshold is not satisfied, the pipeline execution will enter the `FailStep` and be marked as failed."
    ]
@@ -1215,6 +1213,9 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
@@ -1232,6 +1233,9 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }

--- a/sagemaker_processing/basic_sagemaker_data_processing/basic_sagemaker_processing.ipynb
+++ b/sagemaker_processing/basic_sagemaker_data_processing/basic_sagemaker_processing.ipynb
@@ -23,7 +23,7 @@
     "from sagemaker import get_execution_role\n",
     "from sagemaker.sklearn.processing import SKLearnProcessor\n",
     "\n",
-    "region = boto3.session.Session().region_name\n",
+    "region = sagemaker.Session().boto_region_name\n",
     "\n",
     "role = get_execution_role()\n",
     "sklearn_processor = SKLearnProcessor(\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
These three notebooks use boto3 to get the region_name instead of the Sagemaker SDK. This PR fixes that.

*Testing done:*
Ran notebooks end-to-end and it works.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
