### PR TITLE
fix: Amend PR 3760 with notebook outputs

### DIFF
--- a/sagemaker_model_monitor/fairness_and_explainability_jsonlines/SageMaker-Monitoring-Bias-Drift-for-Endpoint.ipynb
+++ b/sagemaker_model_monitor/fairness_and_explainability_jsonlines/SageMaker-Monitoring-Bias-Drift-for-Endpoint.ipynb
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "21f01570-2eee-46ef-b044-8b65569c26b7",
    "metadata": {},
    "outputs": [],
@@ -151,10 +151,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "74b11f7c-e9cd-4321-8de5-27ca6dd85d01",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AWS region: us-west-2\n",
+      "RoleArn: arn:aws:iam::000000000000:role/service-role/AmazonSageMaker-ExecutionRole-20200714T163791\n",
+      "Demo Bucket: sagemaker-us-west-2-000000000000\n",
+      "Demo Prefix: sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6\n",
+      "Demo S3 key: s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6\n",
+      "The endpoint will save the captured data to: s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/data-capture\n",
+      "You should upload the ground truth data to: s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/ground-truth\n",
+      "The baselining job will save the analysis results to: s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/baselining-output\n",
+      "The monitor will save the analysis results to: s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/monitor-output\n"
+     ]
+    }
+   ],
    "source": [
     "sagemaker_session = sagemaker.Session()\n",
     "\n",
@@ -210,7 +226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "f75d26c9-0f0b-422d-97cb-b74efd5eacd6",
    "metadata": {},
    "outputs": [],
@@ -228,7 +244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "f1eaa4fe-622f-4745-a3cc-52d40db8ce9f",
    "metadata": {},
    "outputs": [],
@@ -248,10 +264,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "06c22c10-7ba8-417a-a0dc-1e152a0a3287",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"features\":[41,2,220531,14,15,2,9,0,4,1,0,0,60,38],\"label\":1}\n",
+      "{\"features\":[33,2,35378,9,13,2,11,5,4,0,0,0,45,38],\"label\":1}\n",
+      "{\"features\":[36,2,223433,12,14,2,11,0,4,1,7688,0,50,38],\"label\":1}\n",
+      "{\"features\":[40,2,220589,7,12,4,0,1,4,0,0,0,40,38],\"label\":0}\n",
+      "{\"features\":[30,2,231413,15,10,2,2,0,4,1,0,0,40,38],\"label\":1}\n"
+     ]
+    }
+   ],
    "source": [
     "!head -n 5 $train_dataset_path"
    ]
@@ -266,10 +294,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "9f78d463-f1ff-4483-8cf3-562bccb98a2b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"features\":[28,2,133937,9,13,2,0,0,4,1,15024,0,55,37]}\n",
+      "{\"features\":[43,2,72338,12,14,2,12,0,1,1,0,0,40,37]}\n",
+      "{\"features\":[34,2,162604,11,9,4,2,2,2,1,0,0,40,37]}\n",
+      "{\"features\":[20,2,258509,11,9,4,6,3,2,1,0,0,40,37]}\n",
+      "{\"features\":[27,2,446947,9,13,4,0,4,2,0,0,0,55,37]}\n"
+     ]
+    }
+   ],
    "source": [
     "!head -n 5 $test_dataset_path"
    ]
@@ -284,7 +324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "2a843093-0548-48dd-9f82-e80af07c357e",
    "metadata": {},
    "outputs": [],
@@ -318,10 +358,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "dfe69a8c-9bf6-47c4-bb59-a775fd3b6934",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Success! We are all set to proceed with uploading to S3.\n"
+     ]
+    }
+   ],
    "source": [
     "sagemaker.s3.S3Uploader.upload_string_as_file_body(\n",
     "    body=\"hello\",\n",
@@ -341,10 +389,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "0f0fe183-4c83-4d22-bce5-65eba6a351e2",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model file has been uploaded to s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/ll-adult-prediction-model.tar.gz\n",
+      "Train data is uploaded to: s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/validation-dataset.jsonl\n",
+      "Test data is uploaded to: s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/test-dataset.jsonl\n"
+     ]
+    }
+   ],
    "source": [
     "model_url = sagemaker.s3.S3Uploader.upload(\n",
     "    local_path=model_file,\n",
@@ -393,10 +451,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "d0c565e0-051a-4f6c-bcb6-3dca8f4ec592",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SageMaker model name: DEMO-ll-adult-pred-model-monitor-1674105930-3d28\n",
+      "SageMaker endpoint name: DEMO-ll-adult-pred-model-monitor-1674105930-3d28\n",
+      "SageMaker Linear Learner image: 174872318107.dkr.ecr.us-west-2.amazonaws.com/linear-learner:1\n"
+     ]
+    }
+   ],
    "source": [
     "model_name = sagemaker.utils.unique_name_from_base(\"DEMO-ll-adult-pred-model-monitor\")\n",
     "endpoint_name = model_name\n",
@@ -432,10 +500,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "77330b34-0640-4b00-b3bb-4a8ea6e9a223",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deploying model DEMO-ll-adult-pred-model-monitor-1674105930-3d28 to endpoint DEMO-ll-adult-pred-model-monitor-1674105930-3d28\n",
+      "------!"
+     ]
+    }
+   ],
    "source": [
     "print(f\"Deploying model {model_name} to endpoint {endpoint_name}\")\n",
     "model.deploy(\n",
@@ -458,7 +535,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "44a908e5-c16f-41dc-b718-323ab5ed4268",
    "metadata": {},
    "outputs": [],
@@ -485,10 +562,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "52fbb63a-e1d8-414e-968a-20822305f23c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"features\":[28,2,133937,9,13,2,0,0,4,1,15024,0,55,37]}\n"
+     ]
+    }
+   ],
    "source": [
     "request_payload = test_data[0]\n",
     "print(request_payload)"
@@ -504,10 +589,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "87531e43-c9d1-4d9b-8019-19bec1a832eb",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'{\"predicted_label\":1,\"score\":0.989977359771728}\\n'"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "response = sagemaker_session.sagemaker_runtime_client.invoke_endpoint(\n",
     "    EndpointName=endpoint_name,\n",
@@ -537,10 +633,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "2cd41694-9e20-461f-ae85-5f792a521753",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'{\"features\":[28,2,133937,9,13,2,0,0,4,1,15024,0,55,37]}\\n{\"features\":[43,2,72338,12,14,2,12,0,1,1,0,0,40,37]}'"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "request_payload = \"\\n\".join(test_data[:2])\n",
     "request_payload"
@@ -556,10 +663,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "fece49e7-38b9-4b33-91ca-f23fcd06dcbb",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'{\"predicted_label\":1,\"score\":0.989977359771728}\\n{\"predicted_label\":1,\"score\":0.504138827323913}\\n'"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "response = sagemaker_session.sagemaker_runtime_client.invoke_endpoint(\n",
     "    EndpointName=endpoint_name,\n",
@@ -587,10 +705,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "18c649dd-40ef-4260-b499-0f3c371f970f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Waiting for captured data to show up.........................................................\n",
+      "Found capture data files:\n",
+      "s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/data-capture/DEMO-ll-adult-pred-model-monitor-1674105930-3d28/AllTraffic/2023/01/19/05/28-32-105-b59d42b8-3dac-421a-a586-0c4effa143d2.jsonl\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"Waiting for captured data to show up\", end=\"\")\n",
     "for _ in range(120):\n",
@@ -619,10 +747,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "e4ad7021-4bcc-4fe1-880e-11a872941ff1",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"captureData\":{\"endpointInput\":{\"observedContentType\":\"application/jsonlines\",\"mode\":\"INPUT\",\"data\":\"{\\\"features\\\":[28,2,133937,9,13,2,0,0,4,1,15024,0,55,37]}\",\"encoding\":\"JSON\"},\"endpointOutput\":{\"observedContentType\":\"application/jsonlines\",\"mode\":\"OUTPUT\",\"data\":\"{\\\"predicted_label\\\":1,\\\"score\\\":0.989977359771728}\\n\",\"encoding\":\"JSON\"}},\"eventMetadata\":{\"eventId\":\"50ef5ec7-4d6b-4606-b13d-803c7416f853\",\"inferenceTime\":\"2023-01-19T05:28:32Z\"},\"eventVersion\":\"0\"}\n",
+      "{\"captureData\":{\"endpointInput\":{\"observedContentType\":\"application/jsonlines\",\"mode\":\"INPUT\",\"data\":\"{\\\"features\\\":[28,2,133937,9,13,2,0,0,4,1,15024,0,55,37]}\\n{\\\"features\\\":[43,2,72338,12,14,2,12,0,1,1,0,0,40,37]}\",\"encoding\":\"JSON\"},\"endpointOutput\":{\"observedContentType\":\"application/jsonlines\",\"mode\":\"OUTPUT\",\"data\":\"{\\\"predicted_label\\\":1,\\\"score\\\":0.989977359771728}\\n{\\\"predicted_label\\\":1,\\\"score\\\":0.504138827323913}\\n\",\"encoding\":\"JSON\"}},\"eventMetadata\":{\"eventId\":\"74e40c99-2d94-4a6d-a21e-f0222769012e\",\"inferenceTime\":\"2023-01-19T05:28:32Z\"},\"eventVersion\":\"0\"}\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "captured_data = sagemaker.s3.S3Downloader.read_file(\n",
     "    s3_uri=captured_data_files[-1],\n",
@@ -644,10 +782,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "14611944-0ae1-4f9f-ab6e-4b5c74ee7f3f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"captureData\": {\n",
+      "        \"endpointInput\": {\n",
+      "            \"observedContentType\": \"application/jsonlines\",\n",
+      "            \"mode\": \"INPUT\",\n",
+      "            \"data\": \"{\\\"features\\\":[28,2,133937,9,13,2,0,0,4,1,15024,0,55,37]}\\n{\\\"features\\\":[43,2,72338,12,14,2,12,0,1,1,0,0,40,37]}\",\n",
+      "            \"encoding\": \"JSON\"\n",
+      "        },\n",
+      "        \"endpointOutput\": {\n",
+      "            \"observedContentType\": \"application/jsonlines\",\n",
+      "            \"mode\": \"OUTPUT\",\n",
+      "            \"data\": \"{\\\"predicted_label\\\":1,\\\"score\\\":0.989977359771728}\\n{\\\"predicted_label\\\":1,\\\"score\\\":0.504138827323913}\\n\",\n",
+      "            \"encoding\": \"JSON\"\n",
+      "        }\n",
+      "    },\n",
+      "    \"eventMetadata\": {\n",
+      "        \"eventId\": \"74e40c99-2d94-4a6d-a21e-f0222769012e\",\n",
+      "        \"inferenceTime\": \"2023-01-19T05:28:32Z\"\n",
+      "    },\n",
+      "    \"eventVersion\": \"0\"\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "print(json.dumps(json.loads(captured_data.splitlines()[-1]), indent=4))"
    ]
@@ -665,7 +831,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "0af95cc5-9e1d-46fd-b373-16015c87be58",
    "metadata": {},
    "outputs": [],
@@ -686,7 +852,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "id": "00e832f7-8cc7-4044-b2aa-f22c93d2078d",
    "metadata": {},
    "outputs": [],
@@ -727,7 +893,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "id": "d43e06d4-32d8-451c-81f2-be1f131a5ec0",
    "metadata": {},
    "outputs": [],
@@ -765,10 +931,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "id": "49137517-172a-45ea-b139-ae78555b47e6",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Uploading 334 records to s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/ground-truth/2023/01/19/04/2933.jsonl\n"
+     ]
+    }
+   ],
    "source": [
     "# Generate data for the last hour, in case the first monitoring execution is in this hour\n",
     "upload_ground_truth(datetime.datetime.utcnow() - datetime.timedelta(hours=1))"
@@ -776,10 +950,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "573901f2-fbba-4bf0-b73c-807c44fe709b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Uploading 334 records to s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/ground-truth/2023/01/19/05/2933.jsonl\n"
+     ]
+    }
+   ],
    "source": [
     "# Generate data once an hour\n",
     "def generate_fake_ground_truth(terminate_event):\n",
@@ -808,7 +990,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "id": "273af941-56ff-4a08-a1e1-023e2d4ec090",
    "metadata": {},
    "outputs": [],
@@ -860,7 +1042,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "fd146e26-a54c-4a31-acc9-5a406ddf8680",
    "metadata": {},
    "outputs": [],
@@ -889,7 +1071,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "id": "3a49acc6-c6a9-46fa-aed7-e93e67fae373",
    "metadata": {},
    "outputs": [],
@@ -918,7 +1100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "id": "c6dc6502-8a28-4cda-a135-2c687e9097b6",
    "metadata": {},
    "outputs": [],
@@ -942,7 +1124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "id": "0ead08ae-1867-41b9-8c0e-6202760c4175",
    "metadata": {},
    "outputs": [],
@@ -967,10 +1149,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "id": "9c27e74b-31f6-435a-a0d4-bef52a4cdcdb",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Job Name:  baseline-suggestion-job-2023-01-19-05-29-34-322\n",
+      "Inputs:  [{'InputName': 'dataset', 'AppManaged': False, 'S3Input': {'S3Uri': 's3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/validation-dataset.jsonl', 'LocalPath': '/opt/ml/processing/input/data', 'S3DataType': 'S3Prefix', 'S3InputMode': 'File', 'S3DataDistributionType': 'FullyReplicated', 'S3CompressionType': 'None'}}, {'InputName': 'analysis_config', 'AppManaged': False, 'S3Input': {'S3Uri': 's3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/baselining-output/analysis_config.json', 'LocalPath': '/opt/ml/processing/input/config', 'S3DataType': 'S3Prefix', 'S3InputMode': 'File', 'S3DataDistributionType': 'FullyReplicated', 'S3CompressionType': 'None'}}]\n",
+      "Outputs:  [{'OutputName': 'analysis_result', 'AppManaged': False, 'S3Output': {'S3Uri': 's3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/baselining-output', 'LocalPath': '/opt/ml/processing/output', 'S3UploadMode': 'EndOfJob'}}]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<sagemaker.processing.ProcessingJob at 0x7f92b905a810>"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "model_bias_monitor.suggest_baseline(\n",
     "    bias_config=bias_config,\n",
@@ -990,10 +1193,153 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "id": "ad0ece68-f130-4b66-b8ab-36d2916502c8",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ".................................................................................................!\n",
+      "Suggested constraints: s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/baselining-output/analysis.json\n",
+      "{\n",
+      "    \"version\": \"1.0\",\n",
+      "    \"post_training_bias_metrics\": {\n",
+      "        \"label\": \"Target\",\n",
+      "        \"facets\": {\n",
+      "            \"Sex\": [\n",
+      "                {\n",
+      "                    \"value_or_threshold\": \"0\",\n",
+      "                    \"metrics\": [\n",
+      "                        {\n",
+      "                            \"name\": \"AD\",\n",
+      "                            \"description\": \"Accuracy Difference (AD)\",\n",
+      "                            \"value\": -0.15156641604010024\n",
+      "                        },\n",
+      "                        {\n",
+      "                            \"name\": \"CDDPL\",\n",
+      "                            \"description\": \"Conditional Demographic Disparity in Predicted Labels (CDDPL)\",\n",
+      "                            \"value\": 0.28176563733194276\n",
+      "                        },\n",
+      "                        {\n",
+      "                            \"name\": \"DAR\",\n",
+      "                            \"description\": \"Difference in Acceptance Rates (DAR)\",\n",
+      "                            \"value\": -0.09508196721311479\n",
+      "                        },\n",
+      "                        {\n",
+      "                            \"name\": \"DCA\",\n",
+      "                            \"description\": \"Difference in Conditional Acceptance (DCA)\",\n",
+      "                            \"value\": -0.5278688524590163\n",
+      "                        },\n",
+      "                        {\n",
+      "                            \"name\": \"DCR\",\n",
+      "                            \"description\": \"Difference in Conditional Rejection (DCR)\",\n",
+      "                            \"value\": 0.027874251497005953\n",
+      "                        },\n",
+      "                        {\n",
+      "                            \"name\": \"DI\",\n",
+      "                            \"description\": \"Disparate Impact (DI)\",\n",
+      "                            \"value\": 0.17798594847775176\n",
+      "                        },\n",
+      "                        {\n",
+      "                            \"name\": \"DPPL\",\n",
+      "                            \"description\": \"Difference in Positive Proportions in Predicted Labels (DPPL)\",\n",
+      "                            \"value\": 0.2199248120300752\n",
+      "                        },\n",
+      "                        {\n",
+      "                            \"name\": \"DRR\",\n",
+      "                            \"description\": \"Difference in Rejection Rates (DRR)\",\n",
+      "                            \"value\": 0.12565868263473046\n",
+      "                        },\n",
+      "                        {\n",
+      "                            \"name\": \"FT\",\n",
+      "                            \"description\": \"Flip Test (FT)\",\n",
+      "                            \"value\": -0.03333333333333333\n",
+      "                        },\n",
+      "                        {\n",
+      "                            \"name\": \"GE\",\n",
+      "                            \"description\": \"Generalized Entropy (GE)\",\n",
+      "                            \"value\": 0.0841186702174704\n",
+      "                        },\n",
+      "                        {\n",
+      "                            \"name\": \"RD\",\n",
+      "                            \"description\": \"Recall Difference (RD)\",\n",
+      "                            \"value\": 0.1308103661044837\n",
+      "                        },\n",
+      "                        {\n",
+      "                            \"name\": \"SD\",\n",
+      "                            \"description\": \"Specificity Difference (SD)\",\n",
+      "                            \"value\": 0.10465328014037645\n",
+      "                        },\n",
+      "                        {\n",
+      "                            \"name\": \"TE\",\n",
+      "                            \"description\": \"Treatment Equality (TE)\",\n",
+      "                            \"value\": 2.916666666666667\n",
+      "                        }\n",
+      "                    ]\n",
+      "                }\n",
+      "            ]\n",
+      "        },\n",
+      "        \"label_value_or_threshold\": \"1\"\n",
+      "    },\n",
+      "    \"pre_training_bias_metrics\": {\n",
+      "        \"label\": \"Target\",\n",
+      "        \"facets\": {\n",
+      "            \"Sex\": [\n",
+      "                {\n",
+      "                    \"value_or_threshold\": \"0\",\n",
+      "                    \"metrics\": [\n",
+      "                        {\n",
+      "                            \"name\": \"CDDL\",\n",
+      "                            \"description\": \"Conditional Demographic Disparity in Labels (CDDL)\",\n",
+      "                            \"value\": 0.27459074287718793\n",
+      "                        },\n",
+      "                        {\n",
+      "                            \"name\": \"CI\",\n",
+      "                            \"description\": \"Class Imbalance (CI)\",\n",
+      "                            \"value\": 0.36936936936936937\n",
+      "                        },\n",
+      "                        {\n",
+      "                            \"name\": \"DPL\",\n",
+      "                            \"description\": \"Difference in Positive Proportions in Labels (DPL)\",\n",
+      "                            \"value\": 0.2326441102756892\n",
+      "                        },\n",
+      "                        {\n",
+      "                            \"name\": \"JS\",\n",
+      "                            \"description\": \"Jensen-Shannon Divergence (JS)\",\n",
+      "                            \"value\": 0.04508199943437752\n",
+      "                        },\n",
+      "                        {\n",
+      "                            \"name\": \"KL\",\n",
+      "                            \"description\": \"Kullback-Liebler Divergence (KL)\",\n",
+      "                            \"value\": 0.22434464102537785\n",
+      "                        },\n",
+      "                        {\n",
+      "                            \"name\": \"KS\",\n",
+      "                            \"description\": \"Kolmogorov-Smirnov Distance (KS)\",\n",
+      "                            \"value\": 0.2326441102756892\n",
+      "                        },\n",
+      "                        {\n",
+      "                            \"name\": \"LP\",\n",
+      "                            \"description\": \"L-p Norm (LP)\",\n",
+      "                            \"value\": 0.32900845595810163\n",
+      "                        },\n",
+      "                        {\n",
+      "                            \"name\": \"TVD\",\n",
+      "                            \"description\": \"Total Variation Distance (TVD)\",\n",
+      "                            \"value\": 0.2326441102756892\n",
+      "                        }\n",
+      "                    ]\n",
+      "                }\n",
+      "            ]\n",
+      "        },\n",
+      "        \"label_value_or_threshold\": \"1\"\n",
+      "    }\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "model_bias_monitor.latest_baselining_job.wait(logs=False)\n",
     "print()\n",
@@ -1040,7 +1386,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "id": "8d160d3e-0482-4c4b-a171-e62eddb38b87",
    "metadata": {},
    "outputs": [],
@@ -1050,10 +1396,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "id": "1c7a1355-2997-46f2-ae02-cb00063e3661",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model bias monitoring schedule: monitoring-schedule-2023-01-19-05-37-42-411\n"
+     ]
+    }
+   ],
    "source": [
     "model_bias_analysis_config = None\n",
     "if not model_bias_monitor.latest_baselining_job:\n",
@@ -1094,7 +1448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "id": "ae00eb31-bbc7-4cf9-9fae-b323b4d380b2",
    "metadata": {},
    "outputs": [],
@@ -1133,10 +1487,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "id": "b512df1e-57cf-4ba3-9262-0c325c4a600e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "An hourly schedule was created above and it will kick off executions ON the hour (plus 0 - 20 min buffer).\n",
+      "Waiting for the first execution to happen................................\n",
+      "Done! Execution has been created\n",
+      "Now waiting for execution to start..........\n",
+      "Done! Execution has started\n"
+     ]
+    }
+   ],
    "source": [
     "wait_for_execution_to_start(model_bias_monitor)"
    ]
@@ -1151,10 +1517,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "id": "a6980d31-c96d-4850-a7fb-c8583eeac54e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Stopping Monitoring Schedule with name: monitoring-schedule-2023-01-19-05-37-42-411\n"
+     ]
+    }
+   ],
    "source": [
     "model_bias_monitor.stop_monitoring_schedule()"
    ]
@@ -1176,7 +1551,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "id": "2b07426d-f805-4527-9863-1d3d664734fa",
    "metadata": {},
    "outputs": [],
@@ -1213,10 +1588,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "id": "25e36f00-f488-4a16-867f-92c53d819782",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Waiting for execution to finish..........\n",
+      "Done! Execution Status: CompletedWithViolations\n"
+     ]
+    }
+   ],
    "source": [
     "wait_for_execution_to_finish(model_bias_monitor)"
    ]
@@ -1233,10 +1617,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "id": "b6df9816-63ad-4e44-b26d-b79fba785307",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found merged files:\n",
+      "s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/monitor-output/merge/DEMO-ll-adult-pred-model-monitor-1674105930-3d28/AllTraffic/2023/01/19/05/part-00001-d8c20802-c1f9-45c3-a3fa-007f2b73f21b.c000.jsonl\n",
+      " s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/monitor-output/merge/DEMO-ll-adult-pred-model-monitor-1674105930-3d28/AllTraffic/2023/01/19/05/part-00002-45e374bf-f12b-4abb-988d-5b5179da218e.c000.jsonl\n",
+      " s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/monitor-output/merge/DEMO-ll-adult-pred-model-monitor-1674105930-3d28/AllTraffic/2023/01/19/06/part-00000-e4cbb1f0-cc6d-4f92-9397-af7f00604374.c000.jsonl\n",
+      " s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/monitor-output/merge/DEMO-ll-adult-pred-model-monitor-1674105930-3d28/AllTraffic/2023/01/19/06/part-00001-ff724347-c6e3-4ac4-9872-c008d3dad640.c000.jsonl\n",
+      " s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/monitor-output/merge/DEMO-ll-adult-pred-model-monitor-1674105930-3d28/AllTraffic/2023/01/19/06/part-00002-f68c1866-e8b6-4c16-aba3-96669f7af976.c000.jsonl\n"
+     ]
+    }
+   ],
    "source": [
     "merged_data_s3_uri = f\"{monitor_output_s3_uri}/merge\"\n",
     "merged_data_files = sagemaker.s3.S3Downloader.list(\n",
@@ -1261,10 +1658,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "id": "6581b300-4ee0-4884-aef7-bf94577c07aa",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"eventVersion\": \"0\",\n",
+      "    \"groundTruthData\": {\n",
+      "        \"data\": \"{\\\"label\\\": 0}\",\n",
+      "        \"encoding\": \"JSON\"\n",
+      "    },\n",
+      "    \"captureData\": {\n",
+      "        \"endpointInput\": {\n",
+      "            \"data\": \"{\\\"features\\\":[42,2,222756,9,13,0,9,4,4,1,7430,0,40,37]}\",\n",
+      "            \"encoding\": \"JSON\",\n",
+      "            \"mode\": \"INPUT\",\n",
+      "            \"observedContentType\": \"application/jsonlines\"\n",
+      "        },\n",
+      "        \"endpointOutput\": {\n",
+      "            \"data\": \"{\\\"predicted_label\\\":1,\\\"score\\\":0.90517783164978}\\n\",\n",
+      "            \"encoding\": \"JSON\",\n",
+      "            \"mode\": \"OUTPUT\",\n",
+      "            \"observedContentType\": \"application/jsonlines\"\n",
+      "        }\n",
+      "    },\n",
+      "    \"eventMetadata\": {\n",
+      "        \"eventId\": \"d7f04b0c-e3f3-4a55-b0be-47c4942e9ee8\",\n",
+      "        \"inferenceId\": \"95\",\n",
+      "        \"inferenceTime\": \"2023-01-19T06:04:56Z\"\n",
+      "    }\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "merged_data_file = sagemaker.s3.S3Downloader.read_file(\n",
     "    s3_uri=merged_data_files[-1],\n",
@@ -1289,10 +1719,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "id": "3c767cbd-78c5-433d-a850-e230cb5a55dd",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Report URI: s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/monitor-output/DEMO-ll-adult-pred-model-monitor-1674105930-3d28/monitoring-schedule-2023-01-19-05-37-42-411/2023/01/19/06\n",
+      "Found Report Files:\n",
+      "s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/monitor-output/DEMO-ll-adult-pred-model-monitor-1674105930-3d28/monitoring-schedule-2023-01-19-05-37-42-411/2023/01/19/06/analysis.json\n",
+      " s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/monitor-output/DEMO-ll-adult-pred-model-monitor-1674105930-3d28/monitoring-schedule-2023-01-19-05-37-42-411/2023/01/19/06/constraint_violations.json\n",
+      " s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/monitor-output/DEMO-ll-adult-pred-model-monitor-1674105930-3d28/monitoring-schedule-2023-01-19-05-37-42-411/2023/01/19/06/report.html\n",
+      " s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/monitor-output/DEMO-ll-adult-pred-model-monitor-1674105930-3d28/monitoring-schedule-2023-01-19-05-37-42-411/2023/01/19/06/report.ipynb\n",
+      " s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674105929-04d6/monitor-output/DEMO-ll-adult-pred-model-monitor-1674105930-3d28/monitoring-schedule-2023-01-19-05-37-42-411/2023/01/19/06/report.pdf\n"
+     ]
+    }
+   ],
    "source": [
     "schedule_desc = model_bias_monitor.describe_schedule()\n",
     "execution_summary = schedule_desc.get(\"LastMonitoringExecutionSummary\")\n",
@@ -1330,10 +1774,81 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "id": "a7174d2e-9ee4-437f-be9a-c9d984318b76",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{   'version': '1.0',\n",
+      "    'violations': [   {   'constraint_check_type': 'bias_drift_check',\n",
+      "                          'description': 'Metric value 0.37745519271384836 '\n",
+      "                                         \"doesn't meet the baseline constraint \"\n",
+      "                                         'requirement 0.28176563733194276',\n",
+      "                          'facet': 'Sex',\n",
+      "                          'facet_value': '0',\n",
+      "                          'metric_name': 'CDDPL'},\n",
+      "                      {   'constraint_check_type': 'bias_drift_check',\n",
+      "                          'description': 'Metric value -0.3522727272727273 '\n",
+      "                                         \"doesn't meet the baseline constraint \"\n",
+      "                                         'requirement -0.09508196721311479',\n",
+      "                          'facet': 'Sex',\n",
+      "                          'facet_value': '0',\n",
+      "                          'metric_name': 'DAR'},\n",
+      "                      {   'constraint_check_type': 'bias_drift_check',\n",
+      "                          'description': 'Metric value -36.42045454545455 '\n",
+      "                                         \"doesn't meet the baseline constraint \"\n",
+      "                                         'requirement -0.5278688524590163',\n",
+      "                          'facet': 'Sex',\n",
+      "                          'facet_value': '0',\n",
+      "                          'metric_name': 'DCA'},\n",
+      "                      {   'constraint_check_type': 'bias_drift_check',\n",
+      "                          'description': 'Metric value -0.07676294702237407 '\n",
+      "                                         \"doesn't meet the baseline constraint \"\n",
+      "                                         'requirement 0.027874251497005953',\n",
+      "                          'facet': 'Sex',\n",
+      "                          'facet_value': '0',\n",
+      "                          'metric_name': 'DCR'},\n",
+      "                      {   'constraint_check_type': 'bias_drift_check',\n",
+      "                          'description': \"Metric value -0.14 doesn't meet the \"\n",
+      "                                         'baseline constraint requirement '\n",
+      "                                         '-0.03333333333333333',\n",
+      "                          'facet': 'Sex',\n",
+      "                          'facet_value': '0',\n",
+      "                          'metric_name': 'FT'},\n",
+      "                      {   'constraint_check_type': 'bias_drift_check',\n",
+      "                          'description': 'Metric value 0.9537540310981236 '\n",
+      "                                         \"doesn't meet the baseline constraint \"\n",
+      "                                         'requirement 0.0841186702174704',\n",
+      "                          'facet': 'Sex',\n",
+      "                          'facet_value': '0',\n",
+      "                          'metric_name': 'GE'},\n",
+      "                      {   'constraint_check_type': 'bias_drift_check',\n",
+      "                          'description': 'Metric value 0.170704663945835 '\n",
+      "                                         \"doesn't meet the baseline constraint \"\n",
+      "                                         'requirement 0.1308103661044837',\n",
+      "                          'facet': 'Sex',\n",
+      "                          'facet_value': '0',\n",
+      "                          'metric_name': 'RD'},\n",
+      "                      {   'constraint_check_type': 'bias_drift_check',\n",
+      "                          'description': 'Metric value 0.2792792792792793 '\n",
+      "                                         \"doesn't meet the baseline constraint \"\n",
+      "                                         'requirement 0.10465328014037645',\n",
+      "                          'facet': 'Sex',\n",
+      "                          'facet_value': '0',\n",
+      "                          'metric_name': 'SD'},\n",
+      "                      {   'constraint_check_type': 'bias_drift_check',\n",
+      "                          'description': \"Metric value Infinity doesn't meet \"\n",
+      "                                         'the baseline constraint requirement '\n",
+      "                                         '2.916666666666667',\n",
+      "                          'facet': 'Sex',\n",
+      "                          'facet_value': '0',\n",
+      "                          'metric_name': 'TE'}]}\n"
+     ]
+    }
+   ],
    "source": [
     "violations = model_bias_monitor.latest_monitoring_constraint_violations()\n",
     "if violations is not None:\n",
@@ -1368,7 +1883,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 44,
    "id": "f813097c-00cc-4ee4-91cc-d03b72915c67",
    "metadata": {},
    "outputs": [],
@@ -1387,10 +1902,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "id": "e4b99289-3924-4d40-9860-75ccea76646b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Stopping Monitoring Schedule with name: monitoring-schedule-2023-01-19-05-37-42-411\n",
+      "Waiting for execution to finish\n",
+      "Done! Execution Status: CompletedWithViolations\n",
+      "\n",
+      "Deleting Monitoring Schedule with name: monitoring-schedule-2023-01-19-05-37-42-411\n"
+     ]
+    }
+   ],
    "source": [
     "model_bias_monitor.stop_monitoring_schedule()\n",
     "wait_for_execution_to_finish(model_bias_monitor)\n",
@@ -1407,7 +1935,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 46,
    "id": "d6dd0678-66d3-493d-bee4-7e2a9dab901e",
    "metadata": {},
    "outputs": [],

--- a/sagemaker_model_monitor/fairness_and_explainability_jsonlines/SageMaker-Monitoring-Feature-Attribution-Drift-for-Endpoint.ipynb
+++ b/sagemaker_model_monitor/fairness_and_explainability_jsonlines/SageMaker-Monitoring-Feature-Attribution-Drift-for-Endpoint.ipynb
@@ -117,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "21f01570-2eee-46ef-b044-8b65569c26b7",
    "metadata": {},
    "outputs": [],
@@ -149,10 +149,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "74b11f7c-e9cd-4321-8de5-27ca6dd85d01",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AWS region: us-west-2\n",
+      "RoleArn: arn:aws:iam::000000000000:role/service-role/AmazonSageMaker-ExecutionRole-20200714T163791\n",
+      "Demo Bucket: sagemaker-us-west-2-000000000000\n",
+      "Demo Prefix: sagemaker/DEMO-ClarifyModelMonitor-1674106123-4d04\n",
+      "Demo S3 key: s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674106123-4d04\n",
+      "The endpoint will save the captured data to: s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674106123-4d04/data-capture\n",
+      "The baselining job will save the analysis results to: s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674106123-4d04/baselining-output\n",
+      "The monitor will save the analysis results to: s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674106123-4d04/monitor-output\n"
+     ]
+    }
+   ],
    "source": [
     "sagemaker_session = sagemaker.Session()\n",
     "\n",
@@ -206,7 +221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "f75d26c9-0f0b-422d-97cb-b74efd5eacd6",
    "metadata": {},
    "outputs": [],
@@ -224,7 +239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "f1eaa4fe-622f-4745-a3cc-52d40db8ce9f",
    "metadata": {},
    "outputs": [],
@@ -244,10 +259,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "06c22c10-7ba8-417a-a0dc-1e152a0a3287",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"features\":[41,2,220531,14,15,2,9,0,4,1,0,0,60,38],\"label\":1}\n",
+      "{\"features\":[33,2,35378,9,13,2,11,5,4,0,0,0,45,38],\"label\":1}\n",
+      "{\"features\":[36,2,223433,12,14,2,11,0,4,1,7688,0,50,38],\"label\":1}\n",
+      "{\"features\":[40,2,220589,7,12,4,0,1,4,0,0,0,40,38],\"label\":0}\n",
+      "{\"features\":[30,2,231413,15,10,2,2,0,4,1,0,0,40,38],\"label\":1}\n"
+     ]
+    }
+   ],
    "source": [
     "!head -n 5 $train_dataset_path"
    ]
@@ -262,10 +289,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "9f78d463-f1ff-4483-8cf3-562bccb98a2b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"features\":[28,2,133937,9,13,2,0,0,4,1,15024,0,55,37]}\n",
+      "{\"features\":[43,2,72338,12,14,2,12,0,1,1,0,0,40,37]}\n",
+      "{\"features\":[34,2,162604,11,9,4,2,2,2,1,0,0,40,37]}\n",
+      "{\"features\":[20,2,258509,11,9,4,6,3,2,1,0,0,40,37]}\n",
+      "{\"features\":[27,2,446947,9,13,4,0,4,2,0,0,0,55,37]}\n"
+     ]
+    }
+   ],
    "source": [
     "!head -n 5 $test_dataset_path"
    ]
@@ -280,7 +319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "2a843093-0548-48dd-9f82-e80af07c357e",
    "metadata": {},
    "outputs": [],
@@ -315,10 +354,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "dfe69a8c-9bf6-47c4-bb59-a775fd3b6934",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Success! We are all set to proceed with uploading to S3.\n"
+     ]
+    }
+   ],
    "source": [
     "sagemaker.s3.S3Uploader.upload_string_as_file_body(\n",
     "    body=\"hello\",\n",
@@ -338,10 +385,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "0f0fe183-4c83-4d22-bce5-65eba6a351e2",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model file has been uploaded to s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674106123-4d04/ll-adult-prediction-model.tar.gz\n",
+      "Train data is uploaded to: s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674106123-4d04/validation-dataset.jsonl\n",
+      "Test data is uploaded to: s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674106123-4d04/test-dataset.jsonl\n"
+     ]
+    }
+   ],
    "source": [
     "model_url = sagemaker.s3.S3Uploader.upload(\n",
     "    local_path=model_file,\n",
@@ -390,10 +447,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "d0c565e0-051a-4f6c-bcb6-3dca8f4ec592",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SageMaker model name: DEMO-ll-adult-pred-model-monitor-1674106124-9611\n",
+      "SageMaker endpoint name: DEMO-ll-adult-pred-model-monitor-1674106124-9611\n",
+      "SageMaker Linear Learner image: 174872318107.dkr.ecr.us-west-2.amazonaws.com/linear-learner:1\n"
+     ]
+    }
+   ],
    "source": [
     "model_name = sagemaker.utils.unique_name_from_base(\"DEMO-ll-adult-pred-model-monitor\")\n",
     "endpoint_name = model_name\n",
@@ -429,10 +496,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "77330b34-0640-4b00-b3bb-4a8ea6e9a223",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deploying model DEMO-ll-adult-pred-model-monitor-1674106124-9611 to endpoint DEMO-ll-adult-pred-model-monitor-1674106124-9611\n",
+      "------!"
+     ]
+    }
+   ],
    "source": [
     "print(f\"Deploying model {model_name} to endpoint {endpoint_name}\")\n",
     "model.deploy(\n",
@@ -455,7 +531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "44a908e5-c16f-41dc-b718-323ab5ed4268",
    "metadata": {},
    "outputs": [],
@@ -482,10 +558,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "52fbb63a-e1d8-414e-968a-20822305f23c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"features\":[28,2,133937,9,13,2,0,0,4,1,15024,0,55,37]}\n"
+     ]
+    }
+   ],
    "source": [
     "request_payload = test_data[0]\n",
     "print(request_payload)"
@@ -501,10 +585,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "87531e43-c9d1-4d9b-8019-19bec1a832eb",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'{\"predicted_label\":1,\"score\":0.989977359771728}\\n'"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "response = sagemaker_session.sagemaker_runtime_client.invoke_endpoint(\n",
     "    EndpointName=endpoint_name,\n",
@@ -534,10 +629,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "2cd41694-9e20-461f-ae85-5f792a521753",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'{\"features\":[28,2,133937,9,13,2,0,0,4,1,15024,0,55,37]}\\n{\"features\":[43,2,72338,12,14,2,12,0,1,1,0,0,40,37]}'"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "request_payload = \"\\n\".join(test_data[:2])\n",
     "request_payload"
@@ -553,10 +659,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "fece49e7-38b9-4b33-91ca-f23fcd06dcbb",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'{\"predicted_label\":1,\"score\":0.989977359771728}\\n{\"predicted_label\":1,\"score\":0.504138827323913}\\n'"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "response = sagemaker_session.sagemaker_runtime_client.invoke_endpoint(\n",
     "    EndpointName=endpoint_name,\n",
@@ -584,10 +701,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "18c649dd-40ef-4260-b499-0f3c371f970f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Waiting for captured data to show up............................................................\n",
+      "Found capture data files:\n",
+      "s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674106123-4d04/data-capture/DEMO-ll-adult-pred-model-monitor-1674106124-9611/AllTraffic/2023/01/19/05/31-46-585-9ee7358c-33e7-467d-9133-624e448e6552.jsonl\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"Waiting for captured data to show up\", end=\"\")\n",
     "for _ in range(120):\n",
@@ -616,10 +743,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "e4ad7021-4bcc-4fe1-880e-11a872941ff1",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"captureData\":{\"endpointInput\":{\"observedContentType\":\"application/jsonlines\",\"mode\":\"INPUT\",\"data\":\"{\\\"features\\\":[28,2,133937,9,13,2,0,0,4,1,15024,0,55,37]}\",\"encoding\":\"JSON\"},\"endpointOutput\":{\"observedContentType\":\"application/jsonlines\",\"mode\":\"OUTPUT\",\"data\":\"{\\\"predicted_label\\\":1,\\\"score\\\":0.989977359771728}\\n\",\"encoding\":\"JSON\"}},\"eventMetadata\":{\"eventId\":\"40394cfe-37c3-4abb-b22c-dd7accbe9608\",\"inferenceTime\":\"2023-01-19T05:31:46Z\"},\"eventVersion\":\"0\"}\n",
+      "{\"captureData\":{\"endpointInput\":{\"observedContentType\":\"application/jsonlines\",\"mode\":\"INPUT\",\"data\":\"{\\\"features\\\":[28,2,133937,9,13,2,0,0,4,1,15024,0,55,37]}\\n{\\\"features\\\":[43,2,72338,12,14,2,12,0,1,1,0,0,40,37]}\",\"encoding\":\"JSON\"},\"endpointOutput\":{\"observedContentType\":\"application/jsonlines\",\"mode\":\"OUTPUT\",\"data\":\"{\\\"predicted_label\\\":1,\\\"score\\\":0.989977359771728}\\n{\\\"predicted_label\\\":1,\\\"score\\\":0.504138827323913}\\n\",\"encoding\":\"JSON\"}},\"eventMetadata\":{\"eventId\":\"32aaea1b-1a60-4870-b81d-40271f950c4a\",\"inferenceTime\":\"2023-01-19T05:31:46Z\"},\"eventVersion\":\"0\"}\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "captured_data = sagemaker.s3.S3Downloader.read_file(\n",
     "    s3_uri=captured_data_files[-1],\n",
@@ -641,10 +778,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "14611944-0ae1-4f9f-ab6e-4b5c74ee7f3f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"captureData\": {\n",
+      "        \"endpointInput\": {\n",
+      "            \"observedContentType\": \"application/jsonlines\",\n",
+      "            \"mode\": \"INPUT\",\n",
+      "            \"data\": \"{\\\"features\\\":[28,2,133937,9,13,2,0,0,4,1,15024,0,55,37]}\\n{\\\"features\\\":[43,2,72338,12,14,2,12,0,1,1,0,0,40,37]}\",\n",
+      "            \"encoding\": \"JSON\"\n",
+      "        },\n",
+      "        \"endpointOutput\": {\n",
+      "            \"observedContentType\": \"application/jsonlines\",\n",
+      "            \"mode\": \"OUTPUT\",\n",
+      "            \"data\": \"{\\\"predicted_label\\\":1,\\\"score\\\":0.989977359771728}\\n{\\\"predicted_label\\\":1,\\\"score\\\":0.504138827323913}\\n\",\n",
+      "            \"encoding\": \"JSON\"\n",
+      "        }\n",
+      "    },\n",
+      "    \"eventMetadata\": {\n",
+      "        \"eventId\": \"32aaea1b-1a60-4870-b81d-40271f950c4a\",\n",
+      "        \"inferenceTime\": \"2023-01-19T05:31:46Z\"\n",
+      "    },\n",
+      "    \"eventVersion\": \"0\"\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "print(json.dumps(json.loads(captured_data.splitlines()[-1]), indent=4))"
    ]
@@ -662,7 +827,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "0af95cc5-9e1d-46fd-b373-16015c87be58",
    "metadata": {},
    "outputs": [],
@@ -683,7 +848,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "id": "00e832f7-8cc7-4044-b2aa-f22c93d2078d",
    "metadata": {},
    "outputs": [],
@@ -720,7 +885,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "id": "273af941-56ff-4a08-a1e1-023e2d4ec090",
    "metadata": {},
    "outputs": [],
@@ -772,7 +937,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "id": "fd146e26-a54c-4a31-acc9-5a406ddf8680",
    "metadata": {},
    "outputs": [],
@@ -801,7 +966,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "3a49acc6-c6a9-46fa-aed7-e93e67fae373",
    "metadata": {},
    "outputs": [],
@@ -836,10 +1001,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "id": "0ead08ae-1867-41b9-8c0e-6202760c4175",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SHAP baseline: [{'features': [39, 2, 184870, 10, 10, 3, 6, 1, 4, 1, 1597, 61, 41, 37]}]\n"
+     ]
+    }
+   ],
    "source": [
     "# Here use the mean value of train dataset as SHAP baseline\n",
     "dataset = []\n",
@@ -870,10 +1043,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "9c27e74b-31f6-435a-a0d4-bef52a4cdcdb",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Job Name:  baseline-suggestion-job-2023-01-19-05-32-51-896\n",
+      "Inputs:  [{'InputName': 'dataset', 'AppManaged': False, 'S3Input': {'S3Uri': 's3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674106123-4d04/validation-dataset.jsonl', 'LocalPath': '/opt/ml/processing/input/data', 'S3DataType': 'S3Prefix', 'S3InputMode': 'File', 'S3DataDistributionType': 'FullyReplicated', 'S3CompressionType': 'None'}}, {'InputName': 'analysis_config', 'AppManaged': False, 'S3Input': {'S3Uri': 's3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674106123-4d04/baselining-output/analysis_config.json', 'LocalPath': '/opt/ml/processing/input/config', 'S3DataType': 'S3Prefix', 'S3InputMode': 'File', 'S3DataDistributionType': 'FullyReplicated', 'S3CompressionType': 'None'}}]\n",
+      "Outputs:  [{'OutputName': 'analysis_result', 'AppManaged': False, 'S3Output': {'S3Uri': 's3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674106123-4d04/baselining-output', 'LocalPath': '/opt/ml/processing/output', 'S3UploadMode': 'EndOfJob'}}]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<sagemaker.processing.ProcessingJob at 0x7f4ca93c6410>"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "confidence_score_jmespath = \"score\"\n",
     "model_explainability_monitor.suggest_baseline(\n",
@@ -894,10 +1088,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "id": "ad0ece68-f130-4b66-b8ab-36d2916502c8",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "..................................................................................................!\n",
+      "Suggested constraints: s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674106123-4d04/baselining-output/analysis.json\n",
+      "{\n",
+      "    \"version\": \"1.0\",\n",
+      "    \"explanations\": {\n",
+      "        \"kernel_shap\": {\n",
+      "            \"label0\": {\n",
+      "                \"global_shap_values\": {\n",
+      "                    \"Age\": 0.05962069398767555,\n",
+      "                    \"Workclass\": 0.009340874120660063,\n",
+      "                    \"fnlwgt\": 0.0010900750377509304,\n",
+      "                    \"Education\": 0.014739126275038199,\n",
+      "                    \"Education-Num\": 0.09891391226656666,\n",
+      "                    \"Marital Status\": 0.05452765230404344,\n",
+      "                    \"Occupation\": 0.0025392834714334667,\n",
+      "                    \"Relationship\": 0.018169508641909988,\n",
+      "                    \"Ethnic group\": 0.005295263900463686,\n",
+      "                    \"Sex\": 0.032080828962127876,\n",
+      "                    \"Capital Gain\": 0.09913318680892579,\n",
+      "                    \"Capital Loss\": 0.013518474176382519,\n",
+      "                    \"Hours per week\": 0.03641124946588507,\n",
+      "                    \"Country\": 0.004894213349476741\n",
+      "                },\n",
+      "                \"expected_value\": 0.250623226165771\n",
+      "            }\n",
+      "        }\n",
+      "    }\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "model_explainability_monitor.latest_baselining_job.wait(logs=False)\n",
     "print()\n",
@@ -939,7 +1168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "id": "8d160d3e-0482-4c4b-a171-e62eddb38b87",
    "metadata": {},
    "outputs": [],
@@ -949,10 +1178,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "id": "1c7a1355-2997-46f2-ae02-cb00063e3661",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model explainability monitoring schedule: monitoring-schedule-2023-01-19-05-41-04-758\n"
+     ]
+    }
+   ],
    "source": [
     "# Remove label because only features are required for the analysis\n",
     "headers_without_label_header = copy.deepcopy(all_headers)\n",
@@ -992,7 +1229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "id": "ae00eb31-bbc7-4cf9-9fae-b323b4d380b2",
    "metadata": {},
    "outputs": [],
@@ -1031,10 +1268,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "id": "b512df1e-57cf-4ba3-9262-0c325c4a600e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "An hourly schedule was created above and it will kick off executions ON the hour (plus 0 - 20 min buffer).\n",
+      "Waiting for the first execution to happen........................\n",
+      "Done! Execution has been created\n",
+      "Now waiting for execution to start.\n",
+      "Done! Execution has started\n"
+     ]
+    }
+   ],
    "source": [
     "wait_for_execution_to_start(model_explainability_monitor)"
    ]
@@ -1049,10 +1298,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "id": "a6980d31-c96d-4850-a7fb-c8583eeac54e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Stopping Monitoring Schedule with name: monitoring-schedule-2023-01-19-05-41-04-758\n"
+     ]
+    }
+   ],
    "source": [
     "model_explainability_monitor.stop_monitoring_schedule()"
    ]
@@ -1074,7 +1332,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "id": "2b07426d-f805-4527-9863-1d3d664734fa",
    "metadata": {},
    "outputs": [],
@@ -1111,10 +1369,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "id": "25e36f00-f488-4a16-867f-92c53d819782",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Waiting for execution to finish........\n",
+      "Done! Execution Status: Completed\n"
+     ]
+    }
+   ],
    "source": [
     "wait_for_execution_to_finish(model_explainability_monitor)"
    ]
@@ -1134,10 +1401,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "id": "3c767cbd-78c5-433d-a850-e230cb5a55dd",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Report URI: s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674106123-4d04/monitor-output/DEMO-ll-adult-pred-model-monitor-1674106124-9611/monitoring-schedule-2023-01-19-05-41-04-758/2023/01/19/06\n",
+      "Found Report Files:\n",
+      "s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674106123-4d04/monitor-output/DEMO-ll-adult-pred-model-monitor-1674106124-9611/monitoring-schedule-2023-01-19-05-41-04-758/2023/01/19/06/analysis.json\n",
+      " s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674106123-4d04/monitor-output/DEMO-ll-adult-pred-model-monitor-1674106124-9611/monitoring-schedule-2023-01-19-05-41-04-758/2023/01/19/06/report.html\n",
+      " s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674106123-4d04/monitor-output/DEMO-ll-adult-pred-model-monitor-1674106124-9611/monitoring-schedule-2023-01-19-05-41-04-758/2023/01/19/06/report.ipynb\n",
+      " s3://sagemaker-us-west-2-000000000000/sagemaker/DEMO-ClarifyModelMonitor-1674106123-4d04/monitor-output/DEMO-ll-adult-pred-model-monitor-1674106124-9611/monitoring-schedule-2023-01-19-05-41-04-758/2023/01/19/06/report.pdf\n"
+     ]
+    }
+   ],
    "source": [
     "schedule_desc = model_explainability_monitor.describe_schedule()\n",
     "execution_summary = schedule_desc.get(\"LastMonitoringExecutionSummary\")\n",
@@ -1175,7 +1455,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "id": "a7174d2e-9ee4-437f-be9a-c9d984318b76",
    "metadata": {},
    "outputs": [],
@@ -1213,7 +1493,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "id": "f813097c-00cc-4ee4-91cc-d03b72915c67",
    "metadata": {},
    "outputs": [],
@@ -1231,10 +1511,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "id": "e4b99289-3924-4d40-9860-75ccea76646b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Stopping Monitoring Schedule with name: monitoring-schedule-2023-01-19-05-41-04-758\n",
+      "Waiting for execution to finish\n",
+      "Done! Execution Status: Completed\n",
+      "\n",
+      "Deleting Monitoring Schedule with name: monitoring-schedule-2023-01-19-05-41-04-758\n"
+     ]
+    }
+   ],
    "source": [
     "model_explainability_monitor.stop_monitoring_schedule()\n",
     "wait_for_execution_to_finish(model_explainability_monitor)\n",
@@ -1251,7 +1544,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "id": "d6dd0678-66d3-493d-bee4-7e2a9dab901e",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION

*Issue #, if available:* N/A

*Description of changes:*

The notebooks added by [PR 3760](https://github.com/aws/amazon-sagemaker-examples/pull/3760) can take more than one hour to run, mainly because the minimum interval of a monitoring schedule is one hour. This commit retains the cell outputs so that the customers don't have to spend too much time if they just want to see what the product does. It also makes the notebook pages on readthedocs website a more complete document.

*Testing done:*

* Executed the notebooks from E2E in SageMaker Studio
* Executed lint check and grammar check
* Built by "make html" and reviewed the web pages

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [X] I have tested my notebook(s) and ensured it runs end-to-end
- [X] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
