### PR TITLE
added t5 examples using pytorch and python backend for triton

### DIFF
--- a/inference/nlp/realtime/triton/multi-model/t5_pytorch_python-backend/README.md
+++ b/inference/nlp/realtime/triton/multi-model/t5_pytorch_python-backend/README.md
@@ -1,0 +1,13 @@
+# Serve an NLP model on GPU with Amazon SageMaker Multi-model endpoints (MME)
+
+In this example, we will walk you through how to use NVIDIA Triton Inference Server on Amazon SageMaker MME with GPU feature to deploy two different HuggingFace  **T5** NLP model for **Text Translation**. In particular, this model will be using:
+
+T5-small HuggingFace PyTorch Translation Model (Served using Triton's Python Backend) 
+
+## Steps to run the notebook
+
+1. Launch SageMaker notebook instance with `g5.xlarge` instance. This example can also be run on a SageMaker studio notebook instance but the steps that follow will focus on the notebook instance.
+    * IMPORTANT: In Notebook instance settings, within Additional Configuration, for **Volume Size in GB** specify at least **100 GB**.
+    * For git repositories select the option `Clone a public git repository to this notebook instance only` and specify the Git repository URL
+    
+2. Once JupyterLab is ready, launch the **t5_nlp_pytorch_python-gpu.ipynb** notebook with **conda_python3** conda kernel and run through this notebook to learn how to host multiple NLP models on `g5.2xlarge` GPU behind MME endpoint.

--- a/inference/nlp/realtime/triton/multi-model/t5_pytorch_python-backend/t5_pytorch_python-backend.ipynb
+++ b/inference/nlp/realtime/triton/multi-model/t5_pytorch_python-backend/t5_pytorch_python-backend.ipynb
@@ -1,0 +1,759 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1b2aebda",
+   "metadata": {},
+   "source": [
+    "# Serve Multiple DL models on GPU with Amazon SageMaker Multi-model endpoints (MME)\n",
+    "\n",
+    "\n",
+    "\n",
+    "Amazon SageMaker multi-model endpoints(MME) provide a scalable and cost-effective way to deploy large number of deep learning models. Previously, customers had limited options to deploy 100s of deep learning models that need accelerated compute with GPUs. Now customers can deploy 1000s of deep learning models behind one SageMaker endpoint. Now, MME will run multiple models on a GPU, share GPU instances behind an endpoint across multiple models and dynamically load/unload models based on the incoming traffic. With this, customers can significantly save cost and achieve best price performance.\n",
+    "\n",
+    "\n",
+    "\n",
+    "<div class=\"alert alert-info\"> 💡 <strong> Note </strong>\n",
+    "This notebook was tested with the `conda_python3` kernel on an Amazon SageMaker notebook instance of type `g5.xlarge`.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96038ada",
+   "metadata": {},
+   "source": [
+    "In this notebook, we will walk you through how to use NVIDIA Triton Inference Server on Amazon SageMaker MME with GPU feature to deploy a **T5** NLP model for **Translation**. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07d31e8a",
+   "metadata": {},
+   "source": [
+    "## Installs\n",
+    "\n",
+    "Installs the dependencies required to package the model and run inferences using Triton server. Update SageMaker, boto3, awscli etc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "367c8d77",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!pip install -qU pip awscli boto3 sagemaker\n",
+    "!pip install nvidia-pyindex --quiet\n",
+    "!pip install tritonclient[http] --quiet\n",
+    "!pip install transformers[sentencepiece] --quiet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f29c9de0",
+   "metadata": {},
+   "source": [
+    "## Imports and variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2386d882",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import boto3, json, sagemaker, time\n",
+    "from sagemaker import get_execution_role\n",
+    "import numpy as np\n",
+    "import os\n",
+    "\n",
+    "os.environ[\"TOKENIZERS_PARALLELISM\"] = \"false\"\n",
+    "\n",
+    "# sagemaker variables\n",
+    "role = get_execution_role()\n",
+    "sm_client = boto3.client(service_name=\"sagemaker\")\n",
+    "runtime_sm_client = boto3.client(\"sagemaker-runtime\")\n",
+    "sagemaker_session = sagemaker.Session(boto_session=boto3.Session())\n",
+    "s3_client = boto3.client(\"s3\")\n",
+    "bucket = sagemaker.Session().default_bucket()\n",
+    "prefix = \"nlp-mme-gpu\"\n",
+    "\n",
+    "# account mapping for SageMaker MME Triton Image\n",
+    "account_id_map = {\n",
+    "    \"us-east-1\": \"785573368785\",\n",
+    "    \"us-east-2\": \"007439368137\",\n",
+    "    \"us-west-1\": \"710691900526\",\n",
+    "    \"us-west-2\": \"301217895009\",\n",
+    "    \"eu-west-1\": \"802834080501\",\n",
+    "    \"eu-west-2\": \"205493899709\",\n",
+    "    \"eu-west-3\": \"254080097072\",\n",
+    "    \"eu-north-1\": \"601324751636\",\n",
+    "    \"eu-south-1\": \"966458181534\",\n",
+    "    \"eu-central-1\": \"746233611703\",\n",
+    "    \"ap-east-1\": \"110948597952\",\n",
+    "    \"ap-south-1\": \"763008648453\",\n",
+    "    \"ap-northeast-1\": \"941853720454\",\n",
+    "    \"ap-northeast-2\": \"151534178276\",\n",
+    "    \"ap-southeast-1\": \"324986816169\",\n",
+    "    \"ap-southeast-2\": \"355873309152\",\n",
+    "    \"cn-northwest-1\": \"474822919863\",\n",
+    "    \"cn-north-1\": \"472730292857\",\n",
+    "    \"sa-east-1\": \"756306329178\",\n",
+    "    \"ca-central-1\": \"464438896020\",\n",
+    "    \"me-south-1\": \"836785723513\",\n",
+    "    \"af-south-1\": \"774647643957\",\n",
+    "}\n",
+    "\n",
+    "region = boto3.Session().region_name\n",
+    "if region not in account_id_map.keys():\n",
+    "    raise (\"UNSUPPORTED REGION\")\n",
+    "\n",
+    "base = \"amazonaws.com.cn\" if region.startswith(\"cn-\") else \"amazonaws.com\"\n",
+    "mme_triton_image_uri = (\n",
+    "    \"{account_id}.dkr.ecr.{region}.{base}/sagemaker-tritonserver:23.02-py3\".format(\n",
+    "        account_id=account_id_map[region], region=region, base=base\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce64b95c",
+   "metadata": {},
+   "source": [
+    "## Workflow Overview\n",
+    "\n",
+    "This section presents overview of main steps for preparing a T5 Pytorch model (served using Python backend) using Triton Inference Server.\n",
+    "### 1. Generate Model Artifacts\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0f444f2",
+   "metadata": {},
+   "source": [
+    "#### T5 PyTorch Model\n",
+    "\n",
+    "In case of T5-small HuggingFace PyTorch Model, since we are serving it using Triton's [python backend](https://github.com/triton-inference-server/python_backend#usage) we have python script [model.py](./workspace/model.py) which implements all the logic to initialize the T5 model and execute inference for the translation task."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb3dd938",
+   "metadata": {},
+   "source": [
+    "### 2. Build Model Respository\n",
+    "\n",
+    "Using Triton on SageMaker requires us to first set up a [model repository](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_repository.md) folder containing the models we want to serve. For each model we need to create a model directory consisting of the model artifact and define config.pbtxt file to specify [model configuration](https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md) which Triton uses to load and serve the model. \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a39c4592",
+   "metadata": {},
+   "source": [
+    "#### T5 Python Backend Model\n",
+    "\n",
+    "Model repository structure for T5 Model.\n",
+    "\n",
+    "```\n",
+    "t5_pytorch\n",
+    "├── 1\n",
+    "│   └── model.py\n",
+    "└── config.pbtxt\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93792c33",
+   "metadata": {},
+   "source": [
+    "Next we set up the T5 PyTorch Python Backend Model in the model repository:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4b6d6272",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!mkdir -p model_repository/t5_pytorch/1\n",
+    "!cp workspace/model.py model_repository/t5_pytorch/1/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0a12da8",
+   "metadata": {},
+   "source": [
+    "##### Create Conda Environment for Dependencies\n",
+    "\n",
+    "For serving the HuggingFace T5 PyTorch Model using Triton's Python backend we have PyTorch and HuggingFace transformers as dependencies.\n",
+    "\n",
+    "We follow the instructions from the [Triton documentation for packaging dependencies](https://github.com/triton-inference-server/python_backend#2-packaging-the-conda-environment) to be used in the python backend as conda env tar file. Running the bash script [create_hf_env.sh]('./workspace/create_hf_env.sh') creates the conda environment containing PyTorch and HuggingFace transformers, packages it as tar file and then we move it into the t5-pytorch model directory. This can take a few minutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e203209f",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!bash workspace/create_hf_env.sh\n",
+    "!mv hf_env.tar.gz model_repository/t5_pytorch/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3363b6dc",
+   "metadata": {},
+   "source": [
+    "After creating the tar file from the conda environment and placing it in model folder, you need to tell Python backend to use that environment for your model. We do this by including the lines below in the model `config.pbtxt` file:\n",
+    "\n",
+    "```\n",
+    "parameters: {\n",
+    "  key: \"EXECUTION_ENV_PATH\",\n",
+    "  value: {string_value: \"$$TRITON_MODEL_DIRECTORY/hf_env.tar.gz\"}\n",
+    "}\n",
+    "```\n",
+    "Here, `$$TRITON_MODEL_DIRECTORY` helps provide environment path relative to the model folder in model repository and is resolved to `$pwd/model_repository/t5_pytorch`. Finally `hf_env.tar.gz` is the name we gave to our conda env file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de6f3953",
+   "metadata": {},
+   "source": [
+    "Now we are ready to define the config file for t5 pytorch model being served through Triton's Python Backend:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43dcaf95",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%writefile model_repository/t5_pytorch/config.pbtxt\n",
+    "name: \"t5_pytorch\"\n",
+    "backend: \"python\"\n",
+    "max_batch_size: 8\n",
+    "input: [\n",
+    "    {\n",
+    "        name: \"input_ids\"\n",
+    "        data_type: TYPE_INT32\n",
+    "        dims: [ -1 ]\n",
+    "    },\n",
+    "    {\n",
+    "        name: \"attention_mask\"\n",
+    "        data_type: TYPE_INT32\n",
+    "        dims: [ -1 ]\n",
+    "    }\n",
+    "]\n",
+    "output [\n",
+    "  {\n",
+    "    name: \"output\"\n",
+    "    data_type: TYPE_INT32\n",
+    "    dims: [ -1 ]\n",
+    "  }\n",
+    "]\n",
+    "instance_group {\n",
+    "  count: 1\n",
+    "  kind: KIND_GPU\n",
+    "}\n",
+    "dynamic_batching {\n",
+    "}\n",
+    "parameters: {\n",
+    "  key: \"EXECUTION_ENV_PATH\",\n",
+    "  value: {string_value: \"$$TRITON_MODEL_DIRECTORY/hf_env.tar.gz\"}\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3b7670a",
+   "metadata": {},
+   "source": [
+    "### 3. Package models and upload to S3\n",
+    "\n",
+    "Next, we will package our model as `*.tar.gz` files for uploading to S3. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b6bb061",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!tar -C model_repository/ -czf t5_pytorch.tar.gz t5_pytorch\n",
+    "model_uri_t5_pytorch = sagemaker_session.upload_data(path=\"t5_pytorch.tar.gz\", key_prefix=prefix)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b690fe2",
+   "metadata": {},
+   "source": [
+    "### 4. Create SageMaker Endpoint\n",
+    "\n",
+    "Now that we have uploaded the model artifacts to S3, we can create a SageMaker multi-model endpoint."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0075cbb6",
+   "metadata": {},
+   "source": [
+    "#### Define the serving container\n",
+    "In the container definition, define the `ModelDataUrl` to specify the S3 directory that contains all the models that SageMaker multi-model endpoint will use to load and serve predictions. Set `Mode` to `MultiModel` to indicate SageMaker would create the endpoint with MME container specifications. We set the container with an image that supports deploying multi-model endpoints with GPU"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8681e13c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model_data_url = f\"s3://{bucket}/{prefix}/\"\n",
+    "\n",
+    "container = {\n",
+    "    \"Image\": mme_triton_image_uri,\n",
+    "    \"ModelDataUrl\": model_data_url,\n",
+    "    \"Mode\": \"MultiModel\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6c879df",
+   "metadata": {},
+   "source": [
+    "#### Create a multi-model object"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a396ecb",
+   "metadata": {},
+   "source": [
+    "Once the image, data location are set we create the model using `create_model` by specifying the `ModelName` and the Container definition"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a22f650",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ts = time.strftime(\"%Y-%m-%d-%H-%M-%S\", time.gmtime())\n",
+    "sm_model_name = f\"{prefix}-mdl-{ts}\"\n",
+    "\n",
+    "create_model_response = sm_client.create_model(\n",
+    "    ModelName=sm_model_name, ExecutionRoleArn=role, PrimaryContainer=container\n",
+    ")\n",
+    "\n",
+    "print(\"Model Arn: \" + create_model_response[\"ModelArn\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4e335d8",
+   "metadata": {},
+   "source": [
+    "#### Define configuration for the multi-model endpoint"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30d79536",
+   "metadata": {},
+   "source": [
+    "Using the model above, we create an [endpoint configuration](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateEndpointConfig.html) where we can specify the type and number of instances we want in the endpoint. Here we are deploying to `g5.2xlarge` NVIDIA GPU instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a9d4b510",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "endpoint_config_name = f\"{prefix}-epc-{ts}-2xl\"\n",
+    "\n",
+    "create_endpoint_config_response = sm_client.create_endpoint_config(\n",
+    "    EndpointConfigName=endpoint_config_name,\n",
+    "    ProductionVariants=[\n",
+    "        {\n",
+    "            \"InstanceType\": \"ml.g5.2xlarge\",\n",
+    "            \"InitialVariantWeight\": 1,\n",
+    "            \"InitialInstanceCount\": 1,\n",
+    "            \"ModelName\": sm_model_name,\n",
+    "            \"VariantName\": \"AllTraffic\",\n",
+    "        }\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "print(\"Endpoint Config Arn: \" + create_endpoint_config_response[\"EndpointConfigArn\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a23980c",
+   "metadata": {},
+   "source": [
+    "#### Create Multi-Model Endpoint"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52f050c5",
+   "metadata": {},
+   "source": [
+    "Using the above endpoint configuration we create a new sagemaker endpoint and wait for the deployment to finish. The status will change to **InService** once the deployment is successful."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b1b19a5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "endpoint_name = f\"{prefix}-ep-{ts}-2xl\"\n",
+    "\n",
+    "create_endpoint_response = sm_client.create_endpoint(\n",
+    "    EndpointName=endpoint_name, EndpointConfigName=endpoint_config_name\n",
+    ")\n",
+    "\n",
+    "print(\"Endpoint Arn: \" + create_endpoint_response[\"EndpointArn\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3bba0d5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "resp = sm_client.describe_endpoint(EndpointName=endpoint_name)\n",
+    "status = resp[\"EndpointStatus\"]\n",
+    "print(\"Status: \" + status)\n",
+    "\n",
+    "while status == \"Creating\":\n",
+    "    time.sleep(60)\n",
+    "    resp = sm_client.describe_endpoint(EndpointName=endpoint_name)\n",
+    "    status = resp[\"EndpointStatus\"]\n",
+    "    print(\"Status: \" + status)\n",
+    "\n",
+    "print(\"Arn: \" + resp[\"EndpointArn\"])\n",
+    "print(\"Status: \" + status)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b21403ea",
+   "metadata": {},
+   "source": [
+    "### 5. Run Inference"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6be758ed",
+   "metadata": {},
+   "source": [
+    "Once we have the endpoint running we can use some sample raw data to do an inference using JSON as the payload format. For the inference request format, Triton uses the KFServing community standard [inference protocols](https://github.com/triton-inference-server/server/blob/main/docs/protocol/README.md)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a408192b",
+   "metadata": {},
+   "source": [
+    "#### Add utility methods for preparing JSON request payload\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59d65e6f",
+   "metadata": {},
+   "source": [
+    "We'll use the following utility methods to convert our inference request for DistilBERT and T5 models into a json payload."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca3c7965",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from transformers import AutoTokenizer\n",
+    "\n",
+    "\n",
+    "def get_tokenizer(model_name):\n",
+    "    tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
+    "    return tokenizer\n",
+    "\n",
+    "\n",
+    "def tokenize_text(model_name, text):\n",
+    "    tokenizer = get_tokenizer(model_name)\n",
+    "    tokenized_text = tokenizer(text, padding=True, return_tensors=\"np\")\n",
+    "    return tokenized_text.input_ids, tokenized_text.attention_mask\n",
+    "\n",
+    "\n",
+    "def get_text_payload(model_name, text):\n",
+    "    input_ids, attention_mask = tokenize_text(model_name, text)\n",
+    "    payload = {}\n",
+    "    payload[\"inputs\"] = []\n",
+    "    payload[\"inputs\"].append(\n",
+    "        {\n",
+    "            \"name\": \"input_ids\",\n",
+    "            \"shape\": input_ids.shape,\n",
+    "            \"datatype\": \"INT32\",\n",
+    "            \"data\": input_ids.tolist(),\n",
+    "        }\n",
+    "    )\n",
+    "    payload[\"inputs\"].append(\n",
+    "        {\n",
+    "            \"name\": \"attention_mask\",\n",
+    "            \"shape\": attention_mask.shape,\n",
+    "            \"datatype\": \"INT32\",\n",
+    "            \"data\": attention_mask.tolist(),\n",
+    "        }\n",
+    "    )\n",
+    "    return payload"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c8701a7",
+   "metadata": {},
+   "source": [
+    "#### Invoke target model on Multi Model Endpoint"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9386a4a0",
+   "metadata": {},
+   "source": [
+    "We can send inference request to multi-model endpoint using `invoke_enpoint` API. We specify the `TargetModel` in the invocation call and pass in the payload for each model type."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39cbadfb",
+   "metadata": {},
+   "source": [
+    "#### T5 PyTorch Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84e38866",
+   "metadata": {},
+   "source": [
+    "Next, we show some sample inference for translation on the T5 PyTorch Model deployed on Triton's Python Backend behind SageMaker MME GPU endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35c245b3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "texts_to_translate = [\"translate English to German: The house is wonderful.\"]\n",
+    "batch_size = len(texts_to_translate)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e22d076",
+   "metadata": {},
+   "source": [
+    "##### Sample T5 Inference using Json Payload"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce955041",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "t5_payload = get_text_payload(\"t5-small\", texts_to_translate)\n",
+    "\n",
+    "response = runtime_sm_client.invoke_endpoint(\n",
+    "    EndpointName=endpoint_name,\n",
+    "    ContentType=\"application/octet-stream\",\n",
+    "    Body=json.dumps(t5_payload),\n",
+    "    TargetModel=\"t5_pytorch.tar.gz\",\n",
+    ")\n",
+    "\n",
+    "response_body = json.loads(response[\"Body\"].read().decode(\"utf8\"))\n",
+    "output_ids = np.array(response_body[\"outputs\"][0][\"data\"]).reshape(batch_size, -1)\n",
+    "t5_tokenizer = get_tokenizer(\"t5-small\")\n",
+    "decoded_outputs = t5_tokenizer.batch_decode(output_ids, skip_special_tokens=True)\n",
+    "for text in decoded_outputs:\n",
+    "    print(text, \"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db6dc833",
+   "metadata": {},
+   "source": [
+    "##### Sample T5 Inference using Binary + Json Payload"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4c5f084-da45-467b-a897-61c8a32c068e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import tritonclient.http as httpclient\n",
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "def get_text_payload_binary(model_name, text):\n",
+    "    inputs = []\n",
+    "    outputs = []\n",
+    "    input_ids, attention_mask = tokenize_text(model_name, text)\n",
+    "    inputs.append(httpclient.InferInput(\"input_ids\", input_ids.shape, \"INT32\"))\n",
+    "    inputs.append(httpclient.InferInput(\"attention_mask\", attention_mask.shape, \"INT32\"))\n",
+    "\n",
+    "    inputs[0].set_data_from_numpy(input_ids.astype(np.int32), binary_data=True)\n",
+    "    inputs[1].set_data_from_numpy(attention_mask.astype(np.int32), binary_data=True)\n",
+    "\n",
+    "    output_name = \"output\" if model_name == \"t5-small\" else \"logits\"\n",
+    "    request_body, header_length = httpclient.InferenceServerClient.generate_request_body(\n",
+    "        inputs, outputs=outputs\n",
+    "    )\n",
+    "    return request_body, header_length"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c0a33cd",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "request_body, header_length = get_text_payload_binary(\"t5-small\", texts_to_translate)\n",
+    "\n",
+    "response = runtime_sm_client.invoke_endpoint(\n",
+    "    EndpointName=endpoint_name,\n",
+    "    ContentType=\"application/vnd.sagemaker-triton.binary+json;json-header-size={}\".format(\n",
+    "        header_length\n",
+    "    ),\n",
+    "    Body=request_body,\n",
+    "    TargetModel=\"t5_pytorch.tar.gz\",\n",
+    ")\n",
+    "\n",
+    "# Parse json header size length from the response\n",
+    "header_length_prefix = \"application/vnd.sagemaker-triton.binary+json;json-header-size=\"\n",
+    "header_length_str = response[\"ContentType\"][len(header_length_prefix) :]\n",
+    "output_name = \"output\"\n",
+    "# Read response body\n",
+    "result = httpclient.InferenceServerClient.parse_response_body(\n",
+    "    response[\"Body\"].read(), header_length=int(header_length_str)\n",
+    ")\n",
+    "output_ids = result.as_numpy(output_name)\n",
+    "decoded_output = t5_tokenizer.batch_decode(output_ids, skip_special_tokens=True)\n",
+    "for text in decoded_outputs:\n",
+    "    print(text, \"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b6977d9",
+   "metadata": {},
+   "source": [
+    "### Terminate endpoint and clean up artifacts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a91a735c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "sm_client.delete_model(ModelName=sm_model_name)\n",
+    "sm_client.delete_endpoint_config(EndpointConfigName=endpoint_config_name)\n",
+    "sm_client.delete_endpoint(EndpointName=endpoint_name)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "conda_python3",
+   "language": "python",
+   "name": "conda_python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/inference/nlp/realtime/triton/multi-model/t5_pytorch_python-backend/workspace/create_hf_env.sh
+++ b/inference/nlp/realtime/triton/multi-model/t5_pytorch_python-backend/workspace/create_hf_env.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+conda create -y -n hf_env python=3.8
+source ~/anaconda3/etc/profile.d/conda.sh
+source activate hf_env
+export PYTHONNOUSERSITE=True
+pip install torch --extra-index-url https://download.pytorch.org/whl/cu116
+pip install transformers[sentencepiece]
+pip install conda-pack
+conda-pack

--- a/inference/nlp/realtime/triton/multi-model/t5_pytorch_python-backend/workspace/model.py
+++ b/inference/nlp/realtime/triton/multi-model/t5_pytorch_python-backend/workspace/model.py
@@ -1,0 +1,81 @@
+import numpy as np
+import sys
+import os
+import json
+from pathlib import Path
+
+import torch
+
+import triton_python_backend_utils as pb_utils
+
+class TritonPythonModel:
+    # Every Python model must have "TritonPythonModel" as the class name!
+    def initialize(self, args):
+        """`initialize` is called only once when the model is being loaded.
+        Implementing `initialize` function is optional. This function allows
+        the model to initialize any state associated with this model.
+        Parameters
+        ----------
+        args : dict
+          Both keys and values are strings. The dictionary keys and values are:
+          * model_config: A JSON string containing the model configuration
+          * model_instance_kind: A string containing model instance kind
+          * model_instance_device_id: A string containing model instance device ID
+          * model_repository: Model repository path
+          * model_version: Model version
+          * model_name: Model name
+        """
+        self.output_dtype = pb_utils.triton_string_to_numpy(
+            pb_utils.get_output_config_by_name(
+                json.loads(args['model_config']), "output"
+            )['data_type']
+        )
+
+        from transformers import T5ForConditionalGeneration, T5Tokenizer
+        self.model = T5ForConditionalGeneration.from_pretrained("t5-small").cuda()
+        print("TritonPythonModel initialized")
+
+    def execute(self, requests):
+        """`execute` must be implemented in every Python model. `execute`
+        function receives a list of pb_utils.InferenceRequest as the only
+        argument. This function is called when an inference is requested
+        for this model.
+        Parameters
+        ----------
+        requests : list
+          A list of pb_utils.InferenceRequest
+        Returns
+        -------
+        list
+          A list of pb_utils.InferenceResponse. The length of this list must
+          be the same as `requests`
+        """
+        responses = []
+        for request in requests:
+            input_ids = pb_utils.get_input_tensor_by_name(request, "input_ids")
+            input_ids = input_ids.as_numpy()
+            input_ids = torch.as_tensor(input_ids).long().cuda()
+            attention_mask = pb_utils.get_input_tensor_by_name(request, "attention_mask")
+            attention_mask = attention_mask.as_numpy()
+            attention_mask = torch.as_tensor(attention_mask).long().cuda()
+            inputs = {'input_ids': input_ids, 'attention_mask': attention_mask}
+            translation = self.model.generate(**inputs, num_beams=1)
+            # Convert to numpy array on cpu:
+            np_translation =  translation.cpu().int().detach().numpy()
+            inference_response = pb_utils.InferenceResponse(
+                output_tensors=[
+                    pb_utils.Tensor(
+                        "output",
+                        np_translation.astype(self.output_dtype)
+                    )
+                ]
+            )
+            responses.append(inference_response)
+        return responses
+
+    def finalize(self):
+        """`finalize` is called only once when the model is being unloaded.
+        Implementing `finalize` function is optional. This function allows
+        the model to perform any necessary clean ups before exit.
+        """
+        print('Cleaning up...')

--- a/inference/nlp/realtime/triton/single-model/t5_pytorch_python-backend/README.md
+++ b/inference/nlp/realtime/triton/single-model/t5_pytorch_python-backend/README.md
@@ -1,0 +1,13 @@
+# Serve an NLP model on with Amazon SageMaker 
+
+In this example, we will walk you through how to use NVIDIA Triton Inference Server on Amazon SageMaker to deploy a HuggingFace  **T5** NLP model for **Text Translation**. In particular, this model will be using:
+
+T5-small HuggingFace PyTorch Translation Model (Served using Triton's Python Backend) 
+
+## Steps to run the notebook
+
+1. Launch SageMaker notebook instance with `g5.xlarge` instance. This example can also be run on a SageMaker studio notebook instance but the steps that follow will focus on the notebook instance.
+    * IMPORTANT: In Notebook instance settings, within Additional Configuration, for **Volume Size in GB** specify at least **100 GB**.
+    * For git repositories select the option `Clone a public git repository to this notebook instance only` and specify the Git repository URL
+    
+2. Once JupyterLab is ready, launch the **t5_pytorch_python-backend.ipynb** notebook with **conda_python3** conda kernel and run through this notebook to learn how to host multiple NLP models on `g5.2xlarge` GPU behind MME endpoint.

--- a/inference/nlp/realtime/triton/single-model/t5_pytorch_python-backend/t5_pytorch_python-backend.ipynb
+++ b/inference/nlp/realtime/triton/single-model/t5_pytorch_python-backend/t5_pytorch_python-backend.ipynb
@@ -1,0 +1,561 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7d4e905b",
+   "metadata": {},
+   "source": [
+    "# Serve Pytorch models with the Python Backend on GPU with Amazon SageMaker Hosting\n",
+    "\n",
+    "\n",
+    "\n",
+    "Amazon SageMaker Hosting provides a scalable and cost-effective way to deploy large number of deep learning models.\n",
+    "\n",
+    "<div class=\"alert alert-info\"> 💡 <strong> Note </strong>\n",
+    "This notebook was tested with the `conda_python3` kernel on an Amazon SageMaker notebook instance of type `g5.xlarge`.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c39ad03e",
+   "metadata": {},
+   "source": [
+    "In this notebook, we will walk you through how to use NVIDIA Triton Inference Server on Amazon SageMaker with GPU acceleration to deploy a **T5** NLP model for **Translation** using **PyTorch**. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e57030c2",
+   "metadata": {},
+   "source": [
+    "## Installs\n",
+    "\n",
+    "Installs the dependencies required to package the model and run inferences using Triton server. Update SageMaker, boto3, awscli etc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "689cdf8e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!pip install -qU pip awscli boto3 sagemaker\n",
+    "!pip install nvidia-pyindex --quiet\n",
+    "!pip install tritonclient[http] --quiet\n",
+    "!pip install transformers[sentencepiece] --quiet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1775fcd6",
+   "metadata": {},
+   "source": [
+    "## Imports and variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cbc4451e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import boto3, json, sagemaker, time\n",
+    "from sagemaker import get_execution_role\n",
+    "import numpy as np\n",
+    "import os\n",
+    "\n",
+    "os.environ[\"TOKENIZERS_PARALLELISM\"] = \"false\"\n",
+    "\n",
+    "# sagemaker variables\n",
+    "role = get_execution_role()\n",
+    "sm_client = boto3.client(service_name=\"sagemaker\")\n",
+    "runtime_sm_client = boto3.client(\"sagemaker-runtime\")\n",
+    "sagemaker_session = sagemaker.Session(boto_session=boto3.Session())\n",
+    "s3_client = boto3.client(\"s3\")\n",
+    "bucket = sagemaker.Session().default_bucket()\n",
+    "prefix = \"nlp-mme-gpu\"\n",
+    "\n",
+    "# account mapping for SageMaker MME Triton Image\n",
+    "account_id_map = {\n",
+    "    \"us-east-1\": \"785573368785\",\n",
+    "    \"us-east-2\": \"007439368137\",\n",
+    "    \"us-west-1\": \"710691900526\",\n",
+    "    \"us-west-2\": \"301217895009\",\n",
+    "    \"eu-west-1\": \"802834080501\",\n",
+    "    \"eu-west-2\": \"205493899709\",\n",
+    "    \"eu-west-3\": \"254080097072\",\n",
+    "    \"eu-north-1\": \"601324751636\",\n",
+    "    \"eu-south-1\": \"966458181534\",\n",
+    "    \"eu-central-1\": \"746233611703\",\n",
+    "    \"ap-east-1\": \"110948597952\",\n",
+    "    \"ap-south-1\": \"763008648453\",\n",
+    "    \"ap-northeast-1\": \"941853720454\",\n",
+    "    \"ap-northeast-2\": \"151534178276\",\n",
+    "    \"ap-southeast-1\": \"324986816169\",\n",
+    "    \"ap-southeast-2\": \"355873309152\",\n",
+    "    \"cn-northwest-1\": \"474822919863\",\n",
+    "    \"cn-north-1\": \"472730292857\",\n",
+    "    \"sa-east-1\": \"756306329178\",\n",
+    "    \"ca-central-1\": \"464438896020\",\n",
+    "    \"me-south-1\": \"836785723513\",\n",
+    "    \"af-south-1\": \"774647643957\",\n",
+    "}\n",
+    "\n",
+    "region = boto3.Session().region_name\n",
+    "if region not in account_id_map.keys():\n",
+    "    raise (\"UNSUPPORTED REGION\")\n",
+    "\n",
+    "base = \"amazonaws.com.cn\" if region.startswith(\"cn-\") else \"amazonaws.com\"\n",
+    "mme_triton_image_uri = (\n",
+    "    \"{account_id}.dkr.ecr.{region}.{base}/sagemaker-tritonserver:23.02-py3\".format(\n",
+    "        account_id=account_id_map[region], region=region, base=base\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2ee9165",
+   "metadata": {},
+   "source": [
+    "## Workflow Overview\n",
+    "\n",
+    "This section presents overview of main steps for preparing a T5 Pytorch (served using Python backend) model to be served using Triton Inference Server.\n",
+    "\n",
+    "### 1. Generate Model Artifacts\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e590a1bd",
+   "metadata": {},
+   "source": [
+    "#### T5 PyTorch Model\n",
+    "\n",
+    "We will use T5-small HuggingFace PyTorch Model, since we are serving it using Triton's [python backend](https://github.com/triton-inference-server/python_backend#usage) we have python script [model.py](./workspace/model.py) which implements all the logic to initialize the T5 model and execute inference for the translation task."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85b7fb7c",
+   "metadata": {},
+   "source": [
+    "### 2. Build Model Respository\n",
+    "\n",
+    "Using Triton on SageMaker requires us to first set up a [model repository](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_repository.md) folder containing the models we want to serve. For each model we need to create a model directory consisting of the model artifact and define config.pbtxt file to specify [model configuration](https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md) which Triton uses to load and serve the model. \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80da5747",
+   "metadata": {},
+   "source": [
+    "#### T5 Python Backend Model\n",
+    "\n",
+    "Model repository structure for T5 Model.\n",
+    "\n",
+    "```\n",
+    "t5_pytorch\n",
+    "├── 1\n",
+    "│   └── model.py\n",
+    "└── config.pbtxt\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db24fc9a",
+   "metadata": {},
+   "source": [
+    "Next we set up the T5 PyTorch Python Backend Model in the model repository:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9e724cc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!mkdir -p model_repository/t5_pytorch/1\n",
+    "!cp workspace/model.py model_repository/t5_pytorch/1/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d28c24d4",
+   "metadata": {},
+   "source": [
+    "##### Create Conda Environment for Dependencies\n",
+    "\n",
+    "For serving the HuggingFace T5 PyTorch Model using Triton's Python backend we have PyTorch and HuggingFace transformers as dependencies.\n",
+    "\n",
+    "We follow the instructions from the [Triton documentation for packaging dependencies](https://github.com/triton-inference-server/python_backend#2-packaging-the-conda-environment) to be used in the python backend as conda env tar file. Running the bash script [create_hf_env.sh]('./workspace/create_hf_env.sh') creates the conda environment containing PyTorch and HuggingFace transformers, packages it as tar file and then we move it into the t5-pytorch model directory. This can take a few minutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17e2d09e",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!bash workspace/create_hf_env.sh\n",
+    "!mv hf_env.tar.gz model_repository/t5_pytorch/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13bfffe7",
+   "metadata": {},
+   "source": [
+    "After creating the tar file from the conda environment and placing it in model folder, you need to tell Python backend to use that environment for your model. We do this by including the lines below in the model `config.pbtxt` file:\n",
+    "\n",
+    "```\n",
+    "parameters: {\n",
+    "  key: \"EXECUTION_ENV_PATH\",\n",
+    "  value: {string_value: \"$$TRITON_MODEL_DIRECTORY/hf_env.tar.gz\"}\n",
+    "}\n",
+    "```\n",
+    "Here, `$$TRITON_MODEL_DIRECTORY` helps provide environment path relative to the model folder in model repository and is resolved to `$pwd/model_repository/t5_pytorch`. Finally `hf_env.tar.gz` is the name we gave to our conda env file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "806dbfd5",
+   "metadata": {},
+   "source": [
+    "Now we are ready to define the config file for t5 pytorch model being served through Triton's Python Backend:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8fcb975a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%writefile model_repository/t5_pytorch/config.pbtxt\n",
+    "name: \"t5_pytorch\"\n",
+    "backend: \"python\"\n",
+    "max_batch_size: 8\n",
+    "input: [\n",
+    "    {\n",
+    "        name: \"input_ids\"\n",
+    "        data_type: TYPE_INT32\n",
+    "        dims: [ -1 ]\n",
+    "    },\n",
+    "    {\n",
+    "        name: \"attention_mask\"\n",
+    "        data_type: TYPE_INT32\n",
+    "        dims: [ -1 ]\n",
+    "    }\n",
+    "]\n",
+    "output [\n",
+    "  {\n",
+    "    name: \"output\"\n",
+    "    data_type: TYPE_INT32\n",
+    "    dims: [ -1 ]\n",
+    "  }\n",
+    "]\n",
+    "instance_group {\n",
+    "  count: 1\n",
+    "  kind: KIND_GPU\n",
+    "}\n",
+    "dynamic_batching {\n",
+    "}\n",
+    "parameters: {\n",
+    "  key: \"EXECUTION_ENV_PATH\",\n",
+    "  value: {string_value: \"$$TRITON_MODEL_DIRECTORY/hf_env.tar.gz\"}\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5bd554d",
+   "metadata": {},
+   "source": [
+    "### 3. Package models and upload to S3\n",
+    "\n",
+    "Next, we will package our models as `*.tar.gz` files for uploading to S3. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc39f53b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!tar -C model_repository/ -czf t5_pytorch.tar.gz t5_pytorch\n",
+    "model_uri_t5_pytorch = sagemaker_session.upload_data(path=\"t5_pytorch.tar.gz\", key_prefix=prefix)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75053b67",
+   "metadata": {},
+   "source": [
+    "### 4. Create SageMaker Endpoint\n",
+    "\n",
+    "Now that we have uploaded the model artifacts to S3, we can create a SageMaker endpoint."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b616860",
+   "metadata": {},
+   "source": [
+    "#### Define the serving container\n",
+    "In the container definition, define the `ModelDataUrl` to specify the S3 directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2aeda98",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "t5_sm_model_name = \"triton-t5-pt-\" + time.strftime(\"%Y-%m-%d-%H-%M-%S\", time.gmtime())\n",
+    "\n",
+    "t5_container = {\n",
+    "    \"Image\": mme_triton_image_uri,\n",
+    "    \"ModelDataUrl\": model_uri_t5_pytorch,\n",
+    "    \"Environment\": {\"SAGEMAKER_TRITON_DEFAULT_MODEL_NAME\": \"t5_pytorch\"},\n",
+    "}\n",
+    "\n",
+    "t5_create_model_response = sm_client.create_model(\n",
+    "    ModelName=t5_sm_model_name, ExecutionRoleArn=role, PrimaryContainer=t5_container\n",
+    ")\n",
+    "\n",
+    "print(\"Model Arn: \" + t5_create_model_response[\"ModelArn\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b4b35c2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "t5_endpoint_config_name = \"triton-t5-pt-\" + time.strftime(\"%Y-%m-%d-%H-%M-%S\", time.gmtime())\n",
+    "\n",
+    "t5_create_endpoint_config_response = sm_client.create_endpoint_config(\n",
+    "    EndpointConfigName=t5_endpoint_config_name,\n",
+    "    ProductionVariants=[\n",
+    "        {\n",
+    "            \"InstanceType\": \"ml.g5.xlarge\",\n",
+    "            \"InitialVariantWeight\": 1,\n",
+    "            \"InitialInstanceCount\": 1,\n",
+    "            \"ModelName\": t5_sm_model_name,\n",
+    "            \"VariantName\": \"AllTraffic\",\n",
+    "        }\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "print(\"Endpoint Config Arn: \" + t5_create_endpoint_config_response[\"EndpointConfigArn\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30b7b89f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "t5_endpoint_name = \"triton-t5-pt-\" + time.strftime(\"%Y-%m-%d-%H-%M-%S\", time.gmtime())\n",
+    "\n",
+    "t5_create_endpoint_response = sm_client.create_endpoint(\n",
+    "    EndpointName=t5_endpoint_name, EndpointConfigName=t5_endpoint_config_name\n",
+    ")\n",
+    "\n",
+    "print(\"Endpoint Arn: \" + t5_create_endpoint_response[\"EndpointArn\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b89e36e7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "t5_resp = sm_client.describe_endpoint(EndpointName=t5_endpoint_name)\n",
+    "t5_status = t5_resp[\"EndpointStatus\"]\n",
+    "print(\"Status: \" + t5_status)\n",
+    "\n",
+    "while t5_status == \"Creating\":\n",
+    "    time.sleep(60)\n",
+    "    t5_resp = sm_client.describe_endpoint(EndpointName=t5_endpoint_name)\n",
+    "    t5_status = t5_resp[\"EndpointStatus\"]\n",
+    "    print(\"Status: \" + t5_status)\n",
+    "\n",
+    "print(\"Arn: \" + t5_resp[\"EndpointArn\"])\n",
+    "print(\"Status: \" + t5_status)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5811620d",
+   "metadata": {},
+   "source": [
+    "### Run Inference "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ada8906c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from transformers import AutoTokenizer\n",
+    "\n",
+    "\n",
+    "def get_tokenizer(model_name):\n",
+    "    tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
+    "    return tokenizer\n",
+    "\n",
+    "\n",
+    "def tokenize_text(model_name, text):\n",
+    "    tokenizer = get_tokenizer(model_name)\n",
+    "    tokenized_text = tokenizer(text, padding=True, return_tensors=\"np\")\n",
+    "    return tokenized_text.input_ids, tokenized_text.attention_mask\n",
+    "\n",
+    "\n",
+    "def get_text_payload(model_name, text):\n",
+    "    input_ids, attention_mask = tokenize_text(model_name, text)\n",
+    "    payload = {}\n",
+    "    payload[\"inputs\"] = []\n",
+    "    payload[\"inputs\"].append(\n",
+    "        {\n",
+    "            \"name\": \"input_ids\",\n",
+    "            \"shape\": input_ids.shape,\n",
+    "            \"datatype\": \"INT32\",\n",
+    "            \"data\": input_ids.tolist(),\n",
+    "        }\n",
+    "    )\n",
+    "    payload[\"inputs\"].append(\n",
+    "        {\n",
+    "            \"name\": \"attention_mask\",\n",
+    "            \"shape\": attention_mask.shape,\n",
+    "            \"datatype\": \"INT32\",\n",
+    "            \"data\": attention_mask.tolist(),\n",
+    "        }\n",
+    "    )\n",
+    "    return payload"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7dac54cd",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "texts_to_translate = [\"translate English to German: The house is wonderful.\"]\n",
+    "batch_size = len(texts_to_translate)\n",
+    "\n",
+    "t5_payload = get_text_payload(\"t5-small\", texts_to_translate)\n",
+    "\n",
+    "print(\"payload: \" + json.dumps(t5_payload))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5945b763",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = runtime_sm_client.invoke_endpoint(\n",
+    "    EndpointName=t5_endpoint_name,\n",
+    "    ContentType=\"application/octet-stream\",\n",
+    "    Body=json.dumps(t5_payload),\n",
+    ")\n",
+    "\n",
+    "response_body = json.loads(response[\"Body\"].read().decode(\"utf8\"))\n",
+    "output_ids = np.array(response_body[\"outputs\"][0][\"data\"]).reshape(batch_size, -1)\n",
+    "t5_tokenizer = get_tokenizer(\"t5-small\")\n",
+    "decoded_outputs = t5_tokenizer.batch_decode(output_ids, skip_special_tokens=True)\n",
+    "for text in decoded_outputs:\n",
+    "    print(text, \"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23a211c7",
+   "metadata": {},
+   "source": [
+    "### Terminate endpoint and clean up artifacts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86d143c5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "sm_client.delete_model(ModelName=t5_sm_model_name)\n",
+    "sm_client.delete_endpoint_config(EndpointConfigName=t5_endpoint_config_name)\n",
+    "sm_client.delete_endpoint(EndpointName=t5_endpoint_name)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "conda_python3",
+   "language": "python",
+   "name": "conda_python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/inference/nlp/realtime/triton/single-model/t5_pytorch_python-backend/workspace/create_hf_env.sh
+++ b/inference/nlp/realtime/triton/single-model/t5_pytorch_python-backend/workspace/create_hf_env.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+conda create -y -n hf_env python=3.8
+source ~/anaconda3/etc/profile.d/conda.sh
+source activate hf_env
+export PYTHONNOUSERSITE=True
+pip install torch --extra-index-url https://download.pytorch.org/whl/cu116
+pip install transformers[sentencepiece]
+pip install conda-pack
+conda-pack

--- a/inference/nlp/realtime/triton/single-model/t5_pytorch_python-backend/workspace/model.py
+++ b/inference/nlp/realtime/triton/single-model/t5_pytorch_python-backend/workspace/model.py
@@ -1,0 +1,81 @@
+import numpy as np
+import sys
+import os
+import json
+from pathlib import Path
+
+import torch
+
+import triton_python_backend_utils as pb_utils
+
+class TritonPythonModel:
+    # Every Python model must have "TritonPythonModel" as the class name!
+    def initialize(self, args):
+        """`initialize` is called only once when the model is being loaded.
+        Implementing `initialize` function is optional. This function allows
+        the model to initialize any state associated with this model.
+        Parameters
+        ----------
+        args : dict
+          Both keys and values are strings. The dictionary keys and values are:
+          * model_config: A JSON string containing the model configuration
+          * model_instance_kind: A string containing model instance kind
+          * model_instance_device_id: A string containing model instance device ID
+          * model_repository: Model repository path
+          * model_version: Model version
+          * model_name: Model name
+        """
+        self.output_dtype = pb_utils.triton_string_to_numpy(
+            pb_utils.get_output_config_by_name(
+                json.loads(args['model_config']), "output"
+            )['data_type']
+        )
+
+        from transformers import T5ForConditionalGeneration, T5Tokenizer
+        self.model = T5ForConditionalGeneration.from_pretrained("t5-small").cuda()
+        print("TritonPythonModel initialized")
+
+    def execute(self, requests):
+        """`execute` must be implemented in every Python model. `execute`
+        function receives a list of pb_utils.InferenceRequest as the only
+        argument. This function is called when an inference is requested
+        for this model.
+        Parameters
+        ----------
+        requests : list
+          A list of pb_utils.InferenceRequest
+        Returns
+        -------
+        list
+          A list of pb_utils.InferenceResponse. The length of this list must
+          be the same as `requests`
+        """
+        responses = []
+        for request in requests:
+            input_ids = pb_utils.get_input_tensor_by_name(request, "input_ids")
+            input_ids = input_ids.as_numpy()
+            input_ids = torch.as_tensor(input_ids).long().cuda()
+            attention_mask = pb_utils.get_input_tensor_by_name(request, "attention_mask")
+            attention_mask = attention_mask.as_numpy()
+            attention_mask = torch.as_tensor(attention_mask).long().cuda()
+            inputs = {'input_ids': input_ids, 'attention_mask': attention_mask}
+            translation = self.model.generate(**inputs, num_beams=1)
+            # Convert to numpy array on cpu:
+            np_translation =  translation.cpu().int().detach().numpy()
+            inference_response = pb_utils.InferenceResponse(
+                output_tensors=[
+                    pb_utils.Tensor(
+                        "output",
+                        np_translation.astype(self.output_dtype)
+                    )
+                ]
+            )
+            responses.append(inference_response)
+        return responses
+
+    def finalize(self):
+        """`finalize` is called only once when the model is being unloaded.
+        Implementing `finalize` function is optional. This function allows
+        the model to perform any necessary clean ups before exit.
+        """
+        print('Cleaning up...')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: Added t5 Sagemaker inference example using single model endpoints and Triton Inference Server using the python backend* 

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [ x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [ x] I have tested my notebook(s) and ensured it runs end-to-end
- [ x] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
