### PR TITLE
Update Neo4j Churn example to make it more python native

### DIFF
--- a/autopilot/sagemaker_autopilot_neo4j_portfolio_churn.ipynb
+++ b/autopilot/sagemaker_autopilot_neo4j_portfolio_churn.ipynb
@@ -269,12 +269,12 @@
    },
    "outputs": [],
    "source": [
-    "result = gds.graph.project(\n",
+    "G, result = gds.graph.project(\n",
     "      \"mygraph\",\n",
     "      [\"Company\", \"Manager\", \"Holding\"],\n",
     "      {\n",
-    "          OWNS: {orientation: \"UNDIRECTED\"},\n",
-    "          PARTOF: {orientation: \"UNDIRECTED\"}\n",
+    "          \"OWNS\": {\"orientation\": \"UNDIRECTED\"},\n",
+    "          \"PARTOF\": {\"orientation\": \"UNDIRECTED\"}\n",
     "      }\n",
     "    )\n",
     "\n",
@@ -298,7 +298,8 @@
    },
    "outputs": [],
    "source": [
-    "# result = gds.graph.drop(\"mygraph\")\n",
+    "# G = gds.graph.get(\"mygraph\") \n",
+    "# result = gds.graph.drop(G)\n",
     "\n",
     "# display(result)"
    ]
@@ -345,11 +346,11 @@
    },
    "outputs": [],
    "source": [
-    "result = gds.fastRP.mutate(\"mygraph\",{\n",
-    "    embeddingDimension: 16,\n",
-    "    randomSeed: 1,\n",
-    "    mutateProperty:\"embedding\"\n",
-    "  })\n",
+    "result = gds.fastRP.mutate(G, \n",
+    "    embeddingDimension=16,\n",
+    "    randomSeed=1,\n",
+    "    mutateProperty=\"embedding\"\n",
+    ")\n",
     "\n",
     "display(result)"
    ]
@@ -373,7 +374,7 @@
    },
    "outputs": [],
    "source": [
-    "result = gds.graph.writeNodeProperties(\"mygraph\", [\"embedding\"], [\"Holding\"])\n",
+    "result = gds.graph.writeNodeProperties(G, [\"embedding\"], [\"Holding\"])\n",
     "\n",
     "display(result)"
    ]
@@ -914,7 +915,7 @@
   },
   "vscode": {
    "interpreter": {
-    "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
    }
   }
  },

--- a/autopilot/sagemaker_autopilot_neo4j_portfolio_churn.ipynb
+++ b/autopilot/sagemaker_autopilot_neo4j_portfolio_churn.ipynb
@@ -269,9 +269,7 @@
    },
    "outputs": [],
    "source": [
-    "result = gds.run_cypher(\n",
-    "    \"\"\"\n",
-    "    CALL gds.graph.project(\n",
+    "result = gds.graph.project(\n",
     "      \"mygraph\",\n",
     "      [\"Company\", \"Manager\", \"Holding\"],\n",
     "      {\n",
@@ -279,13 +277,7 @@
     "          PARTOF: {orientation: \"UNDIRECTED\"}\n",
     "      }\n",
     "    )\n",
-    "    YIELD\n",
-    "      graphName AS graph,\n",
-    "      relationshipProjection AS readProjection,\n",
-    "      nodeCount AS nodes,\n",
-    "      relationshipCount AS rels\n",
-    "  \"\"\"\n",
-    ")\n",
+    "\n",
     "display(result)"
    ]
   },
@@ -306,11 +298,8 @@
    },
    "outputs": [],
    "source": [
-    "# result = gds.run_cypher(\n",
-    "#  \"\"\"\n",
-    "#    CALL gds.graph.drop(\"mygraph\")\n",
-    "#  \"\"\"\n",
-    "# )\n",
+    "# result = gds.graph.drop(\"mygraph\")\n",
+    "\n",
     "# display(result)"
    ]
   },
@@ -331,11 +320,8 @@
    },
    "outputs": [],
    "source": [
-    "result = gds.run_cypher(\n",
-    "    \"\"\"\n",
-    "    CALL gds.graph.list()\n",
-    "  \"\"\"\n",
-    ")\n",
+    "result = gds.graph.list()\n",
+    "\n",
     "display(result)"
    ]
   },
@@ -359,15 +345,12 @@
    },
    "outputs": [],
    "source": [
-    "result = gds.run_cypher(\n",
-    "    \"\"\"\n",
-    "  CALL gds.fastRP.mutate(\"mygraph\",{\n",
+    "result = gds.fastRP.mutate(\"mygraph\",{\n",
     "    embeddingDimension: 16,\n",
     "    randomSeed: 1,\n",
     "    mutateProperty:\"embedding\"\n",
     "  })\n",
-    "  \"\"\"\n",
-    ")\n",
+    "\n",
     "display(result)"
    ]
   },
@@ -390,12 +373,8 @@
    },
    "outputs": [],
    "source": [
-    "result = gds.run_cypher(\n",
-    "    \"\"\"\n",
-    "    CALL gds.graph.writeNodeProperties(\"mygraph\", [\"embedding\"], [\"Holding\"])\n",
-    "    YIELD writeMillis\n",
-    "  \"\"\"\n",
-    ")\n",
+    "result = gds.graph.writeNodeProperties(\"mygraph\", [\"embedding\"], [\"Holding\"])\n",
+    "\n",
     "display(result)"
    ]
   },

--- a/autopilot/sagemaker_autopilot_neo4j_portfolio_churn.ipynb
+++ b/autopilot/sagemaker_autopilot_neo4j_portfolio_churn.ipynb
@@ -116,6 +116,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "VxgUxjVQ6OxZ"
    },
@@ -270,13 +277,10 @@
    "outputs": [],
    "source": [
     "G, result = gds.graph.project(\n",
-    "      \"mygraph\",\n",
-    "      [\"Company\", \"Manager\", \"Holding\"],\n",
-    "      {\n",
-    "          \"OWNS\": {\"orientation\": \"UNDIRECTED\"},\n",
-    "          \"PARTOF\": {\"orientation\": \"UNDIRECTED\"}\n",
-    "      }\n",
-    "    )\n",
+    "    \"mygraph\",\n",
+    "    [\"Company\", \"Manager\", \"Holding\"],\n",
+    "    {\"OWNS\": {\"orientation\": \"UNDIRECTED\"}, \"PARTOF\": {\"orientation\": \"UNDIRECTED\"}},\n",
+    ")\n",
     "\n",
     "display(result)"
    ]
@@ -298,7 +302,7 @@
    },
    "outputs": [],
    "source": [
-    "# G = gds.graph.get(\"mygraph\") \n",
+    "# G = gds.graph.get(\"mygraph\")\n",
     "# result = gds.graph.drop(G)\n",
     "\n",
     "# display(result)"
@@ -346,11 +350,7 @@
    },
    "outputs": [],
    "source": [
-    "result = gds.fastRP.mutate(G, \n",
-    "    embeddingDimension=16,\n",
-    "    randomSeed=1,\n",
-    "    mutateProperty=\"embedding\"\n",
-    ")\n",
+    "result = gds.fastRP.mutate(G, embeddingDimension=16, randomSeed=1, mutateProperty=\"embedding\")\n",
     "\n",
     "display(result)"
    ]
@@ -911,7 +911,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.10.6 (main, Nov 14 2022, 16:10:14) [GCC 11.3.0]"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The graphdatascience library provides convenient endpoints instead of always using `gds.run_cypher`.
This PR applies the best practices of the graphdatascience library.

*Testing done:*
Manually ran through the notebook.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
