### PR TITLE
Change instance type in fairness_and_explainability_spark.ipynb

### DIFF
--- a/sagemaker_processing/fairness_and_explainability/fairness_and_explainability_spark.ipynb
+++ b/sagemaker_processing/fairness_and_explainability/fairness_and_explainability_spark.ipynb
@@ -750,7 +750,6 @@
   }
  ],
  "metadata": {
-  "instance_type": "ml.t3.medium",
   "kernelspec": {
    "display_name": "Python 3 (Data Science)",
    "language": "python",


### PR DESCRIPTION
*Issue #, if available:*
Daily CI stopped

*Description of changes:*
Through experimentation on my personal CI, it is found that this notebook is taking too long to run, potentially due to the size of its instance. So I deleted the instance type so that it stops being tested on the smaller and slower t3.medium but the larger and faster m5.xlarge.

*Testing done:*
Ran notebook and it works.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
