### PR TITLE
Add new RTD pages for pre-trained models

### DIFF
--- a/use-cases/index.rst
+++ b/use-cases/index.rst
@@ -46,3 +46,12 @@ Pipelines with NLP for Product Rating Prediction
    :maxdepth: 1
 
    product_ratings_with_pipelines/pipelines_product_ratings
+
+
+SageMaker Algorithms with Pre-Trained Model Examples by Problem Type
+--------------------------------------------------------------------
+.. toctree::
+    :maxdepth: 1
+
+    jumpstart.rst
+

--- a/use-cases/jumpstart.rst
+++ b/use-cases/jumpstart.rst
@@ -1,91 +1,104 @@
 SageMaker Algorithms with Pre-Trained Model Examples by Problem Type
 ====================================================================
 
-The SageMaker Python SDK provides built-in algorithms with pre-trained models from popular open source model hubs, such as TensorFlow Hub, PyTorch Hub, and Hugging Face. Customers can deploy these pre-trained models as-is, or first fine-tune them on a custom dataset and then deploy to a SageMaker endpoint for inference. 
+The SageMaker Python SDK provides built-in algorithms with pre-trained models from popular open source model hubs, such as TensorFlow Hub, PyTorch Hub, and Hugging Face. Customers can deploy these pre-trained models as-is, or first fine-tune them on a custom dataset and then deploy to a SageMaker endpoint for inference.
 
 This section provides example notebooks for different ML problem types supported by SageMaker built-in algorithms. Please visit `Use Built-in Algorithms with Pre-trained Models in SageMaker Python SDK <https://sagemaker.readthedocs.io/en/stable/overview.html#id7>`_ for more documentation.
 
 .. list-table:: Example notebooks by problem type
-   :widths: 40 15 15 30 60
    :header-rows: 1
 
-   * - Problem types
-     - Supports inference with pretrained models
-     - Trainable on a custom dataset
-     - Supported frameworks
-     - Example notebooks
+   * - | Problem types
+     - | Supports
+       | inference
+       | with
+       | pre-trained
+       | models
+     - | Trainable
+       | on a
+       | custom
+       | dataset
+     - | Supported frameworks
+     - | Example notebooks
    * - Image classification
      - Yes
      - Yes
      - PyTorch, TensorFlow
-     - ../introduction_to_amazon_algorithms/jumpstart_image_classification/Amazon_JumpStart_Image_Classification
-   * - 
-     - 
-     - 
-     - 
-     - 
-   * - 
-     - 
-     - 
-     - 
-     - 
-   * - 
-     - 
-     - 
-     - 
-     - 
-   * - 
-     - 
-     - 
-     - 
-     - 
-   * - 
-     - 
-     - 
-     - 
-     - 
-   * - 
-     - 
-     - 
-     - 
-     - 
-   * - 
-     - 
-     - 
-     - 
-     - 
-   * - 
-     - 
-     - 
-     - 
-     - 
-   * - 
-     - 
-     - 
-     - 
-     - 
-   * - 
-     - 
-     - 
-     - 
-     - 
-   * - 
-     - 
-     - 
-     - 
-     - 
-   * - 
-     - 
-     - 
-     - 
-     - 
-   * - 
-     - 
-     - 
-     - 
-     - 
-   * - 
-     - 
-     - 
-     - 
-     - 
+     - .. toctree::
+           :maxdepth: 1
+
+           ../introduction_to_amazon_algorithms/jumpstart_image_classification/Amazon_JumpStart_Image_Classification
+   * - Object detection
+     - Yes
+     - Yes
+     - PyTorch, TensorFlow, MXNet
+     -
+   * - Semantic segmentation
+     - Yes
+     - Yes
+     - MXNet
+     -
+   * - Instance segmentation
+     - Yes
+     - Yes
+     - MXNet
+     -
+   * - Image embedding
+     - Yes
+     - No
+     - TensorFlow, MXNet
+     -
+   * - Text classification
+     - Yes
+     - Yes
+     - TensorFlow
+     -
+   * - Sentence pair classification
+     - Yes
+     - Yes
+     - TensorFlow, Hugging Face
+     -
+   * - Question answering
+     - Yes
+     - Yes
+     - PyTorch
+     -
+   * - Named entity recognition
+     - Yes
+     - No
+     - Hugging Face
+     -
+   * - Text summarization
+     - Yes
+     - No
+     - Hugging Face
+     -
+   * - Text generation
+     - Yes
+     - No
+     - Hugging Face
+     -
+   * - Machine translation
+     - Yes
+     - No
+     - Hugging Face
+     -
+   * - Text embedding
+     - Yes
+     - No
+     - TensorFlow, MXNet
+     -
+   * - Tabular classification
+     - Yes
+     - Yes
+     - | LightGBM, CatBoost, XGBoost,
+       | AutoGluon-Tabular,
+       | TabTransformer, Linear Learner
+     -
+   * - Tabular regression
+     - Yes
+     - Yes
+     - | LightGBM, CatBoost, XGBoost,
+       | AutoGluon-Tabular,
+       | TabTransformer, Linear Learner
+     -

--- a/use-cases/jumpstart.rst
+++ b/use-cases/jumpstart.rst
@@ -3,7 +3,7 @@ SageMaker Algorithms with Pre-Trained Model Examples by Problem Type
 
 The SageMaker Python SDK provides built-in algorithms with pre-trained models from popular open source model hubs, such as TensorFlow Hub, PyTorch Hub, and Hugging Face. Customers can deploy these pre-trained models as-is, or first fine-tune them on a custom dataset and then deploy to a SageMaker endpoint for inference.
 
-This section provides example notebooks for different ML problem types supported by SageMaker built-in algorithms. Please visit `Use Built-in Algorithms with Pre-trained Models in SageMaker Python SDK <https://sagemaker.readthedocs.io/en/stable/overview.html#id7>`_ for more documentation.
+This section provides example notebooks for different ML problem types supported by SageMaker built-in algorithms. Please visit `Use Built-in Algorithms with Pre-trained Models in SageMaker Python SDK <https://sagemaker.readthedocs.io/en/stable/overview.html#use-built-in-algorithms-with-pre-trained-models-in-sagemaker-python-sdk>`_ for more documentation.
 
 .. list-table:: Example notebooks by problem type
    :header-rows: 1
@@ -32,73 +32,121 @@ This section provides example notebooks for different ML problem types supported
      - Yes
      - Yes
      - PyTorch, TensorFlow, MXNet
-     -
+     - .. toctree::
+           :maxdepth: 1
+
+           ../introduction_to_amazon_algorithms/jumpstart_object_detection/Amazon_JumpStart_Object_Detection.ipynb
    * - Semantic segmentation
      - Yes
      - Yes
      - MXNet
-     -
+     - .. toctree::
+           :maxdepth: 1
+
+           ../introduction_to_amazon_algorithms/jumpstart_semantic_segmentation/Amazon_JumpStart_Semantic_Segmentation.ipynb
    * - Instance segmentation
      - Yes
      - Yes
      - MXNet
-     -
+     - .. toctree::
+           :maxdepth: 1
+
+           ../introduction_to_amazon_algorithms/jumpstart_instance_segmentation/Amazon_JumpStart_Instance_Segmentation.ipynb
    * - Image embedding
      - Yes
      - No
      - TensorFlow, MXNet
-     -
+     - .. toctree::
+           :maxdepth: 1
+
+           ../introduction_to_amazon_algorithms/jumpstart_image_embedding/Amazon_JumpStart_Image_Embedding.ipynb
    * - Text classification
      - Yes
      - Yes
      - TensorFlow
-     -
+     - .. toctree::
+           :maxdepth: 1
+
+           ../introduction_to_amazon_algorithms/jumpstart_text_classification/Amazon_JumpStart_Text_Classification.ipynb
    * - Sentence pair classification
      - Yes
      - Yes
      - TensorFlow, Hugging Face
-     -
+     - .. toctree::
+           :maxdepth: 1
+
+           ../introduction_to_amazon_algorithms/jumpstart_sentence_pair_classification/Amazon_JumpStart_Sentence_Pair_Classification.ipynb
    * - Question answering
      - Yes
      - Yes
      - PyTorch
-     -
+     - .. toctree::
+           :maxdepth: 1
+
+           ../introduction_to_amazon_algorithms/jumpstart_question_answering/Amazon_JumpStart_Question_Answering.ipynb
    * - Named entity recognition
      - Yes
      - No
      - Hugging Face
-     -
+     - .. toctree::
+           :maxdepth: 1
+
+           ../introduction_to_amazon_algorithms/jumpstart_named_entity_recognition/Amazon_JumpStart_Named_Entity_Recognition.ipynb
    * - Text summarization
      - Yes
      - No
      - Hugging Face
-     -
+     - .. toctree::
+           :maxdepth: 1
+
+           ../introduction_to_amazon_algorithms/jumpstart_text_summarization/Amazon_JumpStart_Text_Summarization.ipynb
    * - Text generation
      - Yes
      - No
      - Hugging Face
-     -
+     - .. toctree::
+           :maxdepth: 1
+
+           ../introduction_to_amazon_algorithms/jumpstart_text_generation/Amazon_JumpStart_Text_Generation.ipynb
    * - Machine translation
      - Yes
      - No
      - Hugging Face
-     -
+     - .. toctree::
+           :maxdepth: 1
+
+           ../introduction_to_amazon_algorithms/jumpstart_machine_translation/Amazon_JumpStart_Machine_Translation.ipynb
    * - Text embedding
      - Yes
      - No
      - TensorFlow, MXNet
-     -
+     - .. toctree::
+           :maxdepth: 1
+
+           ../introduction_to_amazon_algorithms/jumpstart_text_embedding/Amazon_JumpStart_Text_Embedding.ipynb
    * - Tabular classification
      - Yes
      - Yes
      - | LightGBM, CatBoost, XGBoost,
        | AutoGluon-Tabular,
        | TabTransformer, Linear Learner
-     -
+     - .. toctree::
+           :maxdepth: 1
+
+           ../introduction_to_amazon_algorithms/lightgbm_catboost_tabular/Amazon_Tabular_Classification_LightGBM_CatBoost.ipynb
+           ../introduction_to_amazon_algorithms/xgboost_linear_learner_tabular/Amazon_Tabular_Classification_XGBoost_LinearLearner.ipynb
+           ../introduction_to_amazon_algorithms/autogluon_tabular/Amazon_Tabular_Classification_AutoGluon.ipynb
+           ../introduction_to_amazon_algorithms/tabtransformer_tabular/Amazon_Tabular_Classification_TabTransformer.ipynb
    * - Tabular regression
      - Yes
      - Yes
      - | LightGBM, CatBoost, XGBoost,
        | AutoGluon-Tabular,
        | TabTransformer, Linear Learner
-     -
+     - .. toctree::
+           :maxdepth: 1
+
+           ../introduction_to_amazon_algorithms/lightgbm_catboost_tabular/Amazon_Tabular_Classification_LightGBM_CatBoost.ipynb
+           ../introduction_to_amazon_algorithms/xgboost_linear_learner_tabular/Amazon_Tabular_Classification_XGBoost_LinearLearner.ipynb
+           ../introduction_to_amazon_algorithms/autogluon_tabular/Amazon_Tabular_Classification_AutoGluon.ipynb
+           ../introduction_to_amazon_algorithms/tabtransformer_tabular/Amazon_Tabular_Classification_TabTransformer.ipynb

--- a/use-cases/jumpstart.rst
+++ b/use-cases/jumpstart.rst
@@ -1,0 +1,91 @@
+SageMaker Algorithms with Pre-Trained Model Examples by Problem Type
+====================================================================
+
+The SageMaker Python SDK provides built-in algorithms with pre-trained models from popular open source model hubs, such as TensorFlow Hub, PyTorch Hub, and Hugging Face. Customers can deploy these pre-trained models as-is, or first fine-tune them on a custom dataset and then deploy to a SageMaker endpoint for inference. 
+
+This section provides example notebooks for different ML problem types supported by SageMaker built-in algorithms. Please visit `Use Built-in Algorithms with Pre-trained Models in SageMaker Python SDK <https://sagemaker.readthedocs.io/en/stable/overview.html#id7>`_ for more documentation.
+
+.. list-table:: Example notebooks by problem type
+   :widths: 40 15 15 30 60
+   :header-rows: 1
+
+   * - Problem types
+     - Supports inference with pretrained models
+     - Trainable on a custom dataset
+     - Supported frameworks
+     - Example notebooks
+   * - Image classification
+     - Yes
+     - Yes
+     - PyTorch, TensorFlow
+     - ../introduction_to_amazon_algorithms/jumpstart_image_classification/Amazon_JumpStart_Image_Classification
+   * - 
+     - 
+     - 
+     - 
+     - 
+   * - 
+     - 
+     - 
+     - 
+     - 
+   * - 
+     - 
+     - 
+     - 
+     - 
+   * - 
+     - 
+     - 
+     - 
+     - 
+   * - 
+     - 
+     - 
+     - 
+     - 
+   * - 
+     - 
+     - 
+     - 
+     - 
+   * - 
+     - 
+     - 
+     - 
+     - 
+   * - 
+     - 
+     - 
+     - 
+     - 
+   * - 
+     - 
+     - 
+     - 
+     - 
+   * - 
+     - 
+     - 
+     - 
+     - 
+   * - 
+     - 
+     - 
+     - 
+     - 
+   * - 
+     - 
+     - 
+     - 
+     - 
+   * - 
+     - 
+     - 
+     - 
+     - 
+   * - 
+     - 
+     - 
+     - 
+     - 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Add new RTD pages for pre-trained models. Add a link from the homepage under Use Cases, and a new RST page with a table of different algorithms and their corresponding notebooks. All of the notebooks already exist, so it's just adding markdown and links.

*Testing done:* Built and previewed RTD locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [ ] I have tested my notebook(s) and ensured it runs end-to-end
- [ ] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
