### PR TITLE
Add README to re-direct viewers to aws-samples/sagemaker-genai-hosting-examples

### DIFF
--- a/inference/generativeai/README.md
+++ b/inference/generativeai/README.md
@@ -1,0 +1,5 @@
+![SageMaker](https://github.com/aws/amazon-sagemaker-examples/raw/main/_static/sagemaker-banner.png)
+
+# Amazon SageMaker Examples for Generative Inferencing 
+
+This code repo has been relocated to [sagemaker-genai-hosting-examples](https://github.com/aws-samples/sagemaker-genai-hosting-examples.git).


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add README to aws/amazon-sagemaker-examples/tree/main/inference/generativeai to re-direct viewers to aws-samples/sagemaker-genai-hosting-examples repo for the latest deployments.

*Testing done:*
Yes.
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [ ] I have tested my notebook(s) and ensured it runs end-to-end
- [ ] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
