### PR TITLE
Change endpoint instance type in tensorflow_BYOM_iris.ipynb

### DIFF
--- a/advanced_functionality/tensorflow_iris_byom/tensorflow_BYOM_iris.ipynb
+++ b/advanced_functionality/tensorflow_iris_byom/tensorflow_BYOM_iris.ipynb
@@ -303,7 +303,7 @@
    "source": [
     "### Create endpoint\n",
     "\n",
-    "Now the model is ready to be deployed at a SageMaker endpoint. We can use the ``sagemaker.tensorflow.model.TensorFlowModel.deploy`` method to do this. Unless you have created or prefer other instances, we recommend using a single ``'ml.m5.xlarge'`` instance for this example. These are supplied as arguments. "
+    "Now the model is ready to be deployed at a SageMaker endpoint. We can use the ``sagemaker.tensorflow.model.TensorFlowModel.deploy`` method to do this. Unless you have created or prefer other instances, we recommend using a single ``'ml.m5.2xlarge'`` instance for this example. These are supplied as arguments. "
    ]
   },
   {
@@ -313,7 +313,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "predictor = sagemaker_model.deploy(initial_instance_count=1)"
+    "predictor = sagemaker_model.deploy(initial_instance_count=1, instance_type=\"ml.m5.2xlarge\")"
    ]
   },
   {

--- a/advanced_functionality/tensorflow_iris_byom/tensorflow_BYOM_iris.ipynb
+++ b/advanced_functionality/tensorflow_iris_byom/tensorflow_BYOM_iris.ipynb
@@ -313,7 +313,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "predictor = sagemaker_model.deploy(initial_instance_count=1, instance_type=\"ml.m5.xlarge\")"
+    "predictor = sagemaker_model.deploy(initial_instance_count=1)"
    ]
   },
   {

--- a/advanced_functionality/tensorflow_iris_byom/tensorflow_BYOM_iris.ipynb
+++ b/advanced_functionality/tensorflow_iris_byom/tensorflow_BYOM_iris.ipynb
@@ -387,7 +387,7 @@
   }
  ],
  "metadata": {
-  "instance_type": "ml.t3.medium",
+  "instance_type": "ml.m5.xlarge",
   "kernelspec": {
    "display_name": "Python 3 (TensorFlow 2.3 Python 3.7 CPU Optimized)",
    "language": "python",


### PR DESCRIPTION
*Issue #, if available:*
Daily CI stopped for this notebook

*Description of changes:*
The endpoint uses the main instance type used to test notebooks in the daily CI (ml.m5.xlarge). As all those instance types are used for daily CI, there is not enough left to deploy the endpoint, leading the notebook to time out and stop using the endpoint deployment. I am changing the instance type to ml.m5.2xlarge which is not used as much in daily CI testing. Hopefully, this will prevent the notebook from stopping.

*Testing done:*
Ran notebook end-to-end and it works.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
