### PR TITLE
Changed base image

### DIFF
--- a/aws_marketplace/creating_marketplace_products/models/src/Dockerfile
+++ b/aws_marketplace/creating_marketplace_products/models/src/Dockerfile
@@ -1,23 +1,20 @@
-FROM ubuntu:18.04
+FROM jupyter/scipy-notebook
 
-# Specify encoding
-ENV LC_ALL=C.UTF-8
-ENV LANG=C.UTF-8
-
-# Install python-pip
-RUN apt-get update \
-&& apt-get install -y python3.6 python3-pip curl \
-&& ln -s /usr/bin/python3.6 /usr/bin/python \
-&& ln -s /usr/bin/pip3 /usr/bin/pip;
+# Install dependencies
+USER 0
+RUN apt-get update && apt-get install -y curl;
+USER 1000
 
 # Install flask server
-RUN pip install -U flask gunicorn joblib sklearn;
+RUN pip install -U flask gunicorn;
 
 # Copy scoring logic and model artifacts into the docker image
 COPY scoring_logic.py /scoring_logic.py
 COPY wsgi.py /wsgi.py
 COPY model-artifacts.joblib /opt/ml/model/model-artifacts.joblib
-COPY serve /opt/program/serve
+COPY --chown=1000:100 serve /opt/program/serve
 
 RUN chmod 755 /opt/program/serve
 ENV PATH=/opt/program:${PATH}
+
+WORKDIR /


### PR DESCRIPTION
Previous Dockerfile installed packages that had dependency issues including version mismatches that prevented the container from running. It was also unable to consume the training artifacts generated by the current Jupyter notebook with `conda_python3` kernel. Switched base image to Jupyter image that comes with dependencies pre-packaged (namely `scikit-learn`, `joblib`, and `numpy`) and that are also compatible with the training artifacts.

*Issue #, if available:*

*Description of changes:* Replaced Dockerfile. See above for details.

*Testing done:* Tested end-to-end successfully.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
