### PR TITLE
Fix more Caltech-256 dataset links, part 3

### DIFF
--- a/introduction_to_amazon_algorithms/imageclassification_caltech/Image-classification-lst-format-highlevel.ipynb
+++ b/introduction_to_amazon_algorithms/imageclassification_caltech/Image-classification-lst-format-highlevel.ipynb
@@ -22,7 +22,7 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "Welcome to our end-to-end example of the image classification algorithm training with image format. In this demo, we will use the Amazon SageMaker image classification algorithm in transfer learning mode to fine-tune a pre-trained model (trained on ImageNet data) to learn to classify a new dataset. In particular, the pre-trained model will be fine-tuned using the [Caltech-256 dataset](http://www.vision.caltech.edu/Image_Datasets/Caltech256/). \n",
+    "Welcome to our end-to-end example of the image classification algorithm training with image format. In this demo, we will use the Amazon SageMaker image classification algorithm in transfer learning mode to fine-tune a pre-trained model (trained on ImageNet data) to learn to classify a new dataset. In particular, the pre-trained model will be fine-tuned using the [Caltech-256 dataset](https://paperswithcode.com/dataset/caltech-256). \n",
     "\n",
     "To get started, we need to set up the environment with a few prerequisite steps, for permissions, configurations, and so on."
    ]

--- a/introduction_to_amazon_algorithms/imageclassification_caltech/Image-classification-lst-format.ipynb
+++ b/introduction_to_amazon_algorithms/imageclassification_caltech/Image-classification-lst-format.ipynb
@@ -29,7 +29,7 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "Welcome to our end-to-end example of the image classification algorithm training with image format. In this demo, we will use the Amazon SageMaker image classification algorithm in transfer learning mode to fine-tune a pre-trained model (trained on ImageNet data) to learn to classify a new dataset. In particular, the pre-trained model will be fine-tuned using the [Caltech-256 dataset](http://www.vision.caltech.edu/Image_Datasets/Caltech256/). \n",
+    "Welcome to our end-to-end example of the image classification algorithm training with image format. In this demo, we will use the Amazon SageMaker image classification algorithm in transfer learning mode to fine-tune a pre-trained model (trained on ImageNet data) to learn to classify a new dataset. In particular, the pre-trained model will be fine-tuned using the [Caltech-256 dataset](https://paperswithcode.com/dataset/caltech-256). \n",
     "\n",
     "To get started, we need to set up the environment with a few prerequisite steps, for permissions, configurations, and so on."
    ]

--- a/introduction_to_amazon_algorithms/imageclassification_caltech/Image-classification-transfer-learning-highlevel.ipynb
+++ b/introduction_to_amazon_algorithms/imageclassification_caltech/Image-classification-transfer-learning-highlevel.ipynb
@@ -20,7 +20,7 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "Welcome to our end-to-end example of distributed image classification algorithm in transfer learning mode. In this demo, we will use the Amazon sagemaker image classification algorithm in transfer learning mode to fine-tune a pre-trained model (trained on imagenet data) to learn to classify a new dataset. In particular, the pre-trained model will be fine-tuned using [caltech-256 dataset](http://www.vision.caltech.edu/Image_Datasets/Caltech256/). \n",
+    "Welcome to our end-to-end example of distributed image classification algorithm in transfer learning mode. In this demo, we will use the Amazon sagemaker image classification algorithm in transfer learning mode to fine-tune a pre-trained model (trained on imagenet data) to learn to classify a new dataset. In particular, the pre-trained model will be fine-tuned using [Caltech-256 dataset](https://paperswithcode.com/dataset/caltech-256). \n",
     "\n",
     "This notebook was tested in Amazon SageMaker Studio on ml.t3.medium instance with Python 3 (Data Science) kernel.\n",
     "\n",


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Description of changes: Caltech's image datasets website is down (https://www.vision.caltech.edu/Image_Datasets/), so replace the links to dataset descriptions for Caltech-256. Splitting original PR https://github.com/aws/amazon-sagemaker-examples/pull/3379 into smaller PRs to pass CI instead of time out.

*Testing done:* n/a, markdown only

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
