### PR TITLE
change save to export

### DIFF
--- a/advanced_functionality/tensorflow_iris_byom/tensorflow_BYOM_iris.ipynb
+++ b/advanced_functionality/tensorflow_iris_byom/tensorflow_BYOM_iris.ipynb
@@ -276,7 +276,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "classifier.save(\"export/Servo/1\")\n",
+    "classifier.export("export/Servo/1", format="tf_saved_model")\n",
     "with tarfile.open(\"model.tar.gz\", \"w:gz\") as tar:\n",
     "    tar.add(\"export\")"
    ]


### PR DESCRIPTION
`save_format` argument in `keras.Model.save` [is deprecated](https://www.tensorflow.org/api_docs/python/tf/keras/Model#save).

should use `keras.Model.export` with `format='tf_saved_model'` [instead](https://www.tensorflow.org/api_docs/python/tf/keras/Model#export).