### PR TITLE
Fix tf-resnet-profiling-single-gpu-single-node.ipynb

### DIFF
--- a/sagemaker-debugger/tensorflow_profiling/tf-resnet-profiling-single-gpu-single-node.ipynb
+++ b/sagemaker-debugger/tensorflow_profiling/tf-resnet-profiling-single-gpu-single-node.ipynb
@@ -29,8 +29,7 @@
     "if install_needed:\n",
     "    print(\"installing deps and restarting kernel\")\n",
     "    !{sys.executable} -m pip install -U sagemaker\n",
-    "    !{sys.executable} -m pip install -U smdebug\n",
-    "    IPython.Application.instance().kernel.do_shutdown(True)"
+    "    !{sys.executable} -m pip install -U smdebug"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/aws/amazon-sagemaker-examples/issues/2362

*Description of changes:*
This notebook reset itself, leading to the CI to think that the kernel died. We deleted the code that causes this, fixing it in the CI.

*Testing done:*
Ran notebook end-to-end and it works.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
