### PR TITLE
add additional setup reminders, delete env link during offboard

### DIFF
--- a/   ml_ops/sm-datazone_import/README.md
+++ b/   ml_ops/sm-datazone_import/README.md
@@ -4,13 +4,22 @@ This example contains python scripts to import an existing SageMaker Domain into
 
 ## Setup
 
-1. Add the Bring-Your-Own-Domain (BYOD) service model
+1. Ensure dependencies are up to date.
+
+Update the CLI. See instructions https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+`aws --version`
+
+Update boto.
+`pip install --upgrade -r requirements.txt`
+`pip show boto3`
+
+2. Add the Bring-Your-Own-Domain (BYOD) service model
 
 ```bash
 aws configure add-model --service-model file://resources/datazone-linkedtypes-2018-05-10.normal.json --service-name datazone-byod
 ```
 
-2. Create a federation role
+3. Create a federation role
 
 This role will be used by DataZone to launch the SageMaker Domain. See [BringYourOwnDomainResources.yml](.resources/BringYourOwnDomainResources.yml) for an example.
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* delete environment action link and remove additional tags when onboarding. add additional setup steps to reminder user to update dependencies.

*Testing done:* ran through script e2e in CMH

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have verified that my PR does not contain any new notebook/s which demonstrate a SageMaker functionality already showcased by another existing notebook in the repository
- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/default/CONTRIBUTING.md) doc and adhered to the guidelines regarding folder placement, notebook naming convention and example notebook best practices
- [x] I have updated the necessary documentation, including the README of the appropriate folder as well as the index.rst file
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `python3 -m black -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
