### PR TITLE
fix: use correct client for create env client, fix environment creation

### DIFF
--- a/   ml_ops/sm-datazone_import/import-sagemaker-domain.py
+++ b/   ml_ops/sm-datazone_import/import-sagemaker-domain.py
@@ -253,17 +253,16 @@ class SageMakerDomainImporter:
                 managed_key, self.managed_blueprint_id
             )
         )
+
+        # if already enabled returns success
+        self.dz_client.put_environment_blueprint_configuration(
+            domainIdentifier=self.dz_domain_id,
+            environmentBlueprintIdentifier=self.managed_blueprint_id,
+            enabledRegions=[self.region],
+        )
+
         print("--------------------------------------------------------------------")
 
-        decision = input(
-            "Do you need to enable the configuration for the specified environment blueprint into Amazon DataZone? (put_env_blueprint_config)? [y/n]: "
-        )
-        if decision == "y":
-            self.dz_client.put_environment_blueprint_configuration(
-                domainIdentifier=self.dz_domain_id,
-                environmentBlueprintIdentifier=self.managed_blueprint_id,
-                enabledRegions=[self.region],
-            )
         return self.managed_blueprint_id
 
     def _configure_environment(self):
@@ -336,7 +335,7 @@ class SageMakerDomainImporter:
                 sm_env_action = item
 
         if sm_env_action is None:
-            self.dz_client.create_environment_action(
+            self.byod_client.create_environment_action(
                 domainIdentifier=self.dz_domain_id,
                 environmentIdentifier=self.env_id,
                 name="SageMaker Environment Action Link",
@@ -479,10 +478,10 @@ class SageMakerDomainImporter:
         self._choose_sm_domain()
         self._choose_dz_domain()
         self._choose_dz_project()
+        self._configure_blueprint()
         self._configure_environment()
         self._tag_sm_domain()
         self._map_users()
-        self._configure_blueprint()
         self._add_environment_action()
         self._associate_fed_role()
         self._link_domain()


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* The `CreateEnvironmentAction` API call uses a parameter that is only available in the byod DataZone model. Specifically `parameters: "sageMaker": {}`. Use the byod model to call `CreateEnvironmentAction`.

*Testing done:* Verified using latest public DataZone API model and then ran through script e2e in CMH prod.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have verified that my PR does not contain any new notebook/s which demonstrate a SageMaker functionality already showcased by another existing notebook in the repository
- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/default/CONTRIBUTING.md) doc and adhered to the guidelines regarding folder placement, notebook naming convention and example notebook best practices
- [x] I have updated the necessary documentation, including the README of the appropriate folder as well as the index.rst file
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `python3 -m black -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
