### PR TITLE
'train_input' needs to be a string

### DIFF
--- a/sagemaker-python-sdk/scikit_learn_inference_pipeline/Inference Pipeline with Scikit-learn and Linear Learner.ipynb
+++ b/sagemaker-python-sdk/scikit_learn_inference_pipeline/Inference Pipeline with Scikit-learn and Linear Learner.ipynb
@@ -89,11 +89,12 @@
    "source": [
     "WORK_DIRECTORY = \"abalone_data\"\n",
     "\n",
-    "train_input = sagemaker_session.upload_data(\n",
+    "sagemaker_session.upload_data(\n",
     "    path=\"{}/{}\".format(WORK_DIRECTORY, \"abalone.csv\"),\n",
     "    bucket=bucket,\n",
     "    key_prefix=\"{}/{}\".format(prefix, \"train\"),\n",
     ")"
+    "train_input = path=\"{}/{}\".format(WORK_DIRECTORY, \"abalone.csv\")\n"
    ]
   },
   {


### PR DESCRIPTION
Running this script as is creates a runtime error.  `train_input` needs to be of type string, the path to the S3 training input for the later function call by the Transformer object.

*Issue #, if available:*

*Description of changes:*

*Testing done:* This will run at least the SKLearn training job, and start the batch transform job as well.  However, I receive this error on the `Transformer.transform()` call: `sagemaker_containers._errors.ClientError: axis 1 is out of bounds for array of dimension 0`.  

I'm using a headerless CSV convention for testing... not sure what is causing this issue, still investigating.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [ ] I have tested my notebook(s) and ensured it runs end-to-end
- [ ] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
