### PR TITLE
Fix Caltech-256 links, part 2

### DIFF
--- a/aws_sagemaker_studio/sagemaker_neo_compilation_jobs/imageclassification_caltech/Image-classification-fulltraining-highlevel-neo-studio.ipynb
+++ b/aws_sagemaker_studio/sagemaker_neo_compilation_jobs/imageclassification_caltech/Image-classification-fulltraining-highlevel-neo-studio.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "***\n",
     "\n",
-    "Welcome to our model optimization example for image classification. In this demo, we will use the Amazon SageMaker Image Classification algorithm to train on the [caltech-256 dataset](http://www.vision.caltech.edu/Image_Datasets/Caltech256/) and then we will demonstrate Amazon SageMaker Neo's ability to optimize models."
+    "Welcome to our model optimization example for image classification. In this demo, we will use the Amazon SageMaker Image Classification algorithm to train on the [Caltech-256 dataset](https://paperswithcode.com/dataset/caltech-256) and then we will demonstrate Amazon SageMaker Neo's ability to optimize models."
    ]
   },
   {
@@ -120,7 +120,7 @@
    "source": [
     "### Data preparation\n",
     "\n",
-    "In this demo, we are using [Caltech-256](http://www.vision.caltech.edu/Image_Datasets/Caltech256/) dataset, pre-converted into `RecordIO` format using MXNet's [im2rec](https://mxnet.apache.org/versions/1.7/api/faq/recordio) tool. Caltech-256 dataset contains 30608 images of 256 objects. For the training and validation data, the splitting scheme followed is governed by this [MXNet example](https://github.com/apache/incubator-mxnet/blob/8ecdc49cf99ccec40b1e342db1ac6791aa97865d/example/image-classification/data/caltech256.sh). The example randomly selects 60 images per class for training, and uses the remaining data for validation. It takes around 50 seconds to convert the entire Caltech-256 dataset (~1.2GB) into `RecordIO` format on a p2.xlarge instance. SageMaker's training algorithm takes `RecordIO` files as input. For this demo, we will download the `RecordIO` files and upload it to S3. We then initialize the 256 object categories as well to a variable."
+    "In this demo, we are using Caltech-256 dataset, pre-converted into `RecordIO` format using MXNet's [im2rec](https://mxnet.apache.org/versions/1.7/api/faq/recordio) tool. Caltech-256 dataset contains 30608 images of 256 objects. For the training and validation data, the splitting scheme followed is governed by this [MXNet example](https://github.com/apache/incubator-mxnet/blob/8ecdc49cf99ccec40b1e342db1ac6791aa97865d/example/image-classification/data/caltech256.sh). The example randomly selects 60 images per class for training, and uses the remaining data for validation. It takes around 50 seconds to convert the entire Caltech-256 dataset (~1.2GB) into `RecordIO` format on a p2.xlarge instance. SageMaker's training algorithm takes `RecordIO` files as input. For this demo, we will download the `RecordIO` files and upload it to S3. We then initialize the 256 object categories as well to a variable."
    ]
   },
   {

--- a/hyperparameter_tuning/image_classification_early_stopping/hpo_image_classification_early_stopping.ipynb
+++ b/hyperparameter_tuning/image_classification_early_stopping/hpo_image_classification_early_stopping.ipynb
@@ -75,7 +75,7 @@
    "source": [
     "## Data preparation\n",
     "\n",
-    "In this example, [caltech-256 dataset](http://www.vision.caltech.edu/Image_Datasets/Caltech256/) dataset will be used, which contains 30608 images of 256 objects."
+    "In this example, [Caltech-256 dataset](https://paperswithcode.com/dataset/caltech-256) dataset will be used, which contains 30608 images of 256 objects."
    ]
   },
   {

--- a/hyperparameter_tuning/image_classification_early_stopping/hpo_image_classification_early_stopping.ipynb
+++ b/hyperparameter_tuning/image_classification_early_stopping/hpo_image_classification_early_stopping.ipynb
@@ -10,7 +10,7 @@
     "---\n",
     "## Important notes:\n",
     "\n",
-    "* Two hyperparameter tuning jobs will be created in this sample notebook. With current setting, each tuning job takes around 2 hours to complete and may cost you up to 16 USD depending on which region you are in. \n",
+    "* Two hyperparameter tuning jobs will be created in this sample notebook. With current setting, each tuning job takes around an hour to complete. \n",
     "* Due to cost consideration, the goal of this example is to show you how to use the new feature, not necessarily to achieve the best result.\n",
     "* The built-in image classification algorithm on GPU instance will be used in this example.\n",
     "* Different runs of this notebook may lead to different results, due to the non-deterministic nature of Automatic Model Tuning. But it is fair to assume some training jobs will be stopped by automatic early stopping.\n",
@@ -191,7 +191,7 @@
    "source": [
     "Next, the tuning job with the following configurations need to be specified:\n",
     "* the hyperparameters that SageMaker Automatic Model Tuning will tune: learning_rate, mini_batch_size and optimizer\n",
-    "* the maximum number of training jobs it will run to optimize the objective metric: 20\n",
+    "* the maximum number of training jobs it will run to optimize the objective metric: 10\n",
     "* the number of parallel training jobs that will run in the tuning job: 2\n",
     "* the objective metric that Automatic Model Tuning will use: validation:accuracy"
    ]
@@ -225,7 +225,7 @@
     "    objective_metric_name,\n",
     "    hyperparameter_ranges,\n",
     "    objective_type=\"Maximize\",\n",
-    "    max_jobs=20,\n",
+    "    max_jobs=10,\n",
     "    max_parallel_jobs=2,\n",
     ")"
    ]
@@ -235,7 +235,7 @@
    "metadata": {},
    "source": [
     "## Launch hyperparameter tuning job\n",
-    "Now we can launch a hyperparameter tuning job by calling fit in tuner. We will wait until the tuning finished, which may take around 2 hours."
+    "Now we can launch a hyperparameter tuning job by calling fit in tuner. We will wait until the tuning finished, which may take around an hour."
    ]
   },
   {
@@ -308,7 +308,7 @@
     "    objective_metric_name,\n",
     "    hyperparameter_ranges,\n",
     "    objective_type=\"Maximize\",\n",
-    "    max_jobs=20,\n",
+    "    max_jobs=10,\n",
     "    max_parallel_jobs=2,\n",
     "    early_stopping_type=\"Auto\",\n",
     ")\n",

--- a/hyperparameter_tuning/image_classification_warmstart/hpo_image_classification_warmstart.ipynb
+++ b/hyperparameter_tuning/image_classification_warmstart/hpo_image_classification_warmstart.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "Amazon SageMaker Automatic Model Tuning helps with automating the hyperparameter tuning process. In many occasions the tuning process is iterative and requires to run multiple tuning jobs after analyzing the results to get the best objective metric.\n",
     "\n",
-    "This notebook will demonstrate how to iteratively tune an image classifer leveraging the warm start feature of Amazon SageMaker Automatic Model Tuning. The [caltech-256 dataset](http://www.vision.caltech.edu/Image_Datasets/Caltech256/) will be used to train the image classifier. \n",
+    "This notebook will demonstrate how to iteratively tune an image classifer leveraging the warm start feature of Amazon SageMaker Automatic Model Tuning. The [Caltech-256 dataset](https://paperswithcode.com/dataset/caltech-256) will be used to train the image classifier. \n",
     "\n",
     "Warm start configuration allows you to create a new tuning job with the learning gathered in a parent tuning job by specifying up to 5 parent tuning jobs. If a warm start configuration is specified, Automatic Model Tuning will load the previous [hyperparameter set, objective metrics values] to warm start the new tuning job. This means, you can continue optimizing your model from the point you finished your previous tuning job experiment. \n",
     "\n",
@@ -89,7 +89,7 @@
    "metadata": {},
    "source": [
     "## Data preparation\n",
-    "Download the data and transfer to S3 for use in training. In this example, we are using [Caltech-256](http://www.vision.caltech.edu/Image_Datasets/Caltech256/) dataset, which contains 30608 images of 256 objects. For the training and validation data, we follow the splitting scheme in this MXNet [example](https://github.com/apache/incubator-mxnet/blob/master/example/image-classification/data/caltech256.sh). In particular, it randomly selects 60 images per class for training, and uses the remaining data for validation. The algorithm takes `RecordIO` files as input. The user can also provide the image files as input, which will be converted into `RecordIO` format using MXNet's [im2rec](https://mxnet.incubator.apache.org/how_to/recordio.html?highlight=im2rec) tool. It takes around 50 seconds to converted the entire Caltech-256 dataset (~1.2GB) on a p2.xlarge instance. However, for this example, we will directly use recordio format. "
+    "Download the data and transfer to S3 for use in training. In this example, we are using Caltech-256 dataset, which contains 30608 images of 256 objects. For the training and validation data, we follow the splitting scheme in this MXNet [example](https://github.com/apache/incubator-mxnet/blob/master/example/image-classification/data/caltech256.sh). In particular, it randomly selects 60 images per class for training, and uses the remaining data for validation. The algorithm takes `RecordIO` files as input. The user can also provide the image files as input, which will be converted into `RecordIO` format using MXNet's [im2rec](https://mxnet.incubator.apache.org/how_to/recordio.html?highlight=im2rec) tool. It takes around 50 seconds to converted the entire Caltech-256 dataset (~1.2GB) on a p2.xlarge instance. However, for this example, we will directly use recordio format. "
    ]
   },
   {

--- a/hyperparameter_tuning/image_classification_warmstart/hpo_image_classification_warmstart.ipynb
+++ b/hyperparameter_tuning/image_classification_warmstart/hpo_image_classification_warmstart.ipynb
@@ -76,9 +76,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
+    "from sagemaker.image_uris import retrieve\n",
     "\n",
-    "training_image = get_image_uri(sess.boto_region_name, \"image-classification\", repo_version=\"1\")\n",
+    "training_image = retrieve(region=sess.boto_region_name, framework=\"image-classification\", version=\"1\")\n",
     "print(training_image)\n",
     "\n",
     "smclient = boto3.Session().client(\"sagemaker\")"
@@ -136,13 +136,13 @@
    "source": [
     "# Set the data type and channels used for training\n",
     "s3_output_location = \"s3://{}/{}/output\".format(bucket, prefix)\n",
-    "s3_input_train = sagemaker.session.s3_input(\n",
+    "s3_input_train = sagemaker.inputs.TrainingInput(\n",
     "    s3train,\n",
     "    distribution=\"FullyReplicated\",\n",
     "    content_type=\"application/x-recordio\",\n",
     "    s3_data_type=\"S3Prefix\",\n",
     ")\n",
-    "s3_input_validation = sagemaker.session.s3_input(\n",
+    "s3_input_validation = sagemaker.inputs.TrainingInput(\n",
     "    s3validation,\n",
     "    distribution=\"FullyReplicated\",\n",
     "    content_type=\"application/x-recordio\",\n",
@@ -195,8 +195,8 @@
     "imageclassification = sagemaker.estimator.Estimator(\n",
     "    training_image,\n",
     "    role,\n",
-    "    train_instance_count=1,\n",
-    "    train_instance_type=\"ml.p3.2xlarge\",\n",
+    "    instance_count=1,\n",
+    "    instance_type=\"ml.p3.2xlarge\",\n",
     "    output_path=s3_output_location,\n",
     "    sagemaker_session=sess,\n",
     ")\n",
@@ -306,7 +306,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can analize the results deeper by using HPO_Analyze_TuningJob_Results.ipynb notebook. Here, we will just plot how the objective metric changes overtime as the tuning progresses."
+    "You can analyze the results deeper by using HPO_Analyze_TuningJob_Results.ipynb notebook. Here, we will just plot how the objective metric changes overtime as the tuning progresses."
    ]
   },
   {
@@ -403,7 +403,7 @@
    "metadata": {},
    "source": [
     "## Launch hyperparameter tuning job using warm start configuration\n",
-    "Now we can launch a hyperparameter tuning job by calling tuner.fit and passing warmSatartConfig. After the hyperparameter tuning job is created, we can go to SageMaker console to track the progress of the hyperparameter tuning job until it is completed."
+    "Now we can launch a hyperparameter tuning job by calling tuner.fit and passing warmStartConfig. After the hyperparameter tuning job is created, we can go to SageMaker console to track the progress of the hyperparameter tuning job until it is completed."
    ]
   },
   {

--- a/hyperparameter_tuning/image_classification_warmstart/hpo_image_classification_warmstart.ipynb
+++ b/hyperparameter_tuning/image_classification_warmstart/hpo_image_classification_warmstart.ipynb
@@ -78,7 +78,9 @@
    "source": [
     "from sagemaker.image_uris import retrieve\n",
     "\n",
-    "training_image = retrieve(region=sess.boto_region_name, framework=\"image-classification\", version=\"1\")\n",
+    "training_image = retrieve(\n",
+    "    region=sess.boto_region_name, framework=\"image-classification\", version=\"1\"\n",
+    ")\n",
     "print(training_image)\n",
     "\n",
     "smclient = boto3.Session().client(\"sagemaker\")"


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Description of changes: Caltech's image datasets website is down (https://www.vision.caltech.edu/Image_Datasets/), so replace the links to dataset descriptions for Caltech-256. Splitting original PR https://github.com/aws/amazon-sagemaker-examples/pull/3379 into smaller PRs to pass CI instead of time out. Correct a few typos and SDK v1 usage.

*Testing done:* Ran end-to-end in a notebook instance.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
