### PR TITLE
Replace boto3 with SM SDK Usage in mnist-handwritten-digits-classification-experiment.ipynb

### DIFF
--- a/sagemaker-experiments/mnist-handwritten-digits-classification-experiment/mnist-handwritten-digits-classification-experiment.ipynb
+++ b/sagemaker-experiments/mnist-handwritten-digits-classification-experiment/mnist-handwritten-digits-classification-experiment.ipynb
@@ -129,18 +129,8 @@
    "source": [
     "# create a s3 bucket to hold data, note that your account might already created a bucket with the same name\n",
     "account_id = sess.client(\"sts\").get_caller_identity()[\"Account\"]\n",
-    "bucket = \"sagemaker-experiments-{}-{}\".format(sess.region_name, account_id)\n",
-    "prefix = \"mnist\"\n",
-    "\n",
-    "try:\n",
-    "    if sm_sess.boto_region_name == \"us-east-1\":\n",
-    "        sess.client(\"s3\").create_bucket(Bucket=bucket)\n",
-    "    else:\n",
-    "        sess.client(\"s3\").create_bucket(\n",
-    "            Bucket=bucket, CreateBucketConfiguration={\"LocationConstraint\": sess.region_name}\n",
-    "        )\n",
-    "except Exception as e:\n",
-    "    print(e)"
+    "bucket = sm_sess.default_bucket()\n",
+    "prefix = \"mnist\""
    ]
   },
   {

--- a/sagemaker-experiments/mnist-handwritten-digits-classification-experiment/mnist-handwritten-digits-classification-experiment.ipynb
+++ b/sagemaker-experiments/mnist-handwritten-digits-classification-experiment/mnist-handwritten-digits-classification-experiment.ipynb
@@ -83,7 +83,6 @@
    "source": [
     "import time\n",
     "\n",
-    "import boto3\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "from IPython.display import set_matplotlib_formats\n",
@@ -109,8 +108,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sess = boto3.Session()\n",
-    "sm = sess.client(\"sagemaker\")\n",
+    "sm_sess = sagemaker.Session()\n",
+    "sess = sm_sess.boto_session\n",
+    "sm = sm_sess.sagemaker_client\n",
     "role = get_execution_role()"
    ]
   },
@@ -133,7 +133,7 @@
     "prefix = \"mnist\"\n",
     "\n",
     "try:\n",
-    "    if sess.region_name == \"us-east-1\":\n",
+    "    if sm_sess.boto_region_name == \"us-east-1\":\n",
     "        sess.client(\"s3\").create_bucket(Bucket=bucket)\n",
     "    else:\n",
     "        sess.client(\"s3\").create_bucket(\n",
@@ -207,7 +207,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "inputs = sagemaker.Session().upload_data(path=\"mnist\", bucket=bucket, key_prefix=prefix)\n",
+    "inputs = sm_sess.upload_data(path=\"mnist\", bucket=bucket, key_prefix=prefix)\n",
     "print(\"input spec: {}\".format(inputs))"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove boto3 usage in mnist-handwritten-digits-classification-experiment.ipynb and replace with SageMaker SDK usage

*Testing done:*
Ran notebook end-to-end and it works

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
