### PR TITLE
p3.16xlarge vs p3dn.24xlarge vs p4d.24xlarge with updated hyperparame…

### DIFF
--- a/training/distributed_training/pytorch/model_parallel/gpt-j/train_gptj_smp_notebook.ipynb
+++ b/training/distributed_training/pytorch/model_parallel/gpt-j/train_gptj_smp_notebook.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "a54027ef",
    "metadata": {},
    "source": [
     "# Train EleutherAI GPT-J with PyTorch 1.8.1 and Pipeline Parallelism Using the SageMaker Model Parallelism Library\n",
@@ -31,6 +32,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8a269c5f",
    "metadata": {},
    "source": [
     "## SageMaker Distributed Training \n",
@@ -67,6 +69,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e23f8954",
    "metadata": {},
    "source": [
     "### SageMaker Model Parallel configuration\n",
@@ -90,6 +93,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d40ce50c",
    "metadata": {},
    "source": [
     "#### Additional Resources\n",
@@ -104,6 +108,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2117deca",
    "metadata": {},
    "source": [
     "#### Amazon SageMaker Initialization\n",
@@ -117,6 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4c0f2a98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,6 +132,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c8e3bcf2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,6 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "df039e17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,6 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8f6fe818",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,6 +201,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "90e3de66",
    "metadata": {},
    "source": [
     "## Training Dataset"
@@ -199,6 +209,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ccdad9e1",
    "metadata": {},
    "source": [
     "The training script fine-tunes GPT-J on the `sst2` dataset. \n",
@@ -210,6 +221,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d6638f8c",
    "metadata": {},
    "source": [
     "## Setup Hyperparameters\n",
@@ -222,6 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "fda06a97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -233,6 +246,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "35d2bc98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -251,7 +265,7 @@
     "    \"min_lr\": 0.00001,\n",
     "    \"warmup\": 0.01,\n",
     "    \"shard_optimizer_state\": 1,\n",
-    "    \"activation_checkpointing\": 0,\n",
+    "    \"activation_checkpointing\": 1,\n",
     "    \"activation_strategy\": \"each\",\n",
     "    \"optimize\": \"memory\",\n",
     "    \"pipeline_parallel_degree\": pipeline_parallel_degree,\n",
@@ -263,6 +277,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "971a3c74",
    "metadata": {},
    "source": [
     "## Setup SageMaker Training Job"
@@ -271,6 +286,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "43dd8525",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -278,9 +294,10 @@
     "from sagemaker.pytorch import PyTorch\n",
     "import datetime\n",
     "\n",
-    "instance_type = \"ml.p3.16xlarge\"\n",
+    "# instance_type = \"ml.p3.16xlarge\"\n",
+    "instance_type = \"ml.p4d.24xlarge\"\n",
     "volume_size = 900\n",
-    "instance_count = 4\n",
+    "instance_count = 1\n",
     "\n",
     "cur_time = datetime.datetime.now().strftime(\"%Y-%m-%d-%H-%M-%S\")\n",
     "base_job_name = f\"smp-{instance_type}-{model_name_or_path}-{cur_time}\".replace(\".\", \"-\").replace(\n",
@@ -291,6 +308,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4f6c018a",
    "metadata": {},
    "source": [
     "#### Specify SageMaker Model Parallel Hyperparameters"
@@ -299,6 +317,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "63564282",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -308,6 +327,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "54c6b5ee",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -327,7 +347,7 @@
     "        \"enabled\": True,\n",
     "        \"parameters\": {\n",
     "            \"ddp\": hyperparameters[\"ddp\"],\n",
-    "            \"microbatches\": 2,\n",
+    "            \"microbatches\": 4,\n",
     "            # partitions is a required param in the current SM SDK so it needs to be passed,\n",
     "            # these two map to the same config\n",
     "            \"partitions\": hyperparameters[\"pipeline_parallel_degree\"],\n",
@@ -337,7 +357,7 @@
     "            \"auto_partition\": True,\n",
     "            \"default_partition\": 0,\n",
     "            \"offload_activations\": False,\n",
-    "            \"active_microbatches\": 1,\n",
+    "            \"active_microbatches\": 4,\n",
     "            \"optimize\": hyperparameters[\"optimize\"],\n",
     "        },\n",
     "    }\n",
@@ -349,6 +369,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2b42ac92",
    "metadata": {},
    "source": [
     "The following cell constructs a PyTorch estimator using the parameters defined above. To see how the SageMaker tensor parallelism modules and functions are applied to the script, see the `train_gptj_smp_script.py` file."
@@ -357,6 +378,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "328a7570",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -380,6 +402,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "cface775",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -388,6 +411,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "63b470e2",
    "metadata": {},
    "source": [
     "## Accessing the Training Logs\n",
@@ -416,9 +440,9 @@
  "metadata": {
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (PyTorch 1.8 Python 3.6 CPU Optimized)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/1.8.1-cpu-py36"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -430,7 +454,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.13"
+   "version": "3.10.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
p4d instance provides 21.9% decrease in training time compare to p3dn. 

*Description of changes:*
### Hyperparameters Updated:   
* activation_checkpointing = True (1)
* active_microbatches = 4
* microbatches = 4
* max_steps = 80

*Testing done:*
### Option 1: Instance type and count
* instance_type = "ml.p3.16xlarge"
* instance_count = 2

Training failed (CUDA out of memory)

### Option 2: Instance type and count
* instance_type = "ml.p3dn.24xlarge"
* instance_count = 1

Training successful

### Option 3: Instance type and count
* instance_type = "ml.p4d.24xlarge"
* instance_count = 1

Training successful and training time decreases by 21.9% compare to `ml.p3dn.24xlarge` instance.

*Issue #, if available:*





## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [ ] I have tested my notebook(s) and ensured it runs end-to-end
- [ ] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
