### PR TITLE
Fix fp16 code not working properly in gpt distributed training

### DIFF
--- a/training/distributed_training/pytorch/model_parallel/gpt2/fp16/fp16.py
+++ b/training/distributed_training/pytorch/model_parallel/gpt2/fp16/fp16.py
@@ -309,12 +309,16 @@ def clip_grad_norm_fp32(parameters, param_is_distributed, shard_optimizer_state,
 
 
 def conversion_helper(val, conversion):
-    """Apply conversion to val. Recursively apply conversion if `val` is a nested tuple/list structure."""
-    if not isinstance(val, (tuple, list)):
+    """Apply conversion to val. Recursively apply conversion if `val` is a nested tuple/list/dict structure."""
+    
+    if isinstance(val, (tuple, list)):
+        rtn = [conversion_helper(v, conversion) for v in val]
+        if isinstance(val, tuple):
+            rtn = tuple(rtn)
+    elif isinstance(val, dict):
+        rtn = {k: conversion_helper(val[k], conversion) for k in val}
+    else:
         return conversion(val)
-    rtn = [conversion_helper(v, conversion) for v in val]
-    if isinstance(val, tuple):
-        rtn = tuple(rtn)
     return rtn
 
 
@@ -352,7 +356,7 @@ class FP16_Module(nn.Module):
         self.add_module("module", module.half())
 
     def forward(self, *inputs, **kwargs):
-        return fp16_to_fp32(self.module(*(fp32_to_fp16(inputs)), **kwargs))
+        return fp16_to_fp32(self.module(*(fp32_to_fp16(inputs)), **fp32_to_fp16(kwargs)))
 
     def state_dict(self, destination=None, prefix="", keep_vars=False):
         return self.module.state_dict(destination, prefix, keep_vars)


### PR DESCRIPTION
*Issue #, if available:*

The example code in the fp16 module in `training/distributed_training/pytorch/model_parallel` is strange when training gpt-j or gpt2 in a distributed environment.

In the training code, it is passed in the form of kawargs, but only the list is processed in the fp16 module. it means that model does not handle fp16 values.
```(python)
# training code, train_gpt_simple.py
...
@smp.step
def train_step(model, optimizer, input_ids, attention_mask, args):
    if args.logits_output:
        output = model(input_ids=input_ids, attention_mask=attention_mask, labels=input_ids)
        loss = output["loss"]
    else:
        loss = model(input_ids=input_ids, attention_mask=attention_mask, labels=input_ids)["loss"]
    if args.fp16:
        optimizer.backward(loss, update_master_grads=False)
    else:
        model.backward(loss)
    if args.logits_output:
        return output
    return loss
...

```

```(python)
# fp16/fp16.py
...

class FP16_Module(nn.Module):
    def __init__(self, module):
        super(FP16_Module, self).__init__()
        self.add_module("module", module.half())

    def forward(self, *inputs, **kwargs):
        return fp16_to_fp32(self.module(*(fp32_to_fp16(inputs)), **kwargs))
...
```

*Description of changes:*
So, I modified the fp16 code as below.
```(python)
# fp16.py
...
def conversion_helper(val, conversion):
    """Apply conversion to val. Recursively apply conversion if `val` is a nested tuple/list/dict structure."""
    
    if isinstance(val, (tuple, list)):
        rtn = [conversion_helper(v, conversion) for v in val]
        if isinstance(val, tuple):
            rtn = tuple(rtn)
    elif isinstance(val, dict):
        rtn = {k: conversion_helper(val[k], conversion) for k in val}
    else:
        return conversion(val)
    return rtn
...
...

class FP16_Module(nn.Module):
    def __init__(self, module):
        super(FP16_Module, self).__init__()
        self.add_module("module", module.half())

    def forward(self, *inputs, **kwargs):
        return fp16_to_fp32(self.module(*(fp32_to_fp16(inputs)), **fp32_to_fp16(kwargs)))
...
```
This is all I have changed.


*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [ ] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
