### PR TITLE
factorization machines notebook: updated sdk v1 calls to v2; clarified results

### DIFF
--- a/introduction_to_amazon_algorithms/factorization_machines_mnist/factorization_machines_mnist.ipynb
+++ b/introduction_to_amazon_algorithms/factorization_machines_mnist/factorization_machines_mnist.ipynb
@@ -63,22 +63,28 @@
    },
    "outputs": [],
    "source": [
-    "import re\n",
-    "import boto3\n",
-    "import sagemaker\n",
-    "from sagemaker import get_execution_role\n",
+    "import io\n",
     "import json\n",
+    "import numpy as np\n",
+    "import os\n",
+    "import pandas as pd\n",
+    "import pickle, gzip, numpy\n",
+    "import re\n",
+    "import sagemaker\n",
+    "from sagemaker.serializers import CSVSerializer\n",
+    "from sagemaker.deserializers import JSONDeserializer\n",
+    "import sagemaker.amazon.common as smac\n",
     "\n",
-    "role = get_execution_role()\n",
     "\n",
-    "region = boto3.Session().region_name\n",
+    "role = sagemaker.get_execution_role()\n",
+    "print(role)\n",
+    "\n",
+    "sess = sagemaker.Session()\n",
+    "region = sess.boto_region_name\n",
     "\n",
     "# S3 bucket where the original mnist data is downloaded and stored.\n",
     "downloaded_data_bucket = f\"sagemaker-sample-files\"\n",
     "downloaded_data_prefix = \"datasets/image/MNIST\"\n",
-    "\n",
-    "print(role)\n",
-    "sess = sagemaker.Session()\n",
     "\n",
     "# bucket used for storing processed data and model.\n",
     "bucket = sess.default_bucket()\n",
@@ -92,7 +98,7 @@
    "source": [
     "### Data ingestion\n",
     "\n",
-    "Next, we read the MNIST dataset [1] from an existing repository for preprocessing prior to training. It was downloaded from [here](http://deeplearning.net/data/mnist/mnist.pkl.gz). The processing could be done *in situ* by Amazon Athena, Apache Spark in Amazon EMR, Amazon Redshift, etc., assuming the dataset is present in the appropriate location. Then, the next step would be to transfer the data to S3 for use in training. For small datasets, such as this one, reading into memory isn't onerous, though it would be for larger datasets.\n",
+    "Next, we read the MNIST dataset [1] from an existing repository for preprocessing prior to training. It was downloaded from [deeplearning.net](http://deeplearning.net/data/mnist/mnist.pkl.gz). The processing could be done *in situ* by Amazon Athena, Apache Spark in Amazon EMR, Amazon Redshift, etc., assuming the dataset is present in the appropriate location. Then, the next step would be to transfer the data to S3 for use in training. For small datasets, such as this one, reading into memory isn't onerous, though it would be for larger datasets.\n",
     "\n",
     "> [1] Y. LeCun, L. Bottou, Y. Bengio, and P. Haffner. Gradient-based learning applied to document recognition. Proceedings of the IEEE, 86(11):2278-2324, November 1998."
    ]
@@ -104,13 +110,13 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "import pickle, gzip, numpy, json\n",
-    "import boto3\n",
     "\n",
     "# Load the dataset\n",
-    "s3 = boto3.client(\"s3\")\n",
-    "s3.download_file(downloaded_data_bucket, f\"{downloaded_data_prefix}/mnist.pkl.gz\", \"mnist.pkl.gz\")\n",
-    "with gzip.open(\"mnist.pkl.gz\", \"rb\") as f:\n",
+    "s3 = sagemaker.s3.S3Downloader\n",
+    "s3_uri = f\"s3://{downloaded_data_bucket}/{downloaded_data_prefix}/mnist.pkl.gz\"\n",
+    "print(s3_uri)\n",
+    "s3.download(s3_uri, \"tmp\")\n",
+    "with gzip.open(\"tmp/mnist.pkl.gz\", \"rb\") as f:\n",
     "    train_set, valid_set, test_set = pickle.load(f, encoding=\"latin1\")"
    ]
   },
@@ -166,10 +172,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import io\n",
-    "import numpy as np\n",
-    "import sagemaker.amazon.common as smac\n",
-    "\n",
     "vectors = np.array([t.tolist() for t in train_set[0]]).astype(\"float32\")\n",
     "labels = np.where(np.array([t.tolist() for t in train_set[1]]) == 0, 1.0, 0.0).astype(\"float32\")\n",
     "\n",
@@ -194,12 +196,10 @@
    },
    "outputs": [],
    "source": [
-    "import boto3\n",
-    "import os\n",
-    "\n",
     "key = \"recordio-pb-data\"\n",
-    "boto3.resource(\"s3\").Bucket(bucket).Object(os.path.join(prefix, \"train\", key)).upload_fileobj(buf)\n",
+    "s3 = sagemaker.s3.S3Uploader\n",
     "s3_train_data = f\"s3://{bucket}/{prefix}/train/{key}\"\n",
+    "s3.upload_string_as_file_body(buf, s3_train_data)\n",
     "print(f\"uploaded training data location: {s3_train_data}\")"
    ]
   },
@@ -239,9 +239,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
-    "\n",
-    "container = get_image_uri(boto3.Session().region_name, \"factorization-machines\")"
+    "container = sagemaker.image_uris.retrieve(\n",
+    "    region=boto3.Session().region_name, framework=\"factorization-machines\"\n",
+    ")\n",
+    "print(container)"
    ]
   },
   {
@@ -261,11 +262,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import boto3\n",
-    "import sagemaker\n",
-    "\n",
-    "sess = sagemaker.Session()\n",
-    "\n",
     "fm = sagemaker.estimator.Estimator(\n",
     "    container,\n",
     "    role,\n",
@@ -318,10 +314,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import json\n",
-    "from sagemaker.predictor import json_deserializer\n",
-    "\n",
-    "\n",
     "def fm_serializer(data):\n",
     "    js = {\"instances\": []}\n",
     "    for row in data:\n",
@@ -329,8 +321,8 @@
     "    return json.dumps(js)\n",
     "\n",
     "\n",
-    "fm_predictor.serializer.serialize = fm_serializer\n",
-    "fm_predictor.deserializer = json_deserializer"
+    "fm_predictor.deserializer = JSONDeserializer()\n",
+    "fm_predictor.serializer.serialize = fm_serializer"
    ]
   },
   {
@@ -365,8 +357,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "\n",
     "predictions = []\n",
     "for array in np.array_split(test_set[0], 100):\n",
     "    result = fm_predictor.predict(array, initial_args={\"ContentType\": \"application/json\"})\n",
@@ -381,8 +371,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pandas as pd\n",
-    "\n",
     "pd.crosstab(\n",
     "    np.where(test_set[1] == 0, 1, 0), predictions, rownames=[\"actuals\"], colnames=[\"predictions\"]\n",
     ")"
@@ -392,7 +380,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As we can see from the confusion matrix above, we predict 951 images of the digit 0 correctly (confusingly this is class 1).  Meanwhile we predict 165 images as the digit 0 when in actuality they aren't, and we miss predicting 29 images of the digit 0 that we should have.\n",
+    "As we can see from the confusion matrix above, we predict around 900 images of the digit 0 correctly (this is class 1 and the 1.0 column). \n",
     "\n",
     "*Note: Due to some differences in parameter initialization, your results may differ from those listed above, but should remain reasonably consistent.*"
    ]
@@ -412,19 +400,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sagemaker\n",
-    "\n",
-    "sagemaker.Session().delete_endpoint(fm_predictor.endpoint)"
+    "sagemaker.predictor.Predictor.delete_endpoint(fm_predictor)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science)",
+   "display_name": "conda_python3",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/datascience-1.0"
+   "name": "conda_python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -436,7 +429,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.12"
   },
   "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },

--- a/introduction_to_amazon_algorithms/factorization_machines_mnist/factorization_machines_mnist.ipynb
+++ b/introduction_to_amazon_algorithms/factorization_machines_mnist/factorization_machines_mnist.ipynb
@@ -240,7 +240,7 @@
    "outputs": [],
    "source": [
     "container = sagemaker.image_uris.retrieve(\n",
-    "    region=boto3.Session().region_name, framework=\"factorization-machines\"\n",
+    "    region=region, framework=\"factorization-machines\"\n",
     ")\n",
     "print(container)"
    ]


### PR DESCRIPTION
* This notebook had several v1 SageMaker Python SDK calls in it. These were upgraded to v2.
* S3 download and upload calls modernized.
* Removed excessive imports.

*Testing done:*

* Default options for notebook instance is AL2v1 Jupyterlab v1 on a ml.t3.medium.
* Bigger instance option with more recent software: AL2.v2 with Jupyterlab v3 on a ml.m5.xlarge.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
