### PR TITLE
Update wait=True to ensure training job completes before tuning job 

### DIFF
--- a/sagemaker-python-sdk/scikit_learn_randomforest/Sklearn_on_SageMaker_end2end.ipynb
+++ b/sagemaker-python-sdk/scikit_learn_randomforest/Sklearn_on_SageMaker_end2end.ipynb
@@ -278,7 +278,7 @@
    "outputs": [],
    "source": [
     "# launch training job, with asynchronous call\n",
-    "sklearn_estimator.fit({\"train\": trainpath, \"test\": testpath}, wait=False)"
+    "sklearn_estimator.fit({\"train\": trainpath, \"test\": testpath}, wait=True)"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The tuning job fails now because it doesn't wait for training job to finish, which results in the model artifacts not being generated yet, and the tuning job fails if it can't find them. This change ensures they will be found

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [ ] I have tested my notebook(s) and ensured it runs end-to-end
- [ ] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
