### PR TITLE
Cw/remove deprecated pd.io.json

### DIFF
--- a/aws_sagemaker_studio/getting_started/xgboost_customer_churn_studio.ipynb
+++ b/aws_sagemaker_studio/getting_started/xgboost_customer_churn_studio.ipynb
@@ -3354,7 +3354,7 @@
    "outputs": [],
    "source": [
     "baseline_job = my_default_monitor.latest_baselining_job\n",
-    "schema_df = pd.io.json.json_normalize(baseline_job.baseline_statistics().body_dict[\"features\"])\n",
+    "schema_df = pd.json_normalize(baseline_job.baseline_statistics().body_dict[\"features\"])\n",
     "schema_df.head(10)"
    ]
   },
@@ -3374,7 +3374,7 @@
    },
    "outputs": [],
    "source": [
-    "constraints_df = pd.io.json.json_normalize(\n",
+    "constraints_df = pd.json_normalize(\n",
     "    baseline_job.suggested_constraints().body_dict[\"features\"]\n",
     ")\n",
     "constraints_df.head(10)"
@@ -3705,7 +3705,7 @@
    "source": [
     "violations = my_default_monitor.latest_monitoring_constraint_violations()\n",
     "pd.set_option(\"display.max_colwidth\", -1)\n",
-    "constraints_df = pd.io.json.json_normalize(violations.body_dict[\"violations\"])\n",
+    "constraints_df = pd.json_normalize(violations.body_dict[\"violations\"])\n",
     "constraints_df.head(10)"
    ]
   },

--- a/sagemaker_model_monitor/introduction/SageMaker-ModelMonitoring.ipynb
+++ b/sagemaker_model_monitor/introduction/SageMaker-ModelMonitoring.ipynb
@@ -422,7 +422,7 @@
     "import pandas as pd\n",
     "\n",
     "baseline_job = my_default_monitor.latest_baselining_job\n",
-    "schema_df = pd.io.json.json_normalize(baseline_job.baseline_statistics().body_dict[\"features\"])\n",
+    "schema_df = pd.json_normalize(baseline_job.baseline_statistics().body_dict[\"features\"])\n",
     "schema_df.head(10)"
    ]
   },
@@ -432,7 +432,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "constraints_df = pd.io.json.json_normalize(\n",
+    "constraints_df = pd.json_normalize(\n",
     "    baseline_job.suggested_constraints().body_dict[\"features\"]\n",
     ")\n",
     "constraints_df.head(10)"
@@ -683,7 +683,7 @@
    "source": [
     "violations = my_default_monitor.latest_monitoring_constraint_violations()\n",
     "pd.set_option(\"display.max_colwidth\", None)\n",
-    "constraints_df = pd.io.json.json_normalize(violations.body_dict[\"violations\"])\n",
+    "constraints_df = pd.json_normalize(violations.body_dict[\"violations\"])\n",
     "constraints_df.head(10)"
    ]
   },

--- a/sagemaker_model_monitor/model_monitor_batch_transform/SageMaker-ModelMonitoring-Batch-Transform-Data-Quality-On-schedule.ipynb
+++ b/sagemaker_model_monitor/model_monitor_batch_transform/SageMaker-ModelMonitoring-Batch-Transform-Data-Quality-On-schedule.ipynb
@@ -405,7 +405,7 @@
     "import pandas as pd\n",
     "\n",
     "baseline_job = my_default_monitor.latest_baselining_job\n",
-    "schema_df = pd.io.json.json_normalize(baseline_job.baseline_statistics().body_dict[\"features\"])\n",
+    "schema_df = pd.json_normalize(baseline_job.baseline_statistics().body_dict[\"features\"])\n",
     "schema_df.head(10)"
    ]
   },
@@ -415,7 +415,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "constraints_df = pd.io.json.json_normalize(\n",
+    "constraints_df = pd.json_normalize(\n",
     "    baseline_job.suggested_constraints().body_dict[\"features\"]\n",
     ")\n",
     "constraints_df.head(10)"
@@ -625,7 +625,7 @@
    "source": [
     "violations = my_default_monitor.latest_monitoring_constraint_violations()\n",
     "pd.set_option(\"display.max_colwidth\", -1)\n",
-    "constraints_df = pd.io.json.json_normalize(violations.body_dict[\"violations\"])\n",
+    "constraints_df = pd.json_normalize(violations.body_dict[\"violations\"])\n",
     "constraints_df.head(10)"
    ]
   },

--- a/sagemaker_model_monitor/model_monitor_batch_transform/SageMaker-ModelMonitoring-Batch-Transform-Data-Quality-With-SageMaker-Pipelines-On-Demand.ipynb
+++ b/sagemaker_model_monitor/model_monitor_batch_transform/SageMaker-ModelMonitoring-Batch-Transform-Data-Quality-With-SageMaker-Pipelines-On-Demand.ipynb
@@ -607,7 +607,7 @@
    "source": [
     "pd.set_option(\"display.max_colwidth\", -1)\n",
     "\n",
-    "constraints_df = pd.io.json.json_normalize(violation.body_dict[\"violations\"])\n",
+    "constraints_df = pd.json_normalize(violation.body_dict[\"violations\"])\n",
     "constraints_df.head(10)"
    ]
   },

--- a/sagemaker_model_monitor/model_monitor_batch_transform/SageMaker-ModelMonitoring-Batch-Transform-Model-Quality-On-schedule.ipynb
+++ b/sagemaker_model_monitor/model_monitor_batch_transform/SageMaker-ModelMonitoring-Batch-Transform-Model-Quality-On-schedule.ipynb
@@ -565,7 +565,7 @@
    "outputs": [],
    "source": [
     "baseline_job = my_default_monitor.latest_baselining_job\n",
-    "schema_df = pd.io.json.json_normalize(\n",
+    "schema_df = pd.json_normalize(\n",
     "    baseline_job.baseline_statistics().body_dict[\"binary_classification_metrics\"]\n",
     ")\n",
     "schema_df.transpose().head(10)"
@@ -577,7 +577,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "constraints_df = pd.io.json.json_normalize(\n",
+    "constraints_df = pd.json_normalize(\n",
     "    baseline_job.suggested_constraints().body_dict[\"binary_classification_constraints\"]\n",
     ")\n",
     "constraints_df.transpose().head(10)"
@@ -805,7 +805,7 @@
    "source": [
     "violations = my_default_monitor.latest_monitoring_constraint_violations()\n",
     "pd.set_option(\"display.max_colwidth\", -1)\n",
-    "constraints_df = pd.io.json.json_normalize(violations.body_dict[\"violations\"])\n",
+    "constraints_df = pd.json_normalize(violations.body_dict[\"violations\"])\n",
     "constraints_df.head(10)"
    ]
   },

--- a/sagemaker_model_monitor/model_monitor_batch_transform/SageMaker-ModelMonitoring-Batch-Transform-Model-Quality-With-SageMaker-Pipelines-On-Demand.ipynb
+++ b/sagemaker_model_monitor/model_monitor_batch_transform/SageMaker-ModelMonitoring-Batch-Transform-Model-Quality-With-SageMaker-Pipelines-On-Demand.ipynb
@@ -437,7 +437,7 @@
    "outputs": [],
    "source": [
     "baseline_job = my_default_monitor.latest_baselining_job\n",
-    "schema_df = pd.io.json.json_normalize(\n",
+    "schema_df = pd.json_normalize(\n",
     "    baseline_job.baseline_statistics().body_dict[\"binary_classification_metrics\"]\n",
     ")\n",
     "schema_df.transpose().head(10)"
@@ -450,7 +450,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "constraints_df = pd.io.json.json_normalize(\n",
+    "constraints_df = pd.json_normalize(\n",
     "    baseline_job.suggested_constraints().body_dict[\"binary_classification_constraints\"]\n",
     ")\n",
     "constraints_df.transpose().head(10)"
@@ -676,7 +676,7 @@
    "source": [
     "pd.set_option(\"display.max_colwidth\", -1)\n",
     "\n",
-    "constraints_df = pd.io.json.json_normalize(violation.body_dict[\"violations\"])\n",
+    "constraints_df = pd.json_normalize(violation.body_dict[\"violations\"])\n",
     "constraints_df.head(10)"
    ]
   },

--- a/sagemaker_model_monitor/tensorflow/SageMaker-Model-Monitor-tensorflow.ipynb
+++ b/sagemaker_model_monitor/tensorflow/SageMaker-Model-Monitor-tensorflow.ipynb
@@ -482,7 +482,7 @@
     "import pandas as pd\n",
     "\n",
     "baseline_job = my_default_monitor.latest_baselining_job\n",
-    "schema_df = pd.io.json.json_normalize(baseline_job.baseline_statistics().body_dict[\"features\"])\n",
+    "schema_df = pd.json_normalize(baseline_job.baseline_statistics().body_dict[\"features\"])\n",
     "schema_df.head(10)"
    ]
   },
@@ -492,7 +492,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "constraints_df = pd.io.json.json_normalize(\n",
+    "constraints_df = pd.json_normalize(\n",
     "    baseline_job.suggested_constraints().body_dict[\"features\"]\n",
     ")\n",
     "constraints_df.head(10)"
@@ -797,7 +797,7 @@
    "source": [
     "violations = my_default_monitor.latest_monitoring_constraint_violations()\n",
     "pd.set_option(\"display.max_colwidth\", -1)\n",
-    "constraints_df = pd.io.json.json_normalize(violations.body_dict[\"violations\"])\n",
+    "constraints_df = pd.json_normalize(violations.body_dict[\"violations\"])\n",
     "constraints_df.head(10)"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:* No Issue Number.

*Description of changes:*
The function `pd.io.json.json_normalize` has been deprecated, and returns an error whenever a user runs the notebooks that use the function. I found this while going through the data quality and model quality notebooks.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [ x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [ x] I have tested my notebook(s) and ensured it runs end-to-end
- [x ] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
