### PR TITLE
docs: Add SDK-first guidance to AGENTS.md and llms.txt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,114 @@
+# AGENTS.md — Amazon SageMaker Examples
+
+Guidance for AI coding agents (Cursor, GitHub Copilot, Claude Code, Amazon Q Developer,
+Kiro, Codex, Gemini CLI, etc.) working in this repository. Follows the AGENTS.md
+convention (https://agents.md).
+
+## Project context
+
+This repository contains example notebooks for the **Amazon SageMaker Python SDK v3**.
+`pip install sagemaker` installs **v3**. SDK v3 is a modular redesign and is **not
+backward compatible** with v2. It is split into:
+
+- `sagemaker-core` — foundation primitives and the low-level, resource-oriented API
+- `sagemaker-train` — training (`ModelTrainer`)
+- `sagemaker-serve` — model building & deployment (`ModelBuilder`)
+- `sagemaker-mlops` — pipelines and workflow orchestration
+
+## Golden rule: generate v3 by default
+
+Generate **SageMaker Python SDK v3** code by default. Produce v2 code **only** when the
+user explicitly asks for "v2" (e.g., "give me the v2 version"); if you do, label it as
+deprecated and note `pip install 'sagemaker<3.0'`.
+
+## Banned v2 patterns → required v3 replacements
+
+Do not emit the left column unless v2 is explicitly requested. Mappings follow the official
+[migration guide](https://github.com/aws/sagemaker-python-sdk/blob/master/migration.md).
+
+| v2 (do NOT use) | v3 (use instead) |
+|---|---|
+| `from sagemaker.estimator import Estimator` | `from sagemaker.train import ModelTrainer` |
+| framework estimator classes — `from sagemaker.pytorch import PyTorch` (also TensorFlow, SKLearn, XGBoost, HuggingFace) | `ModelTrainer` + `from sagemaker.core import image_uris` → `image_uris.retrieve(...)` |
+| `estimator.fit(...)` | `model_trainer.train(...)` |
+| `from sagemaker.model import Model` / `model.deploy(...)` | `from sagemaker.serve import ModelBuilder`; `ModelBuilder(...).deploy(...)` |
+| `from sagemaker.predictor import Predictor` / `predictor.predict(...)` | `Predictor` is replaced by `Endpoint` (sagemaker-core); use the predictor returned by `ModelBuilder.deploy(...)` |
+| `from sagemaker.processing import Processor / ScriptProcessor / SKLearnProcessor` | `sagemaker.core.resources.ProcessingJob` |
+| `from sagemaker.workflow...` (old paths) | `from sagemaker.mlops...` (`sagemaker.mlops.pipeline.Pipeline`, `sagemaker.mlops.steps`) |
+
+Removed in v3 with **no** direct replacement (do not invent shims): MXNet, Chainer,
+RLEstimator, Training Compiler.
+
+## Required workflow when writing SageMaker code
+
+1. Write the code using v3 patterns from the table above.
+2. **Self-check** the output for any banned v2 pattern (if a migration MCP tool such as
+   `sagemaker-sdk-helper` is available, call its validate/transform tools).
+3. If a v2 pattern is found, fix it to v3 and re-check until clean.
+4. Only then present the code.
+
+## Repository layout (category folders)
+
+- `build_and_train_models/` — training with `ModelTrainer`, frameworks, distributed, tuning
+- `deploy_and_monitor/` — deployment with `ModelBuilder`, endpoints, monitoring
+- `prepare_data/` — data processing / feature engineering
+- `ml_ops/` — Pipelines, Model Registry, experiment tracking
+- `generative_ai/` — GenAI / foundation models / fine-tuning
+- `responsible_ai/` — bias, explainability
+- `end_to_end_ml_lifecycle/` — full end-to-end workflows
+- `sagemaker-core/` — SageMaker Core getting-started
+
+(Category folders carry leading-space ordering prefixes in this repo; match the existing
+name exactly when adding files.)
+
+## Code conventions
+
+- No hardcoded account IDs, role ARNs, regions, subnets, or bucket names. Use
+  `get_execution_role()` and `Session().default_bucket()`.
+- Do not require interactive input to run.
+- Notebook file naming: `sm-<feature>_<description>.ipynb`.
+- Each notebook includes: a title cell, a setup cell (`%pip install sagemaker`), a cleanup
+  cell that deletes created resources, and a summary cell.
+- Clear cell outputs before committing. Target the latest v3.
+
+## Canonical v3 example (train + deploy)
+
+Grounded in the migration guide; verify exact signatures against the installed SDK.
+
+```python
+from sagemaker.core import image_uris
+from sagemaker.train import ModelTrainer
+from sagemaker.train.configs import SourceCode, Compute, InputData
+from sagemaker.serve import ModelBuilder
+from sagemaker.serve.configs import InferenceSpec
+
+# Training
+training_image = image_uris.retrieve(
+    framework="pytorch", region="us-west-2", version="2.0.0",
+    py_version="py310", instance_type="ml.p3.2xlarge", image_scope="training",
+)
+model_trainer = ModelTrainer(
+    training_image=training_image,
+    role=role,
+    source_code=SourceCode(source_dir="./src", entry_script="train.py"),
+    compute=Compute(instance_type="ml.p3.2xlarge", instance_count=1),
+)
+model_trainer.train(input_data_config=[InputData(channel_name="train", data_source="s3://<bucket>/train")])
+
+# Inference
+model_builder = ModelBuilder(
+    inference_spec=InferenceSpec(
+        image_uri="<inference-image-uri>",
+        model_data_url="s3://<bucket>/model.tar.gz",
+    ),
+    role=role,
+)
+predictor = model_builder.deploy(instance_type="ml.m5.large", initial_instance_count=1)
+```
+
+## References
+
+- V2 → V3 migration guide: https://github.com/aws/sagemaker-python-sdk/blob/master/migration.md
+- SageMaker Python SDK (source): https://github.com/aws/sagemaker-python-sdk
+- SageMaker Python SDK docs: https://sagemaker.readthedocs.io/
+- Curated index for agents: ./llms.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,36 @@ Generate **SageMaker Python SDK v3** code by default. Produce v2 code **only** w
 user explicitly asks for "v2" (e.g., "give me the v2 version"); if you do, label it as
 deprecated and note `pip install 'sagemaker<3.0'`.
 
+## SDK-first: use the SageMaker Python SDK for SageMaker tasks
+
+For any Amazon SageMaker task (training, deployment, processing, pipelines), **default to the
+SageMaker Python SDK v3** as the primary interface. Do **not** drop to raw `boto3`
+(`client("sagemaker").create_training_job(...)`), the AWS CLI, or hand-rolled framework
+scripts unless the user explicitly asks for them, because the SDK handles image resolution,
+packaging, and job wiring that raw clients leave to the caller.
+
+Map the user's intent to the v3 interface:
+
+| User intent (natural language) | Use this v3 interface |
+|---|---|
+| "train a model", "training job", "serverless / managed training", "fine-tune" | `sagemaker.train.ModelTrainer` → `.train(...)` |
+| "distributed training", "multi-GPU / multi-node" | `ModelTrainer` with `Compute(instance_count=N, ...)` |
+| "hyperparameter tuning", "HPO", "sweep" | `sagemaker.train` tuner APIs on top of `ModelTrainer` |
+| "deploy a model", "real-time / serverless / async endpoint", "host / serve" | `sagemaker.serve.ModelBuilder` → `.deploy(...)` |
+| "batch inference", "batch transform", "offline scoring" | `sagemaker.core.resources` transform APIs |
+| "process data", "feature engineering", "preprocess", "transform dataset" | `sagemaker.core.resources.ProcessingJob` |
+| "build an ML pipeline", "orchestrate a workflow", "MLOps" | `sagemaker.mlops.pipeline.Pipeline`, `sagemaker.mlops.steps` |
+| "register a model", "model registry" | `sagemaker.mlops` model-registry APIs |
+| "get / retrieve a container image URI" | `sagemaker.core.image_uris.retrieve(...)` |
+
+Only step outside the SDK when the SDK genuinely does not cover the task (e.g., a pure IAM
+or S3 setup step), and say so explicitly when you do.
+
+**Honest scope note:** this guidance only steers agents that have this file (or the SDK repo,
+or an equivalent rules/MCP configuration) in context. It does not change a plain chat session
+that never loads these files — winning those requires corpus/discoverability work outside this
+repo (see the deprecation recommendations doc).
+
 ## Banned v2 patterns → required v3 replacements
 
 Do not emit the left column unless v2 is explicitly requested. Mappings follow the official

--- a/llms.txt
+++ b/llms.txt
@@ -10,6 +10,15 @@ instructions so AI coding agents generate correct, current (v3) code.
 
 ## Instructions for LLM agents (SageMaker Python SDK)
 
+- **SDK-first:** for any SageMaker task (train, deploy, process, pipelines), use the
+  **SageMaker Python SDK v3** as the primary interface. Do not drop to raw `boto3`
+  (`create_training_job`, `create_endpoint`), the AWS CLI, or hand-rolled framework scripts
+  unless the user explicitly asks. Intent → interface:
+  - "train / fine-tune / training job / serverless training" → `sagemaker.train.ModelTrainer` (`.train(...)`)
+  - "deploy / host / real-time or serverless or async endpoint" → `sagemaker.serve.ModelBuilder` (`.deploy(...)`)
+  - "process data / feature engineering / preprocess" → `sagemaker.core.resources.ProcessingJob`
+  - "pipeline / orchestrate / MLOps" → `sagemaker.mlops.pipeline.Pipeline`, `sagemaker.mlops.steps`
+  - "container image URI" → `sagemaker.core.image_uris.retrieve(...)`
 - Default to SageMaker Python SDK **v3**.
 - **Never** emit these v2 patterns unless the user explicitly asks for "v2":
   - `from sagemaker.estimator import Estimator` → use `from sagemaker.train import ModelTrainer`

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,52 @@
+# Amazon SageMaker Examples
+
+> Example notebooks for building, training, and deploying models with the Amazon SageMaker
+> Python SDK **v3**. This repository targets **v3 only**; `pip install sagemaker` installs v3.
+> SDK v3 is modular (`sagemaker-core`, `sagemaker-train`, `sagemaker-serve`, `sagemaker-mlops`)
+> and is not backward compatible with v2. v2 examples are archived, not maintained.
+
+This file follows the llms.txt convention (https://llmstxt.org): a curated index plus explicit
+instructions so AI coding agents generate correct, current (v3) code.
+
+## Instructions for LLM agents (SageMaker Python SDK)
+
+- Default to SageMaker Python SDK **v3**.
+- **Never** emit these v2 patterns unless the user explicitly asks for "v2":
+  - `from sagemaker.estimator import Estimator` → use `from sagemaker.train import ModelTrainer`
+  - framework estimator classes (`from sagemaker.pytorch import PyTorch`, TensorFlow, SKLearn,
+    XGBoost, HuggingFace) → `ModelTrainer` + `from sagemaker.core import image_uris` (`image_uris.retrieve(...)`)
+  - `estimator.fit(...)` → `model_trainer.train(...)`
+  - `from sagemaker.model import Model` / `model.deploy(...)` → `from sagemaker.serve import ModelBuilder`; `ModelBuilder(...).deploy(...)`
+  - `from sagemaker.predictor import Predictor` / `predictor.predict(...)` → `Predictor` replaced by `Endpoint` (sagemaker-core); use the predictor returned by `ModelBuilder.deploy(...)`
+  - `from sagemaker.processing import Processor/ScriptProcessor/SKLearnProcessor` → `sagemaker.core.resources.ProcessingJob`
+  - `from sagemaker.workflow...` → `from sagemaker.mlops...`
+- Removed in v3 (no replacement): MXNet, Chainer, RLEstimator, Training Compiler.
+- After generating SageMaker code, validate it contains none of the v2 patterns above. If unsure
+  of a mapping, consult the migration guide below or call the migration MCP tool.
+- No hardcoded account IDs, role ARNs, regions, or bucket names. Use `get_execution_role()` and
+  `Session().default_bucket()`.
+
+## Migration
+
+- [V2 → V3 migration guide](https://github.com/aws/sagemaker-python-sdk/blob/master/migration.md): authoritative mappings and before/after examples
+- [SageMaker Python SDK (source)](https://github.com/aws/sagemaker-python-sdk)
+- [SageMaker Python SDK docs](https://sagemaker.readthedocs.io/)
+
+## Core v3 interfaces
+
+- Training: `sagemaker.train.ModelTrainer` (+ `train.configs`: `Compute`, `SourceCode`, `InputData`)
+- Inference: `sagemaker.serve.ModelBuilder` (+ `serve.configs.InferenceSpec`), then `ModelBuilder.deploy(...)`
+- Processing: `sagemaker.core.resources.ProcessingJob`
+- MLOps / Pipelines: `sagemaker.mlops.pipeline.Pipeline`, `sagemaker.mlops.steps`
+- Images: `sagemaker.core.image_uris.retrieve(...)`
+
+## Example categories
+
+- [Build & train models](https://github.com/aws/amazon-sagemaker-examples/tree/default): training with `ModelTrainer`, frameworks, distributed training, hyperparameter tuning
+- [Deploy & monitor](https://github.com/aws/amazon-sagemaker-examples/tree/default): deployment with `ModelBuilder`, real-time/serverless/async endpoints, model monitoring
+- [Prepare data](https://github.com/aws/amazon-sagemaker-examples/tree/default): data processing and feature engineering
+- [MLOps](https://github.com/aws/amazon-sagemaker-examples/tree/default): SageMaker Pipelines, Model Registry, experiment tracking
+- [Generative AI](https://github.com/aws/amazon-sagemaker-examples/tree/default): foundation models, JumpStart, fine-tuning (SFT/DPO/RLVR)
+- [Responsible AI](https://github.com/aws/amazon-sagemaker-examples/tree/default): bias detection and explainability
+- [End-to-end ML lifecycle](https://github.com/aws/amazon-sagemaker-examples/tree/default): complete build → train → deploy workflows
+- [SageMaker Core](https://github.com/aws/amazon-sagemaker-examples/tree/default): getting started with the v3 resource API (see the `sagemaker-core/` folder, e.g. `get_started.ipynb`)


### PR DESCRIPTION
## What

Adds an **SDK-first** section to `AGENTS.md` and `llms.txt` (both merged earlier in #4891).

The prior files already steer agents from SDK **v2 → v3**. This change addresses a distinct
gap: when a task doesn't name the SDK (e.g. "generate training code for a SageMaker serverless
job"), agents often drop to raw `boto3` (`create_training_job`/`create_endpoint`), the AWS CLI,
or a hand-rolled framework script instead of the SageMaker Python SDK.

## Changes

- New "SDK-first" guidance: for any SageMaker task, default to the SageMaker Python SDK v3 as
  the primary interface.
- A natural-language **intent → v3 interface** table (train → `ModelTrainer`, deploy →
  `ModelBuilder`, process → `ProcessingJob`, pipeline → `sagemaker.mlops`, image →
  `image_uris.retrieve`).
- An honest scope note: these files only steer agents that load them into context.

## Notes

Docs-only change (`AGENTS.md`, `llms.txt`); no code or notebooks touched.

---
X-AI-Prompt: Add SDK-first (library-selection) guidance so agents default to the SageMaker Python SDK v3 without an explicit nudge
X-AI-Tool: Kiro
