### PR TITLE
fix: Correct SageMaker Clarify notebooks by changing JSONPath to JMESPath

### DIFF
--- a/sagemaker-clarify/fairness_and_explainability/fairness_and_explainability_byoc.ipynb
+++ b/sagemaker-clarify/fairness_and_explainability/fairness_and_explainability_byoc.ipynb
@@ -1018,7 +1018,7 @@
     "#### Writing ModelPredictedLabelConfig\n",
     "\n",
     "A [ModelPredictedLabelConfig](https://sagemaker.readthedocs.io/en/stable/api/training/processing.html#sagemaker.clarify.ModelPredictedLabelConfig) provides information on the format of your predictions.\n",
-    "* `probability` is used by SageMaker Clarify to locate the probability score in endpoint response if the accept type is JSON Lines. In this case, the response payload for a single sample request looks like `'{\"predicted_label\": 0, \"score\": 0.026494730307781475}'`, so SageMaker Clarify can find the score `0.026494730307781475` by JSONPath `'score'`.\n",
+    "* `probability` is used by SageMaker Clarify to locate the probability score in endpoint response if the accept type is JSON Lines. In this case, the response payload for a single sample request looks like `'{\"predicted_label\": 0, \"score\": 0.026494730307781475}'`, so SageMaker Clarify can find the score `0.026494730307781475` by [JMESPath](https://jmespath.org) expression `'score'`.\n",
     "* `probability_threshold` is used by SageMaker Clarify to convert the probability to binary labels for bias analysis. Prediction above the threshold is interpreted as label value 1 and below or equal as label value 0."
    ]
   },

--- a/sagemaker-clarify/fairness_and_explainability/fairness_and_explainability_jsonlines_format.ipynb
+++ b/sagemaker-clarify/fairness_and_explainability/fairness_and_explainability_jsonlines_format.ipynb
@@ -394,7 +394,7 @@
     "A `DataConfig` object communicates some basic information about data I/O to SageMaker Clarify. We specify where to find the input dataset, where to store the output, the target column (`label`), the header names, and the dataset type.\n",
     "\n",
     "Some special things to note about this configuration for the JSON Lines dataset,\n",
-    "* Argument `features` or `label` is **NOT** header string. Instead, it is a [JSONPath string](https://jmespath.org/specification.html) to locate the features list or label in the dataset. For example, for a sample like below, `features` should be 'data.features.values', and `label` should be 'data.label'. \n",
+    "* Argument `features` or `label` is **NOT** header string. Instead, it is a [JMESPath](https://jmespath.org) expression to locate the features list or label in the dataset. For example, for a sample like below, `features` should be 'data.features.values', and `label` should be 'data.label'. \n",
     "\n",
     "```\n",
     "{\"data\": {\"features\": {\"values\": [25, 2, 226802, 1, 7, 4, 6, 3, 2, 1, 0, 0, 40, 37]}, \"label\": 0}}\n",
@@ -450,7 +450,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A `ModelPredictedLabelConfig` provides information on the format of your predictions. The argument `label` is a JSONPath string to locate the predicted label in endpoint response. In this case, the response payload for a single sample request looks like `'{\"predicted_label\": 0, \"score\": 0.013525663875043}'`, so SageMaker Clarify can find predicted label `0` by JSONPath `'predicted_label'`. There is also probability score in the response, so it is possible to use another combination of arguments to decide the predicted label by a custom threshold, for example `probability='score'` and `probability_threshold=0.8`."
+    "A `ModelPredictedLabelConfig` provides information on the format of your predictions. The argument `label` is a JMESPath expression to locate the predicted label in endpoint response. In this case, the response payload for a single sample request looks like `'{\"predicted_label\": 0, \"score\": 0.013525663875043}'`, so SageMaker Clarify can find predicted label `0` by JMESPath expression `'predicted_label'`. There is also probability score in the response, so it is possible to use another combination of arguments to decide the predicted label by a custom threshold, for example `probability='score'` and `probability_threshold=0.8`."
    ]
   },
   {
@@ -623,7 +623,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Run the explainability job, note that Kernel SHAP algorithm requires probability prediction, so JSONPath `\"score\"` is used to extract the probability."
+    "Run the explainability job, note that Kernel SHAP algorithm requires probability prediction, so JMESPath expression `\"score\"` is used to extract the probability."
    ]
   },
   {

--- a/sagemaker_model_monitor/fairness_and_explainability/SageMaker-Model-Monitor-Fairness-and-Explainability.ipynb
+++ b/sagemaker_model_monitor/fairness_and_explainability/SageMaker-Model-Monitor-Fairness-and-Explainability.ipynb
@@ -584,7 +584,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`ModelPredictedLabelConfig` specifies how to extract a predicted label from the model output. This model returns probability that user will churn. Here choose an arbitrary 0.8 cutoff to consider that a customer will churn. For more complicated outputs, there are a few more options, like \"label\" is the index, name or JSONpath to locate predicted label in endpoint response payload."
+    "`ModelPredictedLabelConfig` specifies how to extract a predicted label from the model output. This model returns probability that user will churn. Here choose an arbitrary 0.8 cutoff to consider that a customer will churn. For more complicated outputs, there are a few more options, like \"label\" is the index, name or [JMESPath](https://jmespath.org) expression to locate predicted label in endpoint response payload."
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

https://tiny.amazon.com/l78gdtmh

*Description of changes:*

SageMaker Clarify example notebooks use term JSONPath, but actually the SageMaker Clarify processing container expects [JMESPath](https://jmespath.org) expression. 

The commit corrects the to avoid customer confusion.

*Testing done:*

No code change, only updates to markdown cells. Previewed the notebooks and the updates look good, and hyperlinks work as expected.

## Merge Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [X] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
