### PR TITLE
chore: fix typo in inference recommender

### DIFF
--- a/sagemaker-inference-recommender/sklearn-inference-recommender/sklearn-inference-recommender.ipynb
+++ b/sagemaker-inference-recommender/sklearn-inference-recommender/sklearn-inference-recommender.ipynb
@@ -385,12 +385,12 @@
     "\n",
     "model_package_group_name = \"scikit-learn-california-housing-\" + str(round(time.time()))\n",
     "print(model_package_group_name)\n",
-    "model_pacakge_group_response = client.create_model_package_group(\n",
+    "model_package_group_response = client.create_model_package_group(\n",
     "    ModelPackageGroupName=str(model_package_group_name),\n",
     "    ModelPackageGroupDescription=\"My sample California housing model package group\",\n",
     ")\n",
     "\n",
-    "print(model_pacakge_group_response)"
+    "print(model_package_group_response)"
    ]
   },
   {


### PR DESCRIPTION
*Description of changes:*
Fix typo in variable name of inference recommender

## Merge Checklist


- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
