### PR TITLE
Fix train_deploy_jax.ipynb

### DIFF
--- a/advanced_functionality/jax_bring_your_own/sagemaker_jax.py
+++ b/advanced_functionality/jax_bring_your_own/sagemaker_jax.py
@@ -25,8 +25,12 @@ class JaxEstimator(Framework):
         source_dir=None,
         hyperparameters=None,
         image_uri=None,
+        framework_version=None,
+        py_version=None,
         **kwargs
     ):
+        self.framework_version = framework_version
+        self.py_version = py_version
         super(JaxEstimator, self).__init__(
             entry_point, source_dir, hyperparameters, image_uri=image_uri, **kwargs
         )

--- a/advanced_functionality/jax_bring_your_own/train_deploy_jax.ipynb
+++ b/advanced_functionality/jax_bring_your_own/train_deploy_jax.ipynb
@@ -16,6 +16,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "! pip install matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import os\n",
     "import json\n",
     "\n",
@@ -335,9 +344,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "conda_tensorflow2_p36",
    "language": "python",
-   "name": "python3"
+   "name": "conda_tensorflow2_p36"
   },
   "language_info": {
    "codemirror_mode": {
@@ -349,7 +358,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Issue #, if available:*
Daily CI failed

*Description of changes:*
There were some missing variables in the JAX estimator class (i.e. framework_class and py_version). So I added the missing variables in the class to solve the error.

Additionally, I changed the kernel as the notebook needed tensorflow, so I switched to a tensorflow envirnoment. I also installed matplotlib as it was needed in the notebook and it was not in the DLCs.

*Testing done:*
Ran the notebook in Studio and Mead and it works.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
