### PR TITLE
FM Notebook: Instance Type Change

### DIFF
--- a/introduction_to_amazon_algorithms/factorization_machines_mnist/factorization_machines_mnist.ipynb
+++ b/introduction_to_amazon_algorithms/factorization_machines_mnist/factorization_machines_mnist.ipynb
@@ -301,7 +301,7 @@
     "    container,\n",
     "    role,\n",
     "    instance_count=1,\n",
-    "    instance_type=\"ml.c4.xlarge\",\n",
+    "    instance_type=\"ml.c5.xlarge\",\n",
     "    output_path=output_location,\n",
     "    sagemaker_session=sess,\n",
     ")\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
C4 instance types are not available in a number of regions (e.g. eu-north-1). Thus, updating to use C5 instance type. From a cursory glance this seems to be pretty widely available across regions based on what Training supports.

*Testing done:*
Ran notebook with the change in eu-north-1.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [X] I have tested my notebook(s) and ensured it runs end-to-end
- [ ] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
