### PR TITLE
Updated the BATCH_DELAY to avoid batch response mismatch errors

### DIFF
--- a/sagemaker-python-sdk/pytorch_batch_inference/sagemaker_batch_inference_torchserve.ipynb
+++ b/sagemaker-python-sdk/pytorch_batch_inference/sagemaker_batch_inference_torchserve.ipynb
@@ -175,7 +175,7 @@
     "\n",
     "env_variables_dict = {\n",
     "    \"SAGEMAKER_TS_BATCH_SIZE\": \"3\",\n",
-    "    \"SAGEMAKER_TS_MAX_BATCH_DELAY\": \"100000\",\n",
+    "    \"SAGEMAKER_TS_MAX_BATCH_DELAY\": \"1000\",\n",
     "    \"SAGEMAKER_TS_MIN_WORKERS\": \"1\",\n",
     "    \"SAGEMAKER_TS_MAX_WORKERS\": \"1\",\n",
     "}\n",


### PR DESCRIPTION
Hi Team,

Greetings!!

Description of changes:

We tried testing this [notebook](https://github.com/aws/amazon-sagemaker-examples/blob/main/sagemaker-python-sdk/pytorch_batch_inference/sagemaker_batch_inference_torchserve.ipynb) with default settings to understand how dynamic batch inference works but unfortunately it's not working. However, observed that we have to reduce the batch delay to avoid batch response mismatch errors.

Config used:

`env_variables_dict = {
    "SAGEMAKER_TS_BATCH_SIZE": "3",
    "SAGEMAKER_TS_MAX_BATCH_DELAY": "1000",
    "SAGEMAKER_TS_MIN_WORKERS": "1",
    "SAGEMAKER_TS_MAX_WORKERS": "1",
}`

Testing: Done.

Existing issue: https://github.com/aws/amazon-sagemaker-examples/issues/3525
Support case Id: 10503342361

Error description: MODEL_LOG - model: model, number of batch response mismatched, expect: 3, got: 1.

Please let me know if there are any queries.

Thanks & Regards,
Vinayak S