### PR TITLE
set zipped_data to 0 if using openwebtext

### DIFF
--- a/training/distributed_training/pytorch/model_parallel/gpt2/smp-train-gpt-simple-sharded-data-parallel.ipynb
+++ b/training/distributed_training/pytorch/model_parallel/gpt2/smp-train-gpt-simple-sharded-data-parallel.ipynb
@@ -141,7 +141,7 @@
    },
    "source": [
     "## Prepare your dataset\n",
-    "We recommend that you use the [openwebtext](https://huggingface.co/datasets/viewer/?dataset=openwebtext) in this notebook. You can use the `data_prep_512.py` script to download and preprocess the dataset. The entire process takes 3 to 4 hours, so it is recommended to run the script in a separate SageMaker notebook instance and upload the processed data into your S3 bucket. The script requires `datasets` and `transformers` libraries. Run the following commands to install the libraries.\n",
+    "We recommend that you use the [openwebtext](https://huggingface.co/datasets/viewer/?dataset=openwebtext) in this notebook. You can use the `data_prep_512.py` script to download and preprocess the dataset. The entire process takes 3 to 4 hours and requires 200GB storage; it is recommended to run the script in a separate SageMaker notebook instance and upload the processed data into your S3 bucket. The script requires `datasets` and `transformers` libraries. Run the following commands to install the libraries.\n",
     "```\n",
     "pip install datasets\n",
     "pip install transformers\n",
@@ -398,6 +398,8 @@
     "    \"val_batch_size\": 4,\n",
     "    # parameters for sharded data parallelism\n",
     "    \"sharded_data_parallel_degree\": 2,\n",
+    "    # data_prep_512.py outputs .json files\n",
+    "    \"zipped_data\": 0 if not running_ci else 1\n",
     "}\n",
     "\n",
     "if use_fsx:\n",


### PR DESCRIPTION
*Issue #, if available:*
data_prep_512.py outputs data in .json format, not ,json.gz

*Description of changes:*
running data_prep_512.py requires ~200GB of storage space - updated instructions under prepare your dataset.
set zipped_data to 0 if not running ci.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [ ] I have tested my notebook(s) and ensured it runs end-to-end
- [ ] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
