### PR TITLE
updating parsing bug

### DIFF
--- a/introduction_to_amazon_algorithms/jumpstart_text_to_image/Amazon_JumpStart_Text_To_Image.ipynb
+++ b/introduction_to_amazon_algorithms/jumpstart_text_to_image/Amazon_JumpStart_Text_To_Image.ipynb
@@ -332,7 +332,8 @@
     "def parse_response(query_response):\n",
     "    \"\"\"Parse response and return generated image and the prompt\"\"\"\n",
     "\n",
-    "    response_dict = json.loads(query_response)\n",
+    "    # response_dict = json.loads(query_response)\n",
+    "    response_dict = query_response\n",
     "    return response_dict[\"generated_image\"], response_dict[\"prompt\"]\n",
     "\n",
     "\n",
@@ -372,6 +373,17 @@
     "query_response = query(model_predictor, text)\n",
     "img, prmpt = parse_response(query_response)\n",
     "display_img_and_prompt(img, prmpt)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6afccdd4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#debugging\n",
+    "#query_response"
    ]
   },
   {
@@ -446,7 +458,8 @@
     "def parse_response_multiple_images(query_response):\n",
     "    \"\"\"Parse response and return generated image and the prompt\"\"\"\n",
     "\n",
-    "    response_dict = json.loads(query_response)\n",
+    "    #response_dict = json.loads(query_response)\n",
+    "    response_dict = query_response\n",
     "    return response_dict[\"generated_images\"], response_dict[\"prompt\"]\n",
     "\n",
     "\n",


### PR DESCRIPTION
*Issue #, if available:*

```
text = "cottage in impressionist style"
query_response = query(model_predictor, text)
img, prmpt = parse_response(query_response)
display_img_and_prompt(img, prmpt)
```

> 
> ```
> 
> ---------------------------------------------------------------------------
> TypeError                                 Traceback (most recent call last)
> Cell In[10], line 3
>       1 text = "cottage in impressionist style"
>       2 query_response = query(model_predictor, text)
> ----> 3 img, prmpt = parse_response(query_response)
>       4 display_img_and_prompt(img, prmpt)
> 
> Cell In[8], line 23, in parse_response(query_response)
>      20 def parse_response(query_response):
>      21     """Parse response and return generated image and the prompt"""
> ---> 23     response_dict = json.loads(query_response)
>      24     return response_dict["generated_image"], response_dict["prompt"]
> 
> File /opt/conda/lib/python3.8/json/__init__.py:341, in loads(s, cls, object_hook, parse_float, parse_int, parse_constant, object_pairs_hook, **kw)
>     339 else:
>     340     if not isinstance(s, (bytes, bytearray)):
> --> 341         raise TypeError(f'the JSON object must be str, bytes or bytearray, '
>     342                         f'not {s.__class__.__name__}')
>     343     s = s.decode(detect_encoding(s), 'surrogatepass')
>     345 if "encoding" in kw:
> 
> TypeError: the JSON object must be str, bytes or bytearray, not dict
> 
> ```


*Description of changes: Removed json.loads as it seems its not needed.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [X ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [X ] I have tested my notebook(s) and ensured it runs end-to-end
- [X ] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
