### PR TITLE
Assign mxnet_onnx_ei.ipynb a valid kernel

### DIFF
--- a/aws_sagemaker_studio/frameworks/mxnet_onnx_ei/mxnet_onnx_ei.ipynb
+++ b/aws_sagemaker_studio/frameworks/mxnet_onnx_ei/mxnet_onnx_ei.ipynb
@@ -321,9 +321,9 @@
  "metadata": {
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (MXNet CPU Optimized)",
+   "display_name": "conda_mxnet_p36",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-2:429704687514:image/mxnet-1.6-cpu-py36"
+   "name": "conda_mxnet_p36"
   },
   "language_info": {
    "codemirror_mode": {
@@ -335,7 +335,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.13"
   },
   "notice": "Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The kernel name assigned to mxnet_onnx_ei.ipynb doesn't exist. As such, we assigned it a Mead notebook name. We also made sure it worked with its mapped Studio container name.

*Testing done:*
Tested notebook in both Studio and Mead and it works.


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
