### PR TITLE
Fix factorization machine notebook for SageMaker 2.x

### DIFF
--- a/introduction_to_amazon_algorithms/factorization_machines_mnist/factorization_machines_mnist.ipynb
+++ b/introduction_to_amazon_algorithms/factorization_machines_mnist/factorization_machines_mnist.ipynb
@@ -352,18 +352,20 @@
    "outputs": [],
    "source": [
     "import json\n",
-    "from sagemaker.predictor import json_deserializer\n",
+    "from sagemaker.serializers import JSONSerializer\n",
+    "from sagemaker.deserializers import JSONDeserializer\n",
     "\n",
     "\n",
-    "def fm_serializer(data):\n",
-    "    js = {\"instances\": []}\n",
-    "    for row in data:\n",
-    "        js[\"instances\"].append({\"features\": row.tolist()})\n",
-    "    return json.dumps(js)\n",
+    "class FMSerializer(JSONSerializer):\n",
+    "    def serialize(self, data):\n",
+    "        js = {\"instances\": []}\n",
+    "        for row in data:\n",
+    "            js[\"instances\"].append({\"features\": row.tolist()})\n",
+    "        return json.dumps(js)\n",
     "\n",
     "\n",
-    "fm_predictor.serializer.serialize = fm_serializer\n",
-    "fm_predictor.deserializer = json_deserializer"
+    "fm_predictor.serializer = FMSerializer()\n",
+    "fm_predictor.deserializer = JSONDeserializer()"
    ]
   },
   {


### PR DESCRIPTION

*Description of changes:* Fixed serializer and deserializer code - breaking changes for SageMaker 2.x - now it's installed by default without pinning a verion

*Testing done:* Ran notebook to completion

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ x ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [ x ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [ x ] I have tested my notebook(s) and ensured it runs end-to-end
- [ x ] I have linted my notebook(s) and code using ` black-nb -l 100 introduction_to_amazon_algorithms/factorization_machines_mnist/factorization_machines_mnist.ipynb`

(nbdime) MAC:~/workplace/ML/amazon-sagemaker-examples (factorization-machines-fix %) $ black-nb -l 100 introduction_to_amazon_algorithms/factorization_machines_mnist/factorization_machines_mnist.ipynb
    14 cells left unchanged.
All done! ✨ 🍰 ✨
1 file left unchanged.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
