### PR TITLE
Fix documentation issues in README files

### DIFF
--- a/        end_to_end_ml_lifecycle/README.md
+++ b/        end_to_end_ml_lifecycle/README.md
@@ -6,4 +6,4 @@ These examples are a diverse collection of end-to-end notebooks that demonstrate
 
 - [Customer Churn Prediction with Amazon SageMaker Autopilot](sm-autopilot_customer_churn.ipynb)
 - [Housing Price Prediction with Amazon SageMaker Autopilot](sm-autopilot_linear_regression_california_housing.ipynb)
-- [Time-Series Forecasting with Amazon SageMaker Autopilot](sm-sm-autopilot_time_series_forecasting.ipynb)
+- [Time-Series Forecasting with Amazon SageMaker Autopilot](sm-autopilot_time_series_forecasting.ipynb)

--- a/       prepare_data/README.md
+++ b/       prepare_data/README.md
@@ -2,7 +2,7 @@
 
 ### Prepare Data
 
-The example notebooks within this folder showcase Sagemaker's data preparation capabilities. Data preparation in machine learning refers to the process of collecting, preprocessing, and organizing raw data to make it suitable for analysis and modeling.
+The example notebooks within this folder showcase SageMaker's data preparation capabilities. Data preparation in machine learning refers to the process of collecting, preprocessing, and organizing raw data to make it suitable for analysis and modeling.
 
 - [Data Wrangler Data Prep Widget - Example Notebook](sm-data_wrangler_data_prep_widget/sm-data_wrangler_data_prep_widget.ipynb)
 - [Amazon SageMaker Feature Store: Feature Processor Introduction](sm-feature_store_feature_processor/sm-feature_store_feature_processor.ipynb)


### PR DESCRIPTION
Correct duplicate prefix in notebook link and standardize product name capitalization

- Fix broken link in end_to_end_ml_lifecycle/README.md by removing duplicate "sm-" prefix
- Standardize "SageMaker" capitalization in prepare_data/README.md to match official branding

These changes improve documentation accuracy and consistency across the repository.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have verified that my PR does not contain any new notebook/s which demonstrate a SageMaker functionality already showcased by another existing notebook in the repository
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/default/CONTRIBUTING.md) doc and adhered to the guidelines regarding folder placement, notebook naming convention and example notebook best practices
- [ ] I have updated the necessary documentation, including the README of the appropriate folder as well as the index.rst file
- [ ] I have tested my notebook(s) and ensured it runs end-to-end
- [ ] I have linted my notebook(s) and code using `python3 -m black -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
