### PR TITLE
Adapt batch size for vector enrichment notebook

### DIFF
--- a/sagemaker-geospatial/vector-enrichment-reverse-geocoding/vector-enrichment-reverse-geocoding.ipynb
+++ b/sagemaker-geospatial/vector-enrichment-reverse-geocoding/vector-enrichment-reverse-geocoding.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "432d9996-f346-417b-b149-2ab301934829",
    "metadata": {},
@@ -9,6 +10,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "982790fa",
    "metadata": {},
@@ -23,6 +25,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "c848d74f-927f-4d9c-93a6-6bffb8ff684b",
    "metadata": {},
@@ -41,6 +44,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "7757ae92-ea99-4b57-a037-cb5fe78498ed",
    "metadata": {},
@@ -76,6 +80,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "1ea44c84-3cd9-4237-95f6-42354e7069be",
    "metadata": {
@@ -104,6 +109,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "acd2c4bb-1f5c-44f6-856e-4fa45841db82",
    "metadata": {},
@@ -126,6 +132,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "4e75e232-17ac-434a-996f-c399a25e81a2",
    "metadata": {
@@ -189,7 +196,7 @@
     "    \"Target\",\n",
     "]\n",
     "df_housing_data = pd.read_csv(\"CaliforniaHousing/cal_housing.data\", names=columns, header=None)\n",
-    "df_housing_data = df_housing_data.drop(columns=[\"Target\"])[:15000]\n",
+    "df_housing_data = df_housing_data.drop(columns=[\"Target\"])[:5000]\n",
     "df_housing_data.to_csv(\"california_housing.csv\", index=False)\n",
     "df_housing_data.head(5)"
    ]
@@ -215,6 +222,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "5b6eafe2-524c-453d-a2fe-eb2cd066c70c",
    "metadata": {},
@@ -279,6 +287,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f3d7a121-89b1-4296-bfba-0105c700830b",
    "metadata": {
@@ -331,6 +340,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "5187b7d9-be49-4bbf-9bfd-72d12d504f2b",
    "metadata": {
@@ -370,6 +380,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "018e01b2-0eb5-4029-be5e-4ba276d673ff",
    "metadata": {
@@ -405,6 +416,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e10bdc82-79ec-46c9-873d-4db1e2aa90b8",
    "metadata": {
@@ -435,6 +447,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e93d473e",
    "metadata": {},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This is a minor change, which decreases the batch size for input data using the vector enrichment reverse geocoding feature. This feature works most optimal with the new defined batch size.

*Testing done:* Executed notebook

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
