### PR TITLE
Change experiment name day-by-day in associate-hyperparameter-tuning-job.ipynb

### DIFF
--- a/sagemaker-experiments/associate-hyper-parameter-tuning-job/associate-hyperparameter-tuning-job.ipynb
+++ b/sagemaker-experiments/associate-hyper-parameter-tuning-job/associate-hyperparameter-tuning-job.ipynb
@@ -39,7 +39,7 @@
    "outputs": [],
    "source": [
     "import time\n",
-    "from datetime import timezone\n",
+    "from datetime import timezone, datetime\n",
     "\n",
     "import boto3\n",
     "from sagemaker import HyperparameterTuningJobAnalytics, Session\n",
@@ -68,7 +68,7 @@
     "tuning_jobs = list_tuning_jobs_response[\"HyperParameterTuningJobSummaries\"]\n",
     "most_recently_created_tuning_job = tuning_jobs[0]\n",
     "tuning_job_name = most_recently_created_tuning_job[\"HyperParameterTuningJobName\"]\n",
-    "experiment_name = \"example-experiment-with-tuning-jobs\"\n",
+    "experiment_name = \"example-experiment-with-tuning-jobs-{}\".format(datetime.now().strftime(\"%Y%m%d-%H%M%S\"))\n",
     "trial_name = tuning_job_name + \"-trial\"\n",
     "\n",
     "print(f\"Associate all training jobs created by {tuning_job_name} with trial {trial_name}\")"
@@ -159,9 +159,9 @@
  "metadata": {
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "conda_python3",
    "language": "python",
-   "name": "python3"
+   "name": "conda_python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -173,7 +173,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Issue #, if available:*
Daily CI fails

*Description of changes:*
The notebook throws the follow error in the daily CI:
```
ResourceLimitExceeded: An error occurred (ResourceLimitExceeded) when calling the CreateTrial operation: The account-level service limit 'Total number of trials allowed in a single experiment, excluding those automatically created by SageMaker' is 300 Trials, with current utilization of 0 Trials and a request delta of 301 Trials. Please contact AWS support to request an increase for this limit.
```

This is because every day, we add more trials to the same experiment as the same experiment name is consistently used. The number of trials for that one experiment keeps adding up until the limit is exceeded, hence this error. Therefore, an easy fix is to change the experiment name everyday by appending the current time and date to it.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
