### PR TITLE
Updated example with newer dependencies versions

### DIFF
--- a/hyperparameter_tuning/huggingface_multiclass_text_classification_20_newsgroups/hpo_huggingface_text_classification_20_newsgroups.ipynb
+++ b/hyperparameter_tuning/huggingface_multiclass_text_classification_20_newsgroups/hpo_huggingface_text_classification_20_newsgroups.ipynb
@@ -32,7 +32,16 @@
    "source": [
     "import sys\n",
     "\n",
-    "!{sys.executable} -m pip install \"scikit_learn==0.20.0\" \"sagemaker>=2.48.0\" \"transformers==4.6.1\" \"datasets[s3]==1.6.2\" \"nltk==3.4.4\""
+    "!{sys.executable} -m pip install -U \"scikit-learn==1.2.1\" \"sagemaker>=2.48.0\" \"transformers==4.26.0\" \"datasets==2.9.0\" \"nltk==3.8.1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! ls /opt/conda/lib/python3.8/site-packages/datasets | grep datasets"
    ]
   },
   {
@@ -283,7 +292,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sklearn.datasets.twenty_newsgroups import (\n",
+    "from sklearn.datasets._twenty_newsgroups import (\n",
     "    strip_newsgroup_header,\n",
     "    strip_newsgroup_quoting,\n",
     "    strip_newsgroup_footer,\n",
@@ -379,7 +388,7 @@
     "    df[\"text\"] = df[\"text\"].apply(strip_newsgroup_item)\n",
     "    df[\"text\"] = process_text(df[\"text\"].tolist())\n",
     "    df[\"label\"] = label\n",
-    "    all_categories_df = all_categories_df.append(df, ignore_index=True)"
+    "    all_categories_df = pd.concat([all_categories_df, df])"
    ]
   },
   {
@@ -1037,6 +1046,13 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1056,11 +1072,13 @@
     "    instance_count=1,\n",
     "    volume_size=256,\n",
     "    role=role,\n",
-    "    transformers_version=\"4.6\",\n",
-    "    pytorch_version=\"1.7\",\n",
-    "    py_version=\"py36\",\n",
+    "\ttransformers_version='4.17.0',\n",
+    "\tpytorch_version='1.10.2',\n",
+    "\tpy_version='py38',\n",
     "    hyperparameters=hyperparameters,\n",
     "    metric_definitions=metric_definitions,\n",
+    "    dependencies=[\"/opt/conda/lib/python3.8/site-packages/datasets\"],\n",
+    "    \n",
     ")"
    ]
   },
@@ -1261,7 +1279,7 @@
     "        df = df.sort_values(\"FinalObjectiveValue\", ascending=is_minimize)\n",
     "        print(\"Number of training jobs with valid objective: %d\" % len(df))\n",
     "        print({\"lowest\": min(df[\"FinalObjectiveValue\"]), \"highest\": max(df[\"FinalObjectiveValue\"])})\n",
-    "        pd.set_option(\"display.max_colwidth\", -1)  # Don't truncate TrainingJobName\n",
+    "        pd.set_option(\"display.max_colwidth\", None)  # Don't truncate TrainingJobName\n",
     "    else:\n",
     "        print(\"No training jobs have reported valid results yet.\")\n",
     "\n",
@@ -1349,14 +1367,21 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (PyTorch 1.6 Python 3.6 CPU Optimized)",
+   "display_name": "Python 3 (PyTorch 1.12 Python 3.8 GPU Optimized)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/pytorch-1.6-cpu-py36-ubuntu16.04-v1"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-2:429704687514:image/pytorch-1.12-gpu-py38"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1368,7 +1393,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.13"
+   "version": "3.8.13"
   },
   "notice": "Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },


### PR DESCRIPTION
*Description of changes:*

After trying out the HPO example, we've found that the `scikit-learn` library is rather old and the newer version `1.2.1` moves the data-dependent processing scripts a little. 

And to make the preprocessed data work without the [length issue in the huggingface dataset library](https://discuss.huggingface.co/t/keyerror-length-load-from-disk-training-model-on-aws-sagemaker/27232), copying the latest `dataset==2.9.0` dependency from the notebook to the docker image would work seamlessly. 

*Testing done:* Yes, ran end-to-end on Sagemaker kernel `Python 3`; Image `PyTorch 1.12 Python 3.8 GPU Optimized`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
