### PR TITLE
fix inconsistency when describing AddAssociation request validation

### DIFF
--- a/sagemaker-lineage/sagemaker-lineage.ipynb
+++ b/sagemaker-lineage/sagemaker-lineage.ipynb
@@ -286,7 +286,7 @@
     "## Caveats\n",
     "\n",
     "* Associations cannot be created between two experiment entities. For example between an Experiment and Trial.\n",
-    "* Associations can only be created between the following resources: Experiment, Trial, Trial Component, Action, Artifact, or Context.\n",
+    "* Associations can only be created between the following resources: Action, Artifact, or Context.\n",
     "* The maximum number of manually created lineage entities are:\n",
     "  * Artifacts: 6000\n",
     "  * Contexts: 500\n",


### PR DESCRIPTION
Fix a documentation inconsistency around `AddAssociation` validation behavior.

https://github.com/aws/sagemaker-experiments/issues/157