### PR TITLE
Updating Training Compiler notebooks to TF 2.11

### DIFF
--- a/sagemaker-training-compiler/tensorflow/multiple_gpu_single_node/vision-transformer.ipynb
+++ b/sagemaker-training-compiler/tensorflow/multiple_gpu_single_node/vision-transformer.ipynb
@@ -75,7 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install \"sagemaker>=2.115\" botocore boto3 awscli matplotlib --upgrade"
+    "!pip install \"sagemaker>=2.129\" botocore boto3 awscli matplotlib --upgrade"
    ]
   },
   {
@@ -221,7 +221,7 @@
     "    model_dir=False,\n",
     "    instance_type=\"ml.p3.8xlarge\",\n",
     "    instance_count=1,\n",
-    "    framework_version=\"2.10.0\",\n",
+    "    framework_version=\"2.11\",\n",
     "    py_version=\"py39\",\n",
     "    debugger_hook_config=None,\n",
     "    disable_profiler=True,\n",

--- a/sagemaker-training-compiler/tensorflow/single_gpu_single_node/hyper-parameter-tuning.ipynb
+++ b/sagemaker-training-compiler/tensorflow/single_gpu_single_node/hyper-parameter-tuning.ipynb
@@ -80,7 +80,7 @@
    "outputs": [],
    "source": [
     "!pip install pip --upgrade\n",
-    "!pip install \"sagemaker>=2.115\" botocore boto3 awscli --upgrade"
+    "!pip install \"sagemaker>=2.129\" botocore boto3 awscli --upgrade"
    ]
   },
   {
@@ -228,7 +228,7 @@
     "    model_dir=False,\n",
     "    instance_type=\"ml.p3.2xlarge\",\n",
     "    instance_count=1,\n",
-    "    framework_version=\"2.10.0\",\n",
+    "    framework_version=\"2.11\",\n",
     "    py_version=\"py39\",\n",
     "    debugger_hook_config=None,\n",
     "    disable_profiler=True,\n",

--- a/sagemaker-training-compiler/tensorflow/single_gpu_single_node/vision-transformer.ipynb
+++ b/sagemaker-training-compiler/tensorflow/single_gpu_single_node/vision-transformer.ipynb
@@ -75,7 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install \"sagemaker>=2.115\" botocore boto3 awscli matplotlib --upgrade"
+    "!pip install \"sagemaker>=2.129\" botocore boto3 awscli matplotlib --upgrade"
    ]
   },
   {
@@ -203,7 +203,7 @@
     "    model_dir=False,\n",
     "    instance_type=\"ml.p3.2xlarge\",\n",
     "    instance_count=1,\n",
-    "    framework_version=\"2.10.0\",\n",
+    "    framework_version=\"2.11\",\n",
     "    py_version=\"py39\",\n",
     "    debugger_hook_config=None,\n",
     "    disable_profiler=True,\n",
@@ -227,8 +227,16 @@
     "    },\n",
     "    base_job_name=\"native-tf210-vit\",\n",
     "    **kwargs,\n",
-    ")\n",
-    "\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e40a103",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Start training with our uploaded datasets as input\n",
     "native_estimator.fit(inputs=destn, wait=False)\n",
     "\n",
@@ -272,8 +280,16 @@
     "    compiler_config=TrainingCompilerConfig(),\n",
     "    base_job_name=\"optimized-tf210-vit\",\n",
     "    **kwargs,\n",
-    ")\n",
-    "\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8f79ba0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Start training with our uploaded datasets as input\n",
     "optimized_estimator.fit(inputs=destn, wait=False)\n",
     "\n",

--- a/sagemaker-training-compiler/tensorflow/single_gpu_single_node/vision-transformer.ipynb
+++ b/sagemaker-training-compiler/tensorflow/single_gpu_single_node/vision-transformer.ipynb
@@ -227,7 +227,7 @@
     "    },\n",
     "    base_job_name=\"native-tf210-vit\",\n",
     "    **kwargs,\n",
-    ")\n"
+    ")"
    ]
   },
   {
@@ -280,7 +280,7 @@
     "    compiler_config=TrainingCompilerConfig(),\n",
     "    base_job_name=\"optimized-tf210-vit\",\n",
     "    **kwargs,\n",
-    ")\n"
+    ")"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

Successful Executions:

[vision-transformer-multi-gpu-tf211-01.pdf](https://github.com/aws/amazon-sagemaker-examples/files/10494428/vision-transformer-multi-gpu-tf211-01.pdf)
[vision-transformer-single-gpu-tf211-01.pdf](https://github.com/aws/amazon-sagemaker-examples/files/10494430/vision-transformer-single-gpu-tf211-01.pdf)
[hyper-parameter-tuning-tf211-01.pdf](https://github.com/aws/amazon-sagemaker-examples/files/10494431/hyper-parameter-tuning-tf211-01.pdf)


*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
