### PR TITLE
Fix Caltech-101 links

### DIFF
--- a/sagemaker-debugger/pytorch_iterative_model_pruning/iterative_model_pruning_alexnet.ipynb
+++ b/sagemaker-debugger/pytorch_iterative_model_pruning/iterative_model_pruning_alexnet.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "source": [
     "### Get training dataset\n",
-    "Next we get the [Caltech101](http://www.vision.caltech.edu/Image_Datasets/Caltech101/) dataset. This dataset consists of 101 image categories. "
+    "Next we get the [Caltech-101](https://paperswithcode.com/dataset/caltech-101) dataset. This dataset consists of 101 image categories. "
    ]
   },
   {

--- a/sagemaker-debugger/pytorch_iterative_model_pruning/iterative_model_pruning_resnet.ipynb
+++ b/sagemaker-debugger/pytorch_iterative_model_pruning/iterative_model_pruning_resnet.ipynb
@@ -42,7 +42,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next we get the [Caltech101](http://www.vision.caltech.edu/Image_Datasets/Caltech101/) dataset. This dataset consists of 101 image categories. "
+    "Next we get the [Caltech-101](https://paperswithcode.com/dataset/caltech-101) dataset. This dataset consists of 101 image categories. "
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Caltech's image datasets website is down (https://www.vision.caltech.edu/Image_Datasets/), so replace the links to dataset descriptions for Caltech-101. Splitting original PR https://github.com/aws/amazon-sagemaker-examples/pull/3379 into smaller PRs to pass CI instead of time out.

*Testing done:* n/a, markdown only

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [ ] I have tested my notebook(s) and ensured it runs end-to-end
- [ ] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
