### PR TITLE
Update yolov5.ipynb with lowercase ecr repository name

### DIFF
--- a/training/distributed_training/pytorch/data_parallel/yolov5/yolov5.ipynb
+++ b/training/distributed_training/pytorch/data_parallel/yolov5/yolov5.ipynb
@@ -104,7 +104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "image = \"YOLOv5-smdataparallel-sagemaker\"  # use any image name you want\n",
+    "image = \"yolov5-smdataparallel-sagemaker\"  # use any image name you want, as long as it is all lower case\n",
     "tag = \"pt1.10.2\"  # use any tag name you want"
    ]
   },


### PR DESCRIPTION
Changing image name to lowercase since it errors out on `invalid reference format: repository name must be lowercase` during build and push

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ x ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [ NA ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [ x ] I have tested my notebook(s) and ensured it runs end-to-end
- [ x ] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
