### PR TITLE
Use ECR-hosted Ubuntu 18.04 image

### DIFF
--- a/advanced_functionality/causal-inference/container/Dockerfile
+++ b/advanced_functionality/causal-inference/container/Dockerfile
@@ -2,7 +2,7 @@
 # This is a Python 3 image that uses the nginx, gunicorn, flask stack
 # for serving inferences in a stable way.
 
-FROM ubuntu:18.04
+FROM public.ecr.aws/ubuntu/ubuntu:18.04_stable
 
 MAINTAINER Amazon AI <sage-learner@amazon.com>
 

--- a/advanced_functionality/multi_model_bring_your_own/container/Dockerfile
+++ b/advanced_functionality/multi_model_bring_your_own/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM public.ecr.aws/ubuntu/ubuntu:18.04_stable
 
 # Set a docker label to advertise multi-model support on the container
 LABEL com.amazonaws.sagemaker.capabilities.multi-models=true

--- a/advanced_functionality/multi_model_catboost/container/Dockerfile
+++ b/advanced_functionality/multi_model_catboost/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM public.ecr.aws/ubuntu/ubuntu:18.04_stable
 
 # Set a docker label to advertise multi-model support on the container
 LABEL com.amazonaws.sagemaker.capabilities.multi-models=true

--- a/advanced_functionality/scikit_bring_your_own/container/Dockerfile
+++ b/advanced_functionality/scikit_bring_your_own/container/Dockerfile
@@ -2,7 +2,7 @@
 # This is a Python 3 image that uses the nginx, gunicorn, flask stack
 # for serving inferences in a stable way.
 
-FROM ubuntu:18.04
+FROM public.ecr.aws/ubuntu/ubuntu:18.04_stable
 
 MAINTAINER Amazon AI <sage-learner@amazon.com>
 

--- a/aws_marketplace/creating_marketplace_products/algorithms/container/Dockerfile
+++ b/aws_marketplace/creating_marketplace_products/algorithms/container/Dockerfile
@@ -2,7 +2,7 @@
 # This is a Python 2 image that uses the nginx, gunicorn, flask stack
 # for serving inferences in a stable way.
 
-FROM ubuntu:18.04
+FROM public.ecr.aws/ubuntu/ubuntu:18.04_stable
 
 MAINTAINER Amazon AI <sage-learner@amazon.com>
 

--- a/inference/nlp/realtime/byoc/container/mme_catboost/Dockerfile
+++ b/inference/nlp/realtime/byoc/container/mme_catboost/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM public.ecr.aws/ubuntu/ubuntu:18.04_stable
 
 # Set a docker label to advertise multi-model support on the container
 LABEL com.amazonaws.sagemaker.capabilities.multi-models=true

--- a/sagemaker-clarify/text_explainability_sagemaker_algorithm/container/Dockerfile
+++ b/sagemaker-clarify/text_explainability_sagemaker_algorithm/container/Dockerfile
@@ -2,7 +2,7 @@
 # This is a Python 3 image that uses the nginx, gunicorn, flask stack
 # for serving inferences in a stable way.
 
-FROM ubuntu:18.04
+FROM public.ecr.aws/ubuntu/ubuntu:18.04_stable
 
 MAINTAINER Amazon AI <sage-learner@amazon.com>
 

--- a/sagemaker-fundamentals/create-endpoint/container/Dockerfile
+++ b/sagemaker-fundamentals/create-endpoint/container/Dockerfile
@@ -2,7 +2,7 @@
 # This is a Python 3 image that uses the nginx, gunicorn, flask stack
 # for serving inferences in a stable way.
 
-FROM ubuntu:18.04
+FROM public.ecr.aws/ubuntu/ubuntu:18.04_stable
 
 MAINTAINER Amazon AI <sage-learner@amazon.com>
 

--- a/sagemaker-fundamentals/create-endpoint/create_endpoint.ipynb
+++ b/sagemaker-fundamentals/create-endpoint/create_endpoint.ipynb
@@ -398,7 +398,7 @@
       "# This is a Python 3 image that uses the nginx, gunicorn, flask stack\n",
       "# for serving inferences in a stable way.\n",
       "\n",
-      "FROM ubuntu:18.04\n",
+      "FROM public.ecr.aws/ubuntu/ubuntu:18.04_stable\n",
       "\n",
       "MAINTAINER Amazon AI <sage-learner@amazon.com>\n",
       "\n",

--- a/sagemaker-pipeline-multi-model/container/Dockerfile
+++ b/sagemaker-pipeline-multi-model/container/Dockerfile
@@ -2,7 +2,7 @@
 # This is a Python 3 image that uses the nginx, gunicorn, flask stack
 # for serving inferences in a stable way.
 
-FROM ubuntu:18.04
+FROM public.ecr.aws/ubuntu/ubuntu:18.04_stable
 
 MAINTAINER Amazon AI <sage-learner@amazon.com>
 


### PR DESCRIPTION
*Issue #, if available:*

In my company's recent workshop, most participants were unable to build the required Docker image because Docker Hub denied our attempts to pull the image due to exceeding the free tier's rate limits.

*Description of changes:*

Switch all `ubuntu:18.04` references in Dockerfiles to using the equivalent ECR-hosted image, as ECR won't deny the pull attempts.

*Testing done:*

Manually started building one of the updated `Dockerfiles` and verified that the ECR image was successfully pulled.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- ~~[ ] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`~~ Not applicable because no notebook code was changed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license..
