### PR TITLE
Add gradient accumulation to SMP v2 train loop

### DIFF
--- a/training/distributed_training/pytorch/model_parallel_v2/shared-scripts/arguments.py
+++ b/training/distributed_training/pytorch/model_parallel_v2/shared-scripts/arguments.py
@@ -20,6 +20,11 @@ def parse_args():  # pylint: disable=too-many-statements
         default=2,
         help="batch size per dp rank, for tensor parallelism degree 8 with pipeline parallel degree 1 this means 8*this batch size per node",  # pylint: disable=line-too-long
     )
+    opt_grp.add_argument(
+        "--gradient_accumulation_steps",
+        type=int,
+        default=1,
+    )
     opt_grp.add_argument("--max_steps", "--max_training_steps", type=int, default=5000)
     opt_grp.add_argument(
         "--epochs", type=int, default=3, help="times of iterating over the training dataset"


### PR DESCRIPTION
*Issue #, if available:* Add new function.

*Description of changes:* Add a straight-forward gradient accumulation function to the train_step and arguments.py

*Testing done:* Behave as expected.
<img width="471" alt="图片" src="https://github.com/aws/amazon-sagemaker-examples/assets/121946073/6d7cc328-cb15-46a8-8930-a6d9faeb26b0">

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
