### PR TITLE
FM Notebook Instance Type Update

### DIFF
--- a/introduction_to_amazon_algorithms/factorization_machines_mnist/factorization_machines_mnist.ipynb
+++ b/introduction_to_amazon_algorithms/factorization_machines_mnist/factorization_machines_mnist.ipynb
@@ -329,7 +329,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fm_predictor = fm.deploy(initial_instance_count=1, instance_type=\"ml.m4.xlarge\")"
+    "fm_predictor = fm.deploy(initial_instance_count=1, instance_type=\"ml.m5.xlarge\")"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
M4 instance types are not supported in some of the more newer/opt-in regions. Thus, revising to M5.

*Testing done:*
End-to-end checks have been done for the same M4 instance type, and the sanity check through the CodeBuild check should suffice.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [X] I have tested my notebook(s) and ensured it runs end-to-end
- [ ] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
