### PR TITLE
Update Dockerfile in multi-model byoc example to use python 3.7

### DIFF
--- a/advanced_functionality/multi_model_bring_your_own/container/Dockerfile
+++ b/advanced_functionality/multi_model_bring_your_own/container/Dockerfile
@@ -5,18 +5,30 @@ LABEL com.amazonaws.sagemaker.capabilities.multi-models=true
 # Set a docker label to enable container to use SAGEMAKER_BIND_TO_PORT environment variable if present
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
+
+# Upgrade installed packages
+RUN apt-get update && apt-get upgrade -y && apt-get clean
+
+# Python package management and basic dependencies
+RUN apt-get install -y curl python3.7 python3.7-dev python3.7-distutils
+
+# Register the version in alternatives
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1
+
+# Set python 3 as the default python
+RUN update-alternatives --set python /usr/bin/python3.7
+
 # Install necessary dependencies for MMS and SageMaker Inference Toolkit
-RUN apt-get update && \
-    apt-get -y install --no-install-recommends \
+RUN apt-get -y install --no-install-recommends \
     build-essential \
     ca-certificates \
     openjdk-8-jdk-headless \
-    python3-dev \
     curl \
     vim \
     && rm -rf /var/lib/apt/lists/* \
+    && python --version \
     && curl -O https://bootstrap.pypa.io/get-pip.py \
-    && python3 get-pip.py
+    && python get-pip.py
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN update-alternatives --install /usr/local/bin/pip pip /usr/local/bin/pip3 1


### PR DESCRIPTION
*Issue #, if available:*
Docker build fails due to python version requirement in entrypoint code. This PR updates the docker file to use correct python version. 

*Description of changes:*
Update Dockerfile in multi-model byoc example to use python 3.7

*Testing done:*
I was able to run the corresponding notebook. 

I have updated exactly one file in this PR, but running `tox -e black-check,black-nb-check` tells me it will refactor 56 files. 
```
All done! ✨ 🍰 ✨
52 files would be reformatted, 469 files would be left unchanged, 5 files would fail to reformat.
```
So, I didn't actually run it. If I need to run it, any help would be appreciated. 


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [ ] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
