### PR TITLE
Model parallel v2 llama finetuning  notebook fixes

### DIFF
--- a/training/distributed_training/pytorch/model_parallel_v2/README.md
+++ b/training/distributed_training/pytorch/model_parallel_v2/README.md
@@ -3,13 +3,7 @@
 This directory contains example scripts to train or fine-tune large scale models,
 with the Sagemaker distributed model parallelism library.
 When using one of the ipynb notebooks within the folders of this directory please 
-make sure to use the `./shared-scripts/` directory as the source directory when submitting a job.
+make sure to use the `../shared-scripts/` directory as the source directory when submitting a job.
 
 For example, if one wanted to submit a llama finetune job on Sagemaker using the `/llama_v2/smp-finetuning-llama-fsdp-tp.ipynb`
-notebook, they would have to copy that notebook within the `./shared-scripts/` directory to make sure it can access all the accompanied files.
-
-After cloning this repository run the following command to setup a copy of the notebook associated with your desired model into the `./shared-scripts/` directory.
-
-- `cp [RELATIVE PATH TO ipynb] shared-scripts/`
-
-Finally, upload the `./shared-scripts/` directory to a Sagemaker notebook to submit your training/finetuning job. 
+notebook, they would have to upload  `/llama_v2/smp-finetuning-llama-fsdp-tp.ipynb` along with the `../shared-scripts/` directory to Sagemaker notebook.

--- a/training/distributed_training/pytorch/model_parallel_v2/llama_v2/smp-finetuning-llama-fsdp-tp.ipynb
+++ b/training/distributed_training/pytorch/model_parallel_v2/llama_v2/smp-finetuning-llama-fsdp-tp.ipynb
@@ -66,10 +66,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "FILE_SYSTEM_ID = \"...\"\n",
-    "FSX_SECURITY_GROUP_ID = \"...\"\n",
-    "FSX_SUBNET = \"...\"\n",
-    "BASE_PATH = \"...\"\n",
+    "# FSX setup if you plan to use it.\n",
+    "FSX_FILE_SYSTEM_ID = \"fs-XXXXXXXXXXXXXXXXX\"  # Sample: \"fs-[a-z0-9]+\"\n",
+    "\n",
+    "# - Specify the SG and subnet used by the FSX, these are passed to SM Estimator so jobs use this as well.\n",
+    "FSX_SECURITY_GROUP_ID = \"sg-XXXXXXXXXXXXXXXXX\"  # Sample: \"sg-[a-z0-9]+\"\n",
+    "FSX_SUBNET_ID = \"subnet-XXXXXXXXXXXXXXXXX\"  # Sample: \"subnet-[a-z0-9]+\"\n",
+    "\n",
+    "# - Specify directory path for input data on the file system.\n",
+    "# You need to provide normalized and absolute path below.\n",
+    "# Your mount name can be provided by you when creating fsx, or generated automatically.\n",
+    "# You can find this mount_name on the FSX page in console.\n",
+    "# Example of fsx generated mount_name: \"3x5lhbmv\"\n",
+    "# Example base path: \"/3x5lhbmv\"\n",
+    "FSX_FILE_SYSTEM_BASE_PATH = \"/XXXXXXXX\"\n",
+    "\n",
+    "\n",
     "PRETRAINED_MODEL = \"...\"\n",
     "PRETRAINED_DIR = \"...\""
    ]
@@ -140,6 +152,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "pip install --upgrade pytest\n",
     "! pip install -q datasets==2.15.0 transformers pytest"
    ]
   },
@@ -553,7 +566,7 @@
     "    from sagemaker.inputs import FileSystemInput\n",
     "\n",
     "    # Specify FSx Lustre file system id.\n",
-    "    file_system_id = FILE_SYSTEM_ID\n",
+    "    file_system_id = FSX_FILE_SYSTEM_ID\n",
     "\n",
     "    # Specify the SG and subnet used by the FSX, these are passed to SM Estimator so jobs use this as well\n",
     "    fsx_security_group_id = FSX_SECURITY_GROUP_ID\n",
@@ -565,7 +578,7 @@
     "    # You can find this mount_name on the FSX page in console.\n",
     "    # Example of fsx generated mount_name: \"3x5lhbmv\"\n",
     "    # Example base path: \"/3x5lhbmv\"\n",
-    "    base_path = BASE_PATH\n",
+    "    base_path = FSX_FILE_SYSTEM_BASE_PATH\n",
     "\n",
     "    # Specify your file system type.\n",
     "    file_system_type = \"FSxLustre\"\n",

--- a/training/distributed_training/pytorch/model_parallel_v2/shared-scripts/arguments.py
+++ b/training/distributed_training/pytorch/model_parallel_v2/shared-scripts/arguments.py
@@ -27,7 +27,7 @@ def parse_args():  # pylint: disable=too-many-statements
     opt_grp.add_argument("--seed", type=int, default=12345)
     opt_grp.add_argument("--same_seed", type=int, default=0)
     opt_grp.add_argument("--bf16", default=1, type=int, help="automatic mixed precision training")
-    opt_grp.add_argument("--fp8", default=1, type=int, help="fp8 mixed precision training")
+    opt_grp.add_argument("--fp8", default=0, type=int, help="fp8 mixed precision training")
     opt_grp.add_argument("--fp8_amax_history_len", default=1024, type=int, help="amax history length")
     opt_grp.add_argument("--fp8_amax_compute_algo", default="max", type=str, help="amax computation algorithm: 'max' or 'most_recent'")
     opt_grp.add_argument("--grad_clip", default=1.0, type=float, help="gradient clipping")


### PR DESCRIPTION
*Description of changes:*
- **Updating the model parallel v2 README to clarify usage of shared-scripts directory**
- **Disabling fp8 by default for backward compatibility**
- **Updating llma finetuning example with inline comments for FSX args and upgrade command for pytest**

*Testing done:*
Ran smp-finetuning-llama-fsdp-tp.ipynb in sagemaker notebook and ensured sagemaker training job succeded

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
