### PR TITLE
Change instance type in SEC_Section_Extraction_Functions.ipynb to fix kernel died error

### DIFF
--- a/sagemaker-jumpstart/nlp_score_dashboard_sec/sec-dashboard/SEC_Section_Extraction_Functions.ipynb
+++ b/sagemaker-jumpstart/nlp_score_dashboard_sec/sec-dashboard/SEC_Section_Extraction_Functions.ipynb
@@ -857,7 +857,6 @@
   }
  ],
  "metadata": {
-  "instance_type": "ml.t3.medium",
   "kernelspec": {
    "display_name": "Python 3 (Data Science)",
    "language": "python",

--- a/sagemaker-jumpstart/nlp_score_dashboard_sec/sec-dashboard/SEC_Section_Extraction_Functions.ipynb
+++ b/sagemaker-jumpstart/nlp_score_dashboard_sec/sec-dashboard/SEC_Section_Extraction_Functions.ipynb
@@ -561,7 +561,7 @@
    "source": [
     "# truncates a number\n",
     "def truncate(n, decimal):\n",
-    "    multiplier = 10 ** decimal\n",
+    "    multiplier = 10**decimal\n",
     "    return int(n * multiplier) / multiplier"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:*
Daily CI fails

*Description of changes:*
It was discovered through experimentation that kernel died errors are caused by having instances with insufficient capacity. This is especially important for daily CI, during which multiple notebooks are run at once and sufficient capacity must be provisioned.

*Testing done:*
Ran notebooks and they work.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
