### PR TITLE
fix: add domain execution role fallback, additional domain tags

### DIFF
--- a/   ml_ops/sm-datazone_import/README.md
+++ b/   ml_ops/sm-datazone_import/README.md
@@ -4,7 +4,7 @@ This example contains python scripts to import an existing SageMaker Domain into
 
 ## Setup
 
-1. Add the byod service model
+1. Add the Bring-Your-Own-Domain (BYOD) service model
 
 ```bash
 aws configure add-model --service-model file://resources/datazone-linkedtypes-2018-05-10.normal.json --service-name datazone-byod
@@ -34,3 +34,8 @@ python import-sagemaker-domain.py \
     --federation-role ARN_OF_FEDERATION_ROLE \
     --account-id ACCOUNTID
 ```
+
+### Additional Configuration
+
+- SageMaker execution roles need DataZone API permissions in order for the Assets UI to function. See [DataZoneUserPolicy.json](./resources/DataZoneUserPolicy.json) for an example.
+- Ensure the DataZone Domain trusts SageMaker. In the AWS DataZone console navigate to Domain details and select the "Trusted services".

--- a/   ml_ops/sm-datazone_import/resources/DatazoneUserPolicy.json
+++ b/   ml_ops/sm-datazone_import/resources/DatazoneUserPolicy.json
@@ -1,0 +1,65 @@
+{
+    "Statement": [
+        {
+            "Condition": {
+                "StringEquals": {
+                    "iam:PassedToService": "datazone.amazonaws.com"
+                }
+            },
+            "Action": [
+                "iam:PassRole"
+            ],
+            "Resource": [
+                "arn:aws:iam::*:role/AmazonDataZone*",
+                "arn:aws:iam::*:role/service-role/AmazonDataZone*"
+            ],
+            "Effect": "Allow"
+        },
+        {
+            "Action": [
+                "datazone:AcceptSubscriptionRequest",
+                "datazone:CreateSubscriptionRequest",
+                "datazone:CreateDataSource",
+                "datazone:DeleteSubscriptionRequest",
+                "datazone:Search",
+                "datazone:SearchListings",
+                "datazone:ListSubscriptionRequests",
+                "datazone:ListAssetRevisions",
+                "datazone:GetListing",
+                "datazone:GetAsset",
+                "datazone:GetEnvironment",
+                "datazone:GetProject",
+                "datazone:RejectSubscriptionRequest",
+                "datazone:CancelSubscription",
+                "datazone:ListSubscriptions",
+                "datazone:ListDataSources",
+                "datazone:ListDataSourceRuns",
+                "datazone:ListDataSourceRunActivities",
+                "datazone:GetDataSource",
+                "datazone:GetDataSourceRun",
+                "datazone:StartDataSourceRun",
+                "datazone:UpdateDataSource",
+                "datazone:DeleteDataSource",
+                "datazone:ListEnvironments",
+                "datazone:CreateListingChangeSet",
+                "datazone:RevokeSubscription",
+                "datazone:GetGlossaryTerm",
+                "datazone:CreateAsset",
+                "datazone:CreateAssetRevision",
+                "datazone:GetUserProfile",
+                "datazone:GetUserProfile",
+                "datazone:ListSubscriptionGrants",
+                "datazone:CreateSubscriptionGrant",
+                "datazone:GetSubscriptionGrant",
+                "datazone:DeleteAsset",
+                "datazone:DeleteDataSource",
+                "datazone:GetFormType",
+                "datazone:ListGroupsForUser",
+                "datazone:ListProjectMemberships",
+                "datazone:DeleteListing"
+            ],
+            "Resource": "*",
+            "Effect": "Allow"
+        }
+    ]
+}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* 
- adds a fallback to retrieve execution role from sm domain if `UserSettings` not found on user profile
- tag the sm domain with dz project and dz environment as a short term fix for UI behavior
- change auth mode configuration option based on auth mode of sm domain

*Testing done:* In CMH I created a DataZone Domain, Project, and Environment, enabled AWS IdC, created IdC users, and created a SageMaker Domain with AuthMode = SSO. I think ran the import script and off board script multiple times, making changes until I was able to successfully login to the SSO user prortal, launch DataZone, and then launch SageMaker from DataZone and verify that the Assets tab displayed in Studio V2 along with successful calls to DataZone. This feature is not available in Studio Classic.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have verified that my PR does not contain any new notebook/s which demonstrate a SageMaker functionality already showcased by another existing notebook in the repository
- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/default/CONTRIBUTING.md) doc and adhered to the guidelines regarding folder placement, notebook naming convention and example notebook best practices
- [x] I have updated the necessary documentation, including the README of the appropriate folder as well as the index.rst file
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `python3 -m black -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
