### PR TITLE
Provide a link to the code instead of redirecting to a section within…

### DIFF
--- a/advanced_functionality/scikit_bring_your_own/scikit_bring_your_own.ipynb
+++ b/advanced_functionality/scikit_bring_your_own/scikit_bring_your_own.ipynb
@@ -61,7 +61,7 @@
     "    1. [Create a Transform Job](#Create-a-Transform-Job)\n",
     "    2. [View Output](#View-Output)\n",
     "\n",
-    "_or_ I'm impatient, just [let me see the code](#The-Dockerfile)!\n",
+    "_or_ I'm impatient, just [let me see the code](https://github.com/aws/amazon-sagemaker-examples/tree/main/advanced_functionality/scikit_bring_your_own)!\n",
     "\n",
     "## When should I build my own algorithm container?\n",
     "\n",


### PR DESCRIPTION
… the notebook itself

This in the only place in the doc where a link to the code is provided, and currently it just redirects to the Dockerfile section in the doc itself.

*Issue #, if available:* NA

*Description of changes:* Added a link to the code repo

*Testing done:* NA

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [ ] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
