### PR TITLE
[Batch 2] migrate 9 example notebooks V2 -> V3

### DIFF
--- a/      build_and_train_models/sm-introduction_to_object2vec_sentence_similarity/sm-introduction_to_object2vec_sentence_similarity-v3.ipynb
+++ b/      build_and_train_models/sm-introduction_to_object2vec_sentence_similarity/sm-introduction_to_object2vec_sentence_similarity-v3.ipynb
@@ -1,0 +1,2032 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# An Introduction to SageMaker ObjectToVec model for sequence-sequence embedding\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "This notebook's CI test result for us-west-2 is as follows. CI test results in other regions can be found at the end of the notebook. \n",
+    "\n",
+    "![This us-west-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-west-2/build_and_train_models|sm-introduction_to_object2vec_sentence_similarity|sm-introduction_to_object2vec_sentence_similarity.ipynb)\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Table of contents\n",
+    "\n",
+    "1. [Background](#Background)\n",
+    "1. [Download datasets](#Download-datasets)\n",
+    "1. [Preprocessing](#Preprocessing)\n",
+    "1. [Model training and inference](#Model-training-and-inference)\n",
+    "1. [Transfer learning with object2vec](#Transfer-learning)\n",
+    "1. [How to enable the optimal training result](#How-to-enable-the-optimal-training-result)\n",
+    "1. [Hyperparameter Tuning (Advanced)](#Hyperparameter-Tuning-(Advanced))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Background\n",
+    "\n",
+    "*Object2Vec* is a highly customizable multi-purpose algorithm that can learn embeddings of pairs of objects. The embeddings are learned in a way that it preserves their pairwise **similarities**\n",
+    "- **Similarity** is user-defined: users need to provide the algorithm with pairs of objects that they define as similar (1) or dissimilar (0); alternatively, the users can define similarity in a continuous sense (provide a real-valued similarity score for reach object pair)\n",
+    "- The learned embeddings can be used to compute nearest neighbors of objects, as well as to visualize natural clusters of related objects in the embedding space. In addition, the embeddings can also be used as features of the corresponding objects in downstream supervised tasks such as classification or regression"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Using Object2Vec to Encode Sentences into Fixed Length Embeddings "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this notebook, we will demonstrate how to train *Object2Vec* to encode sequences of varying length into fixed length embeddings. \n",
+    "\n",
+    "As a specific example, we will represent each sentence as a sequence of integers, and we will show how to learn an encoder to embed these sentences into fixed-length vectors. To this end, we need pairs of sentences with labels that indicate their similarity. The Stanford Natural Language Inference data set (https://nlp.stanford.edu/projects/snli/), which consists\n",
+    "of pairs of sentences labeled as \"entailment\", \"neutral\" or \"contradiction\", comes close to our requirements; we will pick this data set as our training dataset in this notebook example. \n",
+    "\n",
+    "Once the model is trained on this data,\n",
+    "the trained encoders can be used to convert any new English sentences into fixed length embeddings. We will measure the quality of learned sentence embeddings on new sentences, by computing similarity of sentence pairs in the embedding space from the STS'16 dataset (http://alt.qcri.org/semeval2016/task1/), and evaluating against human-labeled ground-truth ratings."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<img style=\"float:middle\" src=\"image_snli.png\" width=\"480\">"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Before running the notebook\n",
+    "- Please use a Python 3 kernel for the notebook\n",
+    "- Please make sure you have `jsonlines` and `nltk` packages installed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### (If you haven't done it) install jsonlines and nltk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -U nltk\n",
+    "!pip install jsonlines\n",
+    "!pip install -U sagemaker sagemaker-core"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download datasets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please be aware of the following requirements about acknowledgment, copyright and availability, cited from the [dataset description page](https://nlp.stanford.edu/projects/snli/).\n",
+    "> The Stanford Natural Language Inference Corpus by The Stanford NLP Group is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License.\n",
+    "Based on a work at http://shannon.cs.illinois.edu/DenotationGraph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import requests\n",
+    "import io\n",
+    "import numpy as np\n",
+    "from zipfile import ZipFile\n",
+    "from datetime import datetime"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SNLI_PATH = \"snli_1.0\"\n",
+    "STS_PATH = \"sts2016-english-with-gs-v1.0\"\n",
+    "\n",
+    "if not os.path.exists(SNLI_PATH):\n",
+    "    url_address = \"https://nlp.stanford.edu/projects/snli/snli_1.0.zip\"\n",
+    "    request = requests.get(url_address)\n",
+    "    zfile = ZipFile(io.BytesIO(request.content))\n",
+    "    zfile.extractall()\n",
+    "    zfile.close()\n",
+    "\n",
+    "if not os.path.exists(STS_PATH):\n",
+    "    url_address = (\n",
+    "        \"http://alt.qcri.org/semeval2016/task1/data/uploads/sts2016-english-with-gs-v1.0.zip\"\n",
+    "    )\n",
+    "    request = requests.get(url_address)\n",
+    "    zfile = ZipFile(io.BytesIO(request.content))\n",
+    "    zfile.extractall()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Preprocessing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "import sys, os\n",
+    "import jsonlines\n",
+    "import json\n",
+    "from collections import Counter\n",
+    "from itertools import chain, islice\n",
+    "from nltk.tokenize import TreebankWordTokenizer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# constants\n",
+    "\n",
+    "BOS_SYMBOL = \"<s>\"\n",
+    "EOS_SYMBOL = \"</s>\"\n",
+    "UNK_SYMBOL = \"<unk>\"\n",
+    "PAD_SYMBOL = \"<pad>\"\n",
+    "PAD_ID = 0\n",
+    "TOKEN_SEPARATOR = \" \"\n",
+    "VOCAB_SYMBOLS = [PAD_SYMBOL, UNK_SYMBOL, BOS_SYMBOL, EOS_SYMBOL]\n",
+    "\n",
+    "\n",
+    "LABEL_DICT = {\"entailment\": 0, \"neutral\": 1, \"contradiction\": 2}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#### Utility functions\n",
+    "\n",
+    "\n",
+    "def read_jsonline(fname):\n",
+    "    \"\"\"\n",
+    "    Reads jsonline files and returns iterator\n",
+    "    \"\"\"\n",
+    "    with jsonlines.open(fname) as reader:\n",
+    "        for line in reader:\n",
+    "            yield line\n",
+    "\n",
+    "\n",
+    "def sentence_to_integers(sentence, tokenizer, word_dict):\n",
+    "    \"\"\"\n",
+    "    Converts a string of tokens to a list of integers\n",
+    "    TODO: Better handling of the case\n",
+    "          where token is not in word_dict\n",
+    "    \"\"\"\n",
+    "    return [word_dict[token] for token in get_tokens(sentence, tokenizer) if token in word_dict]\n",
+    "\n",
+    "\n",
+    "def get_tokens(line, tokenizer):\n",
+    "    \"\"\"\n",
+    "    Yields tokens from input string.\n",
+    "\n",
+    "    :param line: Input string.\n",
+    "    :return: Iterator over tokens.\n",
+    "    \"\"\"\n",
+    "    for token in tokenizer.tokenize(line):\n",
+    "        if len(token) > 0:\n",
+    "            yield token\n",
+    "\n",
+    "\n",
+    "def get_tokens_from_snli(input_dict, tokenizer):\n",
+    "    iter_list = list()\n",
+    "    for sentence_key in [\"sentence1\", \"sentence2\"]:\n",
+    "        sentence = input_dict[sentence_key]\n",
+    "        iter_list.append(get_tokens(sentence, tokenizer))\n",
+    "    return chain(iter_list[0], iter_list[1])\n",
+    "\n",
+    "\n",
+    "def get_tokens_from_sts(input_sentence_pair, tokenizer):\n",
+    "    iter_list = list()\n",
+    "    for s in input_sentence_pair:\n",
+    "        iter_list.append(get_tokens(s, tokenizer))\n",
+    "    return chain(iter_list[0], iter_list[1])\n",
+    "\n",
+    "\n",
+    "def resolve_snli_label(raw_label):\n",
+    "    \"\"\"\n",
+    "    Converts raw label to integer\n",
+    "    \"\"\"\n",
+    "    return LABEL_DICT[raw_label]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Functions to build vocabulary from SNLI corpus"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_vocab(\n",
+    "    data_iter, dataname=\"snli\", num_words=50000, min_count=1, use_reserved_symbols=True, sort=True\n",
+    "):\n",
+    "    \"\"\"\n",
+    "    Creates a vocabulary mapping from words to ids. Increasing integer ids are assigned by word frequency,\n",
+    "    using lexical sorting as a tie breaker. The only exception to this are special symbols such as the padding symbol\n",
+    "    (PAD).\n",
+    "\n",
+    "    :param data_iter: Sequence of sentences containing whitespace delimited tokens.\n",
+    "    :param num_words: Maximum number of words in the vocabulary.\n",
+    "    :param min_count: Minimum occurrences of words to be included in the vocabulary.\n",
+    "    :return: word-to-id mapping.\n",
+    "    \"\"\"\n",
+    "    vocab_symbols_set = set(VOCAB_SYMBOLS)\n",
+    "    tokenizer = TreebankWordTokenizer()\n",
+    "    if dataname == \"snli\":\n",
+    "        raw_vocab = Counter(\n",
+    "            token\n",
+    "            for line in data_iter\n",
+    "            for token in get_tokens_from_snli(line, tokenizer)\n",
+    "            if token not in vocab_symbols_set\n",
+    "        )\n",
+    "    elif dataname == \"sts\":\n",
+    "        raw_vocab = Counter(\n",
+    "            token\n",
+    "            for line in data_iter\n",
+    "            for token in get_tokens_from_sts(line, tokenizer)\n",
+    "            if token not in vocab_symbols_set\n",
+    "        )\n",
+    "    else:\n",
+    "        raise NameError(f\"Data name {dataname} is not recognized!\")\n",
+    "\n",
+    "    print(\"Initial vocabulary: {} types\".format(len(raw_vocab)))\n",
+    "\n",
+    "    # For words with the same count, they will be ordered reverse alphabetically.\n",
+    "    # Not an issue since we only care for consistency\n",
+    "    pruned_vocab = sorted(((c, w) for w, c in raw_vocab.items() if c >= min_count), reverse=True)\n",
+    "    print(\"Pruned vocabulary: {} types (min frequency {})\".format(len(pruned_vocab), min_count))\n",
+    "\n",
+    "    # truncate the vocabulary to fit size num_words (only includes the most frequent ones)\n",
+    "    vocab = islice((w for c, w in pruned_vocab), num_words)\n",
+    "\n",
+    "    if sort:\n",
+    "        # sort the vocabulary alphabetically\n",
+    "        vocab = sorted(vocab)\n",
+    "    if use_reserved_symbols:\n",
+    "        vocab = chain(VOCAB_SYMBOLS, vocab)\n",
+    "\n",
+    "    word_to_id = {word: idx for idx, word in enumerate(vocab)}\n",
+    "\n",
+    "    print(\"Final vocabulary: {} types\".format(len(word_to_id)))\n",
+    "\n",
+    "    if use_reserved_symbols:\n",
+    "        # Important: pad symbol becomes index 0\n",
+    "        assert word_to_id[PAD_SYMBOL] == PAD_ID\n",
+    "    return word_to_id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Functions to convert SNLI data to pairs of sequences of integers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def convert_snli_to_integers(data_iter, word_to_id, dirname=SNLI_PATH, fname_suffix=\"\"):\n",
+    "    \"\"\"\n",
+    "    Go through snli jsonline file line by line and convert sentences to list of integers\n",
+    "    - convert entailments to labels\n",
+    "    \"\"\"\n",
+    "    fname = \"snli-integer-\" + fname_suffix + \".jsonl\"\n",
+    "    path = os.path.join(dirname, fname)\n",
+    "    tokenizer = TreebankWordTokenizer()\n",
+    "    count = 0\n",
+    "    max_seq_length = 0\n",
+    "    with jsonlines.open(path, mode=\"w\") as writer:\n",
+    "        for in_dict in data_iter:\n",
+    "            # in_dict = json.loads(line)\n",
+    "            out_dict = dict()\n",
+    "            rlabel = in_dict[\"gold_label\"]\n",
+    "            if rlabel in LABEL_DICT:\n",
+    "                rsentence1 = in_dict[\"sentence1\"]\n",
+    "                rsentence2 = in_dict[\"sentence2\"]\n",
+    "                for idx, sentence in enumerate([rsentence1, rsentence2]):\n",
+    "                    # print(count, sentence)\n",
+    "                    s = sentence_to_integers(sentence, tokenizer, word_to_id)\n",
+    "                    out_dict[f\"in{idx}\"] = s\n",
+    "                    count += 1\n",
+    "                    max_seq_length = max(len(s), max_seq_length)\n",
+    "                out_dict[\"label\"] = resolve_snli_label(rlabel)\n",
+    "                writer.write(out_dict)\n",
+    "            else:\n",
+    "                count += 1\n",
+    "    print(f\"There are in total {count} invalid labels\")\n",
+    "    print(f\"The max length of converted sequence is {max_seq_length}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Generate vocabulary from SNLI data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_snli_full_vocab(dirname=SNLI_PATH, force=True):\n",
+    "    vocab_path = os.path.join(dirname, \"snli-vocab.json\")\n",
+    "    if not os.path.exists(vocab_path) or force:\n",
+    "        data_iter_list = list()\n",
+    "        for fname_suffix in [\"train\", \"test\", \"dev\"]:\n",
+    "            fname = \"snli_1.0_\" + fname_suffix + \".jsonl\"\n",
+    "            data_iter_list.append(read_jsonline(os.path.join(dirname, fname)))\n",
+    "        data_iter = chain(data_iter_list[0], data_iter_list[1], data_iter_list[2])\n",
+    "        with open(vocab_path, \"w\") as write_file:\n",
+    "            word_to_id = build_vocab(\n",
+    "                data_iter, num_words=50000, min_count=1, use_reserved_symbols=False, sort=True\n",
+    "            )\n",
+    "            json.dump(word_to_id, write_file)\n",
+    "\n",
+    "\n",
+    "make_snli_full_vocab(force=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Generate tokenized SNLI data as sequences of integers\n",
+    "- We use the SNLI vocabulary as a lookup dictionary to convert SNLI sentence pairs into sequences of integers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_snli_data(dirname=SNLI_PATH, vocab_file=\"snli-vocab.json\", outfile_suffix=\"\", force=True):\n",
+    "    for fname_suffix in [\"train\", \"test\", \"validation\"]:\n",
+    "        outpath = os.path.join(dirname, f\"snli-integer-{fname_suffix}-{outfile_suffix}.jsonl\")\n",
+    "        if not os.path.exists(outpath) or force:\n",
+    "            if fname_suffix == \"validation\":\n",
+    "                inpath = os.path.join(dirname, f\"snli_1.0_dev.jsonl\")\n",
+    "            else:\n",
+    "                inpath = os.path.join(dirname, f\"snli_1.0_{fname_suffix}.jsonl\")\n",
+    "            data_iter = read_jsonline(inpath)\n",
+    "            vocab_path = os.path.join(dirname, vocab_file)\n",
+    "            with open(vocab_path, \"r\") as f:\n",
+    "                word_to_id = json.load(f)\n",
+    "            convert_snli_to_integers(\n",
+    "                data_iter,\n",
+    "                word_to_id,\n",
+    "                dirname=dirname,\n",
+    "                fname_suffix=f\"{fname_suffix}-{outfile_suffix}\",\n",
+    "            )\n",
+    "\n",
+    "\n",
+    "make_snli_data(force=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Model training and inference"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Training"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_vocab_size(vocab_path):\n",
+    "    with open(vocab_path) as f:\n",
+    "        word_to_id = json.load(f)\n",
+    "        return len(word_to_id.keys())\n",
+    "\n",
+    "\n",
+    "vocab_path = os.path.join(SNLI_PATH, \"snli-vocab.json\")\n",
+    "vocab_size = get_vocab_size(vocab_path)\n",
+    "print(\"There are {} words in vocabulary {}\".format(vocab_size, vocab_path))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For the runs in this notebook, we will use the Hierarchical CNN architecture to encode each of the sentences into fixed length embeddings. Some of the other hyperparameters are shown below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Define hyperparameters and define S3 input path\n",
+    "DEFAULT_HP = {\n",
+    "    \"enc_dim\": 4096,\n",
+    "    \"mlp_dim\": 512,\n",
+    "    \"mlp_activation\": \"linear\",\n",
+    "    \"mlp_layers\": 2,\n",
+    "    \"output_layer\": \"softmax\",\n",
+    "    \"optimizer\": \"adam\",\n",
+    "    \"learning_rate\": 0.0004,\n",
+    "    \"mini_batch_size\": 32,\n",
+    "    \"epochs\": 20,\n",
+    "    \"bucket_width\": 0,\n",
+    "    \"early_stopping_tolerance\": 0.01,\n",
+    "    \"early_stopping_patience\": 3,\n",
+    "    \"dropout\": 0,\n",
+    "    \"weight_decay\": 0,\n",
+    "    \"enc0_max_seq_len\": 82,\n",
+    "    \"enc1_max_seq_len\": 82,\n",
+    "    \"enc0_network\": \"hcnn\",\n",
+    "    \"enc1_network\": \"enc0\",\n",
+    "    \"enc0_token_embedding_dim\": 300,\n",
+    "    \"enc0_layers\": \"auto\",\n",
+    "    \"enc0_cnn_filter_width\": 3,\n",
+    "    \"enc1_token_embedding_dim\": 300,\n",
+    "    \"enc1_layers\": \"auto\",\n",
+    "    \"enc1_cnn_filter_width\": 3,\n",
+    "    \"enc0_vocab_file\": \"\",\n",
+    "    \"enc1_vocab_file\": \"\",\n",
+    "    \"enc0_vocab_size\": vocab_size,\n",
+    "    \"enc1_vocab_size\": vocab_size,\n",
+    "    \"num_classes\": 3,\n",
+    "    \"_num_gpus\": \"auto\",\n",
+    "    \"_num_kv_servers\": \"auto\",\n",
+    "    \"_kvstore\": \"device\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define input data channel and output path in S3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from sagemaker.core.helper.session_helper import Session\n",
+    "\n",
+    "sess = Session()\n",
+    "bucket = sess.default_bucket()\n",
+    "default_bucket_prefix = sess.default_bucket_prefix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Input data bucket and prefix\n",
+    "prefix = \"object2vec/input/\"\n",
+    "\n",
+    "# If a default bucket prefix is specified, append it to the s3 path\n",
+    "if default_bucket_prefix:\n",
+    "    prefix = f\"{default_bucket_prefix}/{prefix}\"\n",
+    "\n",
+    "input_path = os.path.join(\"s3://\", bucket, prefix)\n",
+    "print(f\"Data path for training is {input_path}\")\n",
+    "## Output path\n",
+    "output_prefix = \"object2vec/output/\"\n",
+    "output_bucket = bucket\n",
+    "output_path = os.path.join(\"s3://\", output_bucket, output_prefix)\n",
+    "print(f\"Trained model will be saved at {output_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Initialize SageMaker training job configuration\n",
+    "- Get IAM role and the ObjectToVec algorithm container image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "from sagemaker.core.helper.session_helper import get_execution_role\n",
+    "\n",
+    "role = get_execution_role()\n",
+    "print(role)\n",
+    "\n",
+    "## Get docker image of ObjectToVec algorithm\n",
+    "from sagemaker.core import image_uris\n",
+    "\n",
+    "region = boto3.Session().region_name\n",
+    "container = image_uris.retrieve(\"object2vec\", region)\n",
+    "print(f\"Using SageMaker Object2Vec container: {container} ({region})\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.core.shapes import Channel, DataSource, S3DataSource\n",
+    "\n",
+    "\n",
+    "def set_training_environment(\n",
+    "    bucket,\n",
+    "    prefix,\n",
+    "    base_hyperparameters=DEFAULT_HP,\n",
+    "    is_quick_run=True,\n",
+    "    is_pretrain=False,\n",
+    "    use_all_vocab={},\n",
+    "):\n",
+    "    \"\"\"Upload data to S3 and build V3 sagemaker-core input Channels.\n",
+    "\n",
+    "    Returns (hyperparameters, input_channels) where input_channels is a list\n",
+    "    of sagemaker.core.shapes.Channel objects consumed by TrainingJob.create.\n",
+    "    \"\"\"\n",
+    "    input_channels = []\n",
+    "    s3_client = boto3.client(\"s3\")\n",
+    "    for split in [\"train\", \"validation\"]:\n",
+    "        if is_pretrain:\n",
+    "            fname_in = f\"all_vocab_datasets/snli-integer-{split}-pretrain.jsonl\"\n",
+    "            fname_out = f\"{split}/snli-integer-{split}-pretrain.jsonl\"\n",
+    "        else:\n",
+    "            fname_in = os.path.join(SNLI_PATH, f\"snli-integer-{split}-.jsonl\")\n",
+    "            fname_out = f\"{split}/snli-integer-{split}.jsonl\"\n",
+    "\n",
+    "        s3_client.upload_file(fname_in, bucket, os.path.join(prefix, fname_out))\n",
+    "        input_channels.append(\n",
+    "            Channel(\n",
+    "                channel_name=split,\n",
+    "                data_source=DataSource(\n",
+    "                    s3_data_source=S3DataSource(\n",
+    "                        s3_data_type=\"S3Prefix\",\n",
+    "                        s3_uri=input_path + fname_out,\n",
+    "                        s3_data_distribution_type=\"ShardedByS3Key\",\n",
+    "                    )\n",
+    "                ),\n",
+    "                content_type=\"application/jsonlines\",\n",
+    "            )\n",
+    "        )\n",
+    "\n",
+    "        print(\"Uploaded {} data to {}\".format(split, input_path + fname_out))\n",
+    "\n",
+    "    hyperparameters = base_hyperparameters.copy()\n",
+    "\n",
+    "    if use_all_vocab:\n",
+    "        hyperparameters[\"enc0_vocab_file\"] = \"all_vocab.json\"\n",
+    "        hyperparameters[\"enc1_vocab_file\"] = \"all_vocab.json\"\n",
+    "        hyperparameters[\"enc0_vocab_size\"] = use_all_vocab[\"vocab_size\"]\n",
+    "        hyperparameters[\"enc1_vocab_size\"] = use_all_vocab[\"vocab_size\"]\n",
+    "\n",
+    "    if is_pretrain:\n",
+    "        ## set up auxliary channel\n",
+    "        aux_path = os.path.join(prefix, \"auxiliary\")\n",
+    "        # upload auxiliary files\n",
+    "        assert os.path.exists(\"GloVe/glove.840B-trim.txt\"), \"Pretrained embedding does not exist!\"\n",
+    "        s3_client.upload_file(\n",
+    "            \"GloVe/glove.840B-trim.txt\", bucket, os.path.join(aux_path, \"glove.840B-trim.txt\")\n",
+    "        )\n",
+    "        if use_all_vocab:\n",
+    "            s3_client.upload_file(\n",
+    "                \"all_vocab_datasets/all_vocab.json\",\n",
+    "                bucket,\n",
+    "                os.path.join(aux_path, \"all_vocab.json\"),\n",
+    "            )\n",
+    "        else:\n",
+    "            s3_client.upload_file(\n",
+    "                \"snli_1.0/snli-vocab.json\", bucket, os.path.join(aux_path, \"snli-vocab.json\")\n",
+    "            )\n",
+    "\n",
+    "        input_channels.append(\n",
+    "            Channel(\n",
+    "                channel_name=\"auxiliary\",\n",
+    "                data_source=DataSource(\n",
+    "                    s3_data_source=S3DataSource(\n",
+    "                        s3_data_type=\"S3Prefix\",\n",
+    "                        s3_uri=\"s3://\" + bucket + \"/\" + aux_path,\n",
+    "                        s3_data_distribution_type=\"FullyReplicated\",\n",
+    "                    )\n",
+    "                ),\n",
+    "                content_type=\"application/json\",\n",
+    "            )\n",
+    "        )\n",
+    "\n",
+    "        print(\n",
+    "            \"Uploaded auxiliary data for initializing with pretrain-embedding to {}\".format(\n",
+    "                aux_path\n",
+    "            )\n",
+    "        )\n",
+    "\n",
+    "        # add pretrained_embedding_file name to hyperparameters\n",
+    "        for idx in [0, 1]:\n",
+    "            hyperparameters[f\"enc{idx}_pretrained_embedding_file\"] = \"glove.840B-trim.txt\"\n",
+    "\n",
+    "    if is_quick_run:\n",
+    "        hyperparameters[\"mini_batch_size\"] = 8192\n",
+    "        hyperparameters[\"enc_dim\"] = 16\n",
+    "        hyperparameters[\"epochs\"] = 2\n",
+    "    else:\n",
+    "        hyperparameters[\"mini_batch_size\"] = 256\n",
+    "        hyperparameters[\"enc_dim\"] = 8192\n",
+    "        hyperparameters[\"epochs\"] = 20\n",
+    "\n",
+    "    # sagemaker-core requires hyperparameter values to be strings\n",
+    "    hyperparameters = {k: str(v) for k, v in hyperparameters.items()}\n",
+    "    return hyperparameters, input_channels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Train without using pretrained embedding"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from time import gmtime, strftime\n",
+    "from sagemaker.core.resources import TrainingJob\n",
+    "from sagemaker.core.shapes import (\n",
+    "    AlgorithmSpecification,\n",
+    "    ResourceConfig,\n",
+    "    StoppingCondition,\n",
+    "    OutputDataConfig,\n",
+    ")\n",
+    "\n",
+    "## set up training environment\n",
+    "\"\"\"\n",
+    "- To get good training result, set is_quick_run to False\n",
+    "- To test-run the algorithm quickly, set is_quick_run to True\n",
+    "\"\"\"\n",
+    "hyperparameters, input_channels = set_training_environment(\n",
+    "    bucket, prefix, is_quick_run=True, is_pretrain=False, use_all_vocab={}\n",
+    ")\n",
+    "hyperparameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "training_job_name = f\"object2vec-snli-{strftime('%Y-%m-%d-%H-%M-%S', gmtime())}\"\n",
+    "\n",
+    "training_job = TrainingJob.create(\n",
+    "    training_job_name=training_job_name,\n",
+    "    hyper_parameters=hyperparameters,\n",
+    "    algorithm_specification=AlgorithmSpecification(\n",
+    "        training_image=container,\n",
+    "        training_input_mode=\"File\",\n",
+    "    ),\n",
+    "    role_arn=role,\n",
+    "    input_data_config=input_channels,\n",
+    "    output_data_config=OutputDataConfig(s3_output_path=output_path),\n",
+    "    resource_config=ResourceConfig(\n",
+    "        instance_type=\"ml.p2.xlarge\",\n",
+    "        instance_count=1,\n",
+    "        volume_size_in_gb=30,\n",
+    "    ),\n",
+    "    stopping_condition=StoppingCondition(max_runtime_in_seconds=360000),\n",
+    ")\n",
+    "\n",
+    "training_job.wait(logs=True)\n",
+    "print(training_job.training_job_status)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot evaluation metrics for training job\n",
+    "\n",
+    "Evaluation metrics for the completed training job are available in CloudWatch. We can pull the cross entropy metric of the validation data set and plot it to see the performance of the model over time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import time\n",
+    "import pandas as pd\n",
+    "from datetime import datetime, timezone\n",
+    "\n",
+    "# sagemaker.analytics is not available in V3; pull the training metric directly\n",
+    "# from CloudWatch (namespace /aws/sagemaker/TrainingJobs) using boto3 instead.\n",
+    "metric_name = \"validation:cross_entropy\"\n",
+    "cw = boto3.client(\"cloudwatch\", region_name=region)\n",
+    "\n",
+    "tj = TrainingJob.get(training_job_name)\n",
+    "start_time = tj.training_start_time or tj.creation_time\n",
+    "end_time = tj.training_end_time or datetime.now(timezone.utc)\n",
+    "\n",
+    "response = cw.get_metric_statistics(\n",
+    "    Namespace=\"/aws/sagemaker/TrainingJobs\",\n",
+    "    MetricName=metric_name,\n",
+    "    Dimensions=[{\"Name\": \"TrainingJobName\", \"Value\": training_job_name}],\n",
+    "    StartTime=start_time,\n",
+    "    EndTime=end_time,\n",
+    "    Period=60,\n",
+    "    Statistics=[\"Average\"],\n",
+    ")\n",
+    "\n",
+    "datapoints = sorted(response[\"Datapoints\"], key=lambda d: d[\"Timestamp\"])\n",
+    "if datapoints:\n",
+    "    metrics_dataframe = pd.DataFrame(\n",
+    "        [{\"timestamp\": d[\"Timestamp\"], \"value\": d[\"Average\"]} for d in datapoints]\n",
+    "    )\n",
+    "    plt = metrics_dataframe.plot(\n",
+    "        kind=\"line\", figsize=(12, 5), x=\"timestamp\", y=\"value\", style=\"b.\", legend=False\n",
+    "    )\n",
+    "    plt.set_ylabel(metric_name)\n",
+    "else:\n",
+    "    print(f\"No CloudWatch datapoints found yet for {metric_name}.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Deploy trained algorithm and set input-output configuration for inference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.core.resources import Model, EndpointConfig, Endpoint\n",
+    "from sagemaker.core.shapes import ContainerDefinition, ProductionVariant\n",
+    "\n",
+    "suffix = strftime(\"%Y-%m-%d-%H-%M-%S\", gmtime())\n",
+    "model_name_1 = f\"object2vec-snli-{suffix}-model\"\n",
+    "endpoint_config_name_1 = f\"object2vec-snli-{suffix}-config\"\n",
+    "endpoint_name_1 = f\"object2vec-snli-{suffix}\"\n",
+    "\n",
+    "# Fetch the trained model artifacts from the training job.\n",
+    "model_data_1 = TrainingJob.get(training_job_name).model_artifacts.s3_model_artifacts\n",
+    "\n",
+    "model_1 = Model.create(\n",
+    "    model_name=model_name_1,\n",
+    "    primary_container=ContainerDefinition(\n",
+    "        image=container,\n",
+    "        model_data_url=model_data_1,\n",
+    "    ),\n",
+    "    execution_role_arn=role,\n",
+    ")\n",
+    "\n",
+    "endpoint_config_1 = EndpointConfig.create(\n",
+    "    endpoint_config_name=endpoint_config_name_1,\n",
+    "    production_variants=[\n",
+    "        ProductionVariant(\n",
+    "            variant_name=\"AllTraffic\",\n",
+    "            model_name=model_name_1,\n",
+    "            instance_type=\"ml.m4.xlarge\",\n",
+    "            initial_instance_count=1,\n",
+    "            initial_variant_weight=1,\n",
+    "        )\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "predictor1 = Endpoint.create(\n",
+    "    endpoint_name=endpoint_name_1,\n",
+    "    endpoint_config_name=endpoint_config_name_1,\n",
+    ")\n",
+    "predictor1.wait_for_status(\"InService\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "\n",
+    "def o2v_predict(endpoint, payload):\n",
+    "    \"\"\"Invoke an Object2Vec endpoint with a JSON payload and decode the JSON response.\"\"\"\n",
+    "    response = endpoint.invoke(\n",
+    "        body=json.dumps(payload).encode(\"utf-8\"),\n",
+    "        content_type=\"application/json\",\n",
+    "        accept=\"application/json\",\n",
+    "    ).body.read()\n",
+    "    return json.loads(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Invoke endpoint and do inference with trained model\n",
+    "- Suppose we deploy our trained model with the endpoint_name \"seqseq-prelim-with-pretrain-3\". Now we demonstrate how to do inference using our earlier model "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def calc_prediction_accuracy(predictions, labels):\n",
+    "    loss = 0\n",
+    "    for idx, s_and_l in enumerate(zip(predictions[\"predictions\"], labels)):\n",
+    "        score, label = s_and_l\n",
+    "        plabel = np.argmax(score[\"scores\"])\n",
+    "        loss += int(plabel != label[\"label\"])\n",
+    "    return 1 - loss / len(labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Send mini-batches of SNLI test data to the endpoint and evaluate our model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "\n",
+    "# load SNLI test data\n",
+    "snli_test_path = os.path.join(SNLI_PATH, \"snli-integer-test-.jsonl\")\n",
+    "test_data_content = list()\n",
+    "test_label = list()\n",
+    "\n",
+    "for line in read_jsonline(snli_test_path):\n",
+    "    test_data_content.append({\"in0\": line[\"in0\"], \"in1\": line[\"in1\"]})\n",
+    "    test_label.append({\"label\": line[\"label\"]})\n",
+    "\n",
+    "print(\"Evaluating test results on SNLI without pre-trained embedding...\")\n",
+    "\n",
+    "\n",
+    "batch_size = 100\n",
+    "n_test = len(test_label)\n",
+    "n_batches = math.ceil(n_test / float(batch_size))\n",
+    "start = 0\n",
+    "agg_acc = 0\n",
+    "for idx in range(n_batches):\n",
+    "    if idx % 10 == 0:\n",
+    "        print(f\"Evaluating the {idx+1}-th batch\")\n",
+    "    end = (start + batch_size) if (start + batch_size) <= n_test else n_test\n",
+    "    payload = {\"instances\": test_data_content[start:end]}\n",
+    "    acc = calc_prediction_accuracy(o2v_predict(predictor1, payload), test_label[start:end])\n",
+    "    agg_acc += acc * (end - start + 1)\n",
+    "    start = end\n",
+    "print(f\"The test accuracy is {agg_acc/n_test}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Transfer learning\n",
+    "- We evaluate the trained model directly on STS16 **question-question** task\n",
+    "- See SemEval-2016 Task 1 paper (http://www.aclweb.org/anthology/S16-1081) for an explanation of the evaluation method and benchmarking results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The cells below provide details on how to combine vocabulary for STS and SNLI,and how to get glove pretrained embedding"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Functions to generate STS evaluation set (from sts-2016-test set)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def loadSTSFile(fpath=STS_PATH, datasets=[\"question-question\"]):\n",
+    "    data = {}\n",
+    "    for dataset in datasets:\n",
+    "        sent1 = []\n",
+    "        sent2 = []\n",
+    "        for line in (\n",
+    "            io.open(fpath + f\"/STS2016.input.{dataset}.txt\", encoding=\"utf8\").read().splitlines()\n",
+    "        ):\n",
+    "            splitted = line.split(\"\\t\")\n",
+    "            sent1.append(splitted[0])\n",
+    "            sent2.append(splitted[1])\n",
+    "\n",
+    "        raw_scores = np.array(\n",
+    "            [\n",
+    "                x\n",
+    "                for x in io.open(fpath + f\"/STS2016.gs.{dataset}.txt\", encoding=\"utf8\")\n",
+    "                .read()\n",
+    "                .splitlines()\n",
+    "            ]\n",
+    "        )\n",
+    "\n",
+    "        not_empty_idx = raw_scores != \"\"\n",
+    "\n",
+    "        gs_scores = [float(x) for x in raw_scores[not_empty_idx]]\n",
+    "        sent1 = np.array(sent1)[not_empty_idx]\n",
+    "        sent2 = np.array(sent2)[not_empty_idx]\n",
+    "\n",
+    "        data[dataset] = (sent1, sent2, gs_scores)\n",
+    "\n",
+    "    return data\n",
+    "\n",
+    "\n",
+    "def get_sts_data_iterator(fpath=STS_PATH, datasets=[\"question-question\"]):\n",
+    "    data = loadSTSFile(fpath, datasets)\n",
+    "    for dataset in datasets:\n",
+    "        sent1, sent2, _ = data[dataset]\n",
+    "        for s1, s2 in zip(sent1, sent2):\n",
+    "            yield [s1, s2]\n",
+    "\n",
+    "\n",
+    "## preprocessing unit for STS test data\n",
+    "\n",
+    "\n",
+    "def convert_single_sts_to_integers(s1, s2, gs_label, tokenizer, word_dict):\n",
+    "    converted = []\n",
+    "    for s in [s1, s2]:\n",
+    "        converted.append(sentence_to_integers(s, tokenizer, word_dict))\n",
+    "    converted.append(gs_label)\n",
+    "    return converted\n",
+    "\n",
+    "\n",
+    "def convert_sts_to_integers(sent1, sent2, gs_labels, tokenizer, word_dict):\n",
+    "    for s1, s2, gs in zip(sent1, sent2, gs_labels):\n",
+    "        yield convert_single_sts_to_integers(s1, s2, gs, tokenizer, word_dict)\n",
+    "\n",
+    "\n",
+    "def make_sts_data(\n",
+    "    fpath=STS_PATH,\n",
+    "    vocab_path_prefix=SNLI_PATH,\n",
+    "    vocab_name=\"snli-vocab.json\",\n",
+    "    dataset=\"question-question\",\n",
+    "):\n",
+    "    \"\"\"\n",
+    "    prepare test data; example: test_data['left'] = [{'in0':[1,2,3]}, {'in0':[2,10]}, ...]\n",
+    "    \"\"\"\n",
+    "    test_data = {\"left\": [], \"right\": []}\n",
+    "    test_label = list()\n",
+    "    tokenizer = TreebankWordTokenizer()\n",
+    "    vocab_path = os.path.join(vocab_path_prefix, vocab_name)\n",
+    "    with open(vocab_path) as f:\n",
+    "        word_dict = json.load(f)\n",
+    "    data = loadSTSFile(fpath=fpath, datasets=[dataset])\n",
+    "    for s1, s2, gs in convert_sts_to_integers(*data[dataset], tokenizer, word_dict):\n",
+    "        test_data[\"left\"].append({\"in1\": s1})\n",
+    "        test_data[\"right\"].append({\"in1\": s2})\n",
+    "        test_label.append(gs)\n",
+    "    return test_data, test_label"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note, in `make_sts_data`, we pass both inputs (s1 and s2 to a single encoder; in this case, we pass them to 'in1'). This makes sure that both inputs are mapped by the same encoding function (we empirically found that this is crucial to achieve competitive embedding performance)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Build vocabulary using STS corpus"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_sts_full_vocab(dirname=STS_PATH, datasets=[\"question-question\"], force=True):\n",
+    "    vocab_path = os.path.join(dirname, \"sts-vocab.json\")\n",
+    "    if not os.path.exists(vocab_path) or force:\n",
+    "        data_iter = get_sts_data_iterator(dirname, datasets)\n",
+    "        with open(vocab_path, \"w\") as write_file:\n",
+    "            word_to_id = build_vocab(\n",
+    "                data_iter,\n",
+    "                dataname=\"sts\",\n",
+    "                num_words=50000,\n",
+    "                min_count=1,\n",
+    "                use_reserved_symbols=False,\n",
+    "                sort=True,\n",
+    "            )\n",
+    "\n",
+    "            json.dump(word_to_id, write_file)\n",
+    "\n",
+    "\n",
+    "make_sts_full_vocab(force=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Define functions for embedding evaluation on STS16 question-question task"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scipy.stats import pearsonr, spearmanr\n",
+    "import math\n",
+    "\n",
+    "\n",
+    "def wrap_sts_test_data_for_eval(\n",
+    "    fpath=STS_PATH, vocab_path_prefix=\".\", vocab_name=\"all_vocab.json\", dataset=\"question-question\"\n",
+    "):\n",
+    "    \"\"\"\n",
+    "    Prepare data for evaluation\n",
+    "    \"\"\"\n",
+    "    test_data, test_label = make_sts_data(fpath, vocab_path_prefix, vocab_name, dataset)\n",
+    "    input1 = {\"instances\": test_data[\"left\"]}\n",
+    "    input2 = {\"instances\": test_data[\"right\"]}\n",
+    "    return [input1, input2, test_label]\n",
+    "\n",
+    "\n",
+    "def get_cosine_similarity(vec1, vec2):\n",
+    "    assert len(vec1) == len(vec2), \"Vector dimension mismatch!\"\n",
+    "    norm1 = 0\n",
+    "    norm2 = 0\n",
+    "    inner_product = 0\n",
+    "    for v1, v2 in zip(vec1, vec2):\n",
+    "        norm1 += v1**2\n",
+    "        norm2 += v2**2\n",
+    "        inner_product += v1 * v2\n",
+    "    return inner_product / math.sqrt(norm1 * norm2)\n",
+    "\n",
+    "\n",
+    "def eval_corr(predictor, eval_data):\n",
+    "    \"\"\"\n",
+    "    input:\n",
+    "    param: predictor: Sagemaker deployed model\n",
+    "    eval_data: a list of [input1, inpu2, gs_scores]\n",
+    "    Evaluate pearson and spearman correlation between algorithm's embedding and gold standard\n",
+    "    \"\"\"\n",
+    "    sys_scores = []\n",
+    "    input1, input2, gs_scores = (\n",
+    "        eval_data[0],\n",
+    "        eval_data[1],\n",
+    "        eval_data[2],\n",
+    "    )  # get this from make_sts_data\n",
+    "    embeddings = []\n",
+    "    for data in [input1, input2]:\n",
+    "        prediction = o2v_predict(predictor, data)\n",
+    "        embeddings.append(prediction[\"predictions\"])\n",
+    "\n",
+    "    for emb_pair in zip(embeddings[0], embeddings[1]):\n",
+    "        emb1 = emb_pair[0][\"embeddings\"]\n",
+    "        emb2 = emb_pair[1][\"embeddings\"]\n",
+    "        sys_scores.append(get_cosine_similarity(emb1, emb2))  # TODO: implement this\n",
+    "\n",
+    "    results = {\n",
+    "        \"pearson\": pearsonr(sys_scores, gs_scores),\n",
+    "        \"spearman\": spearmanr(sys_scores, gs_scores),\n",
+    "        \"nsamples\": len(sys_scores),\n",
+    "    }\n",
+    "    return results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Check overlap between SNLI and STS vocabulary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "snli_vocab_path = os.path.join(SNLI_PATH, \"snli-vocab.json\")\n",
+    "sts_vocab_path = os.path.join(STS_PATH, \"sts-vocab.json\")\n",
+    "\n",
+    "with open(sts_vocab_path) as f:\n",
+    "    sts_v = json.load(f)\n",
+    "with open(snli_vocab_path) as f:\n",
+    "    snli_v = json.load(f)\n",
+    "\n",
+    "sts_v_set = set(sts_v.keys())\n",
+    "snli_v_set = set(snli_v.keys())\n",
+    "\n",
+    "print(len(sts_v_set))\n",
+    "not_captured = sts_v_set.difference(snli_v_set)\n",
+    "print(not_captured)\n",
+    "print(f\"\\nThe number of words in STS not included in SNLI is {len(not_captured)}\")\n",
+    "print(\n",
+    "    f\"\\nThis is {round(float(len(not_captured)/len(sts_v_set)), 2)} percent of the total STS vocabulary\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Since the percentage of vocabulary in STS not covered by SNLI is pretty large, we are going to include the uncovered words into our vocabulary and use the *GloVe* pretrained embedding to initialize our network. \n",
+    "\n",
+    "##### Intuitive reasoning for why this works\n",
+    "\n",
+    "* Our algorithm will not have seen the ***uncovered words*** during training\n",
+    "* If we directly use integer representation of words during training, the unseen words will have zero correlation with words seen. \n",
+    "  - This means the model cannot embed the unseen words in a manner that takes advantage of its training knowledge\n",
+    "* However, if we use pre-trained word embedding, then we expect that some of the unseen words will be close to the words that the algorithm has seen in the embedding space "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def combine_vocabulary(vocab_paths, new_vocab_path):\n",
+    "    wd_count = 0\n",
+    "    all_vocab = set()\n",
+    "    new_vocab = {}\n",
+    "    for vocab_path in vocab_paths:\n",
+    "        with open(vocab_path) as f:\n",
+    "            vocab = json.load(f)\n",
+    "            all_vocab = all_vocab.union(vocab.keys())\n",
+    "    for idx, wd in enumerate(all_vocab):\n",
+    "        new_vocab[wd] = idx\n",
+    "    print(f\"The new vocabulary size is {idx+1}\")\n",
+    "    with open(new_vocab_path, \"w\") as f:\n",
+    "        json.dump(new_vocab, f)\n",
+    "\n",
+    "\n",
+    "vocab_paths = [snli_vocab_path, sts_vocab_path]\n",
+    "new_vocab_path = \"all_vocab.json\"\n",
+    "\n",
+    "combine_vocabulary(vocab_paths, new_vocab_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get pre-trained GloVe word embedding and upload it to S3\n",
+    "\n",
+    "- Our notebook storage is not enough to host the *GloVe* file. Fortunately, we have extra space in the `/tmp` folder that we can utilize: https://docs.aws.amazon.com/sagemaker/latest/dg/howitworks-create-ws.html\n",
+    "- You may use the bash script below to download and unzip *GloVe* in the `/tmp` folder and remove it after use"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "# download glove file from website\n",
+    "mkdir /tmp/GloVe\n",
+    "curl -Lo /tmp/GloVe/glove.840B.zip http://nlp.stanford.edu/data/glove.840B.300d.zip\n",
+    "unzip /tmp/GloVe/glove.840B.zip -d /tmp/GloVe/\n",
+    "rm /tmp/GloVe/glove.840B.zip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We next trim the original *GloVe* embedding file so that it just covers our combined vocabulary, and then we save the trimmed glove file in the newly created *GloVe* directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!mkdir GloVe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "# credit: This preprocessing function is modified from the w2v preprocessing script in Facebook infersent codebase\n",
+    "# Infersent code license can be found at: https://github.com/facebookresearch/InferSent/blob/master/LICENSE\n",
+    "\n",
+    "\n",
+    "def trim_w2v(in_path, out_path, word_dict):\n",
+    "    # create word_vec with w2v vectors\n",
+    "    lines = []\n",
+    "    with open(out_path, \"w\") as outfile:\n",
+    "        with open(in_path) as f:\n",
+    "            for line in f:\n",
+    "                word, vec = line.split(\" \", 1)\n",
+    "                if word in word_dict:\n",
+    "                    lines.append(line)\n",
+    "\n",
+    "        print(\"Found %s(/%s) words with w2v vectors\" % (len(lines), len(word_dict)))\n",
+    "        outfile.writelines(lines)\n",
+    "\n",
+    "\n",
+    "in_path = \"/tmp/GloVe/glove.840B.300d.txt\"\n",
+    "out_path = \"GloVe/glove.840B-trim.txt\"\n",
+    "with open(\"all_vocab.json\") as f:\n",
+    "    word_dict = json.load(f)\n",
+    "\n",
+    "trim_w2v(in_path, out_path, word_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# remember to remove the original GloVe embedding folder since it takes up a lot of space\n",
+    "!rm -r /tmp/GloVe/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reprocess training data (SNLI) with the combined vocabulary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create a new directory called `all_vocab_datasets`, and copy snli raw json files and all_vocab file to it"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "mkdir all_vocab_datasets\n",
+    "\n",
+    "for SPLIT in train dev test\n",
+    "do\n",
+    "    cp snli_1.0/snli_1.0_${SPLIT}.jsonl all_vocab_datasets/\n",
+    "done\n",
+    "\n",
+    "cp all_vocab.json all_vocab_datasets/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Convert snli data to integers using the all_vocab file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "make_snli_data(\n",
+    "    dirname=\"all_vocab_datasets\",\n",
+    "    vocab_file=\"all_vocab.json\",\n",
+    "    outfile_suffix=\"pretrain\",\n",
+    "    force=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's see the size of this new vocabulary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_vocab_path = \"all_vocab.json\"\n",
+    "all_vocab_size = get_vocab_size(all_vocab_path)\n",
+    "print(\"There are {} words in vocabulary {}\".format(all_vocab_size, all_vocab_path))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Reset training environment"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that when we combine the vocabulary of our training and test data, we should not fine-tune the GloVE embeddings, but instead, keep them fixed. Otherwise, it amounts to a bit of cheating -- training on test data! Thankfully, our hyper-parameter `enc0/1_freeze_pretrained_embedding` is set to `True` by default. Note that in the earlier training where we did not use pretrained embeddings, this parameter is inconsequential."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hyperparameters_2, input_channels_2 = set_training_environment(\n",
+    "    bucket,\n",
+    "    prefix,\n",
+    "    is_quick_run=True,\n",
+    "    is_pretrain=True,\n",
+    "    use_all_vocab={\"vocab_size\": all_vocab_size},\n",
+    ")\n",
+    "\n",
+    "# In V3 there is no estimator.attach: we simply launch a new TrainingJob with the\n",
+    "# pretrain hyperparameters and the auxiliary (GloVe) channel added above.\n",
+    "training_job_name_2 = f\"object2vec-snli-pretrain-{strftime('%Y-%m-%d-%H-%M-%S', gmtime())}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "# fit the new job using the new data (with pretrained embedding)\n",
+    "training_job_2 = TrainingJob.create(\n",
+    "    training_job_name=training_job_name_2,\n",
+    "    hyper_parameters=hyperparameters_2,\n",
+    "    algorithm_specification=AlgorithmSpecification(\n",
+    "        training_image=container,\n",
+    "        training_input_mode=\"File\",\n",
+    "    ),\n",
+    "    role_arn=role,\n",
+    "    input_data_config=input_channels_2,\n",
+    "    output_data_config=OutputDataConfig(s3_output_path=output_path),\n",
+    "    resource_config=ResourceConfig(\n",
+    "        instance_type=\"ml.p2.xlarge\",\n",
+    "        instance_count=1,\n",
+    "        volume_size_in_gb=30,\n",
+    "    ),\n",
+    "    stopping_condition=StoppingCondition(max_runtime_in_seconds=360000),\n",
+    ")\n",
+    "\n",
+    "training_job_2.wait(logs=True)\n",
+    "print(training_job_2.training_job_status)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Deploy and test the new model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "suffix2 = strftime(\"%Y-%m-%d-%H-%M-%S\", gmtime())\n",
+    "model_name_2 = f\"object2vec-snli-pretrain-{suffix2}-model\"\n",
+    "endpoint_config_name_2 = f\"object2vec-snli-pretrain-{suffix2}-config\"\n",
+    "endpoint_name_2 = f\"object2vec-snli-pretrain-{suffix2}\"\n",
+    "\n",
+    "model_data_2 = TrainingJob.get(training_job_name_2).model_artifacts.s3_model_artifacts\n",
+    "\n",
+    "model_2 = Model.create(\n",
+    "    model_name=model_name_2,\n",
+    "    primary_container=ContainerDefinition(\n",
+    "        image=container,\n",
+    "        model_data_url=model_data_2,\n",
+    "    ),\n",
+    "    execution_role_arn=role,\n",
+    ")\n",
+    "\n",
+    "endpoint_config_2 = EndpointConfig.create(\n",
+    "    endpoint_config_name=endpoint_config_name_2,\n",
+    "    production_variants=[\n",
+    "        ProductionVariant(\n",
+    "            variant_name=\"AllTraffic\",\n",
+    "            model_name=model_name_2,\n",
+    "            instance_type=\"ml.m4.xlarge\",\n",
+    "            initial_instance_count=1,\n",
+    "            initial_variant_weight=1,\n",
+    "        )\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "predictor_2 = Endpoint.create(\n",
+    "    endpoint_name=endpoint_name_2,\n",
+    "    endpoint_config_name=endpoint_config_name_2,\n",
+    ")\n",
+    "predictor_2.wait_for_status(\"InService\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We first check the test error on SNLI after adding pretrained embedding"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load SNLI test data\n",
+    "snli_test_path = os.path.join(\"all_vocab_datasets\", \"snli-integer-test-pretrain.jsonl\")\n",
+    "test_data_content = list()\n",
+    "test_label = list()\n",
+    "\n",
+    "for line in read_jsonline(snli_test_path):\n",
+    "    test_data_content.append({\"in0\": line[\"in0\"], \"in1\": line[\"in1\"]})\n",
+    "    test_label.append({\"label\": line[\"label\"]})\n",
+    "\n",
+    "print(\"Evaluating test results on SNLI with pre-trained embedding...\")\n",
+    "\n",
+    "batch_size = 100\n",
+    "n_test = len(test_label)\n",
+    "n_batches = math.ceil(n_test / float(batch_size))\n",
+    "start = 0\n",
+    "agg_acc = 0\n",
+    "for idx in range(n_batches):\n",
+    "    if idx % 10 == 0:\n",
+    "        print(f\"Evaluating the {idx+1}-th batch\")\n",
+    "    end = (start + batch_size) if (start + batch_size) <= n_test else n_test\n",
+    "    payload = {\"instances\": test_data_content[start:end]}\n",
+    "    acc = calc_prediction_accuracy(o2v_predict(predictor_2, payload), test_label[start:end])\n",
+    "    agg_acc += acc * (end - start + 1)\n",
+    "    start = end\n",
+    "print(f\"The test accuracy is {agg_acc/n_test}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "We next test the zero-shot transfer learning performance of our trained model on STS task"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eval_data_qq = wrap_sts_test_data_for_eval(\n",
+    "    fpath=STS_PATH,\n",
+    "    vocab_path_prefix=\"all_vocab_datasets\",\n",
+    "    vocab_name=\"all_vocab.json\",\n",
+    "    dataset=\"question-question\",\n",
+    ")\n",
+    "\n",
+    "results = eval_corr(predictor_2, eval_data_qq)\n",
+    "\n",
+    "pcorr = results[\"pearson\"][0]\n",
+    "spcorr = results[\"spearman\"][0]\n",
+    "print(f\"The Pearson correlation to gold standard labels is {pcorr}\")\n",
+    "print(f\"The Spearman correlation to gold standard labels is {spcorr}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## clean up\n",
+    "predictor1.delete()\n",
+    "endpoint_config_1.delete()\n",
+    "model_1.delete()\n",
+    "\n",
+    "predictor_2.delete()\n",
+    "endpoint_config_2.delete()\n",
+    "model_2.delete()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## How to enable the optimal training result "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So far we have been training the algorithm with `is_quick_run` set to `True` (in `set_training_envirnoment` function); this is because we want to minimize the time for you to run through this notebook. If you want to yield the best performance of *Object2Vec* on the tasks above, we recommend setting `is_quick_run` to `False`. For example, with pretrained embedding used, we would re-run the code block under **Reset training environment** as the block below"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<span style=\"color:red\">Run with caution</span>: \n",
+    "This may take a few hours to complete depending on the machine instance you are using"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hyperparameters_2, input_channels_2 = set_training_environment(\n",
+    "    bucket,\n",
+    "    prefix,\n",
+    "    is_quick_run=False,  # modify is_quick_run flag here\n",
+    "    is_pretrain=True,\n",
+    "    use_all_vocab={\"vocab_size\": all_vocab_size},\n",
+    ")\n",
+    "\n",
+    "# In V3, launch a new TrainingJob with the full-run hyperparameters (no estimator.attach).\n",
+    "training_job_name_full = f\"object2vec-snli-pretrain-full-{strftime('%Y-%m-%d-%H-%M-%S', gmtime())}\"\n",
+    "training_job_full = TrainingJob.create(\n",
+    "    training_job_name=training_job_name_full,\n",
+    "    hyper_parameters=hyperparameters_2,\n",
+    "    algorithm_specification=AlgorithmSpecification(\n",
+    "        training_image=container,\n",
+    "        training_input_mode=\"File\",\n",
+    "    ),\n",
+    "    role_arn=role,\n",
+    "    input_data_config=input_channels_2,\n",
+    "    output_data_config=OutputDataConfig(s3_output_path=output_path),\n",
+    "    resource_config=ResourceConfig(\n",
+    "        instance_type=\"ml.p2.xlarge\",\n",
+    "        instance_count=1,\n",
+    "        volume_size_in_gb=30,\n",
+    "    ),\n",
+    "    stopping_condition=StoppingCondition(max_runtime_in_seconds=360000),\n",
+    ")\n",
+    "# training_job_full.wait(logs=True)  # uncomment to run (may take a few hours)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then we can train and deploy the model as before; similarly, without pretrained embedding, the code block under **Train without using pretrained embedding** can be changed to below to optimize training result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<span style=\"color:red\">Run with caution</span>: \n",
+    "This may take a few hours to complete depending on the machine instance you are using"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hyperparameters, input_channels = set_training_environment(\n",
+    "    bucket,\n",
+    "    prefix,\n",
+    "    is_quick_run=False,  # modify is_quick_run flag here\n",
+    "    is_pretrain=False,\n",
+    "    use_all_vocab={},\n",
+    ")\n",
+    "\n",
+    "# In V3, launch a new TrainingJob with the full-run hyperparameters.\n",
+    "training_job_name_full_nopretrain = (\n",
+    "    f\"object2vec-snli-full-{strftime('%Y-%m-%d-%H-%M-%S', gmtime())}\"\n",
+    ")\n",
+    "training_job_full_nopretrain = TrainingJob.create(\n",
+    "    training_job_name=training_job_name_full_nopretrain,\n",
+    "    hyper_parameters=hyperparameters,\n",
+    "    algorithm_specification=AlgorithmSpecification(\n",
+    "        training_image=container,\n",
+    "        training_input_mode=\"File\",\n",
+    "    ),\n",
+    "    role_arn=role,\n",
+    "    input_data_config=input_channels,\n",
+    "    output_data_config=OutputDataConfig(s3_output_path=output_path),\n",
+    "    resource_config=ResourceConfig(\n",
+    "        instance_type=\"ml.p2.xlarge\",\n",
+    "        instance_count=1,\n",
+    "        volume_size_in_gb=30,\n",
+    "    ),\n",
+    "    stopping_condition=StoppingCondition(max_runtime_in_seconds=360000),\n",
+    ")\n",
+    "# training_job_full_nopretrain.wait(logs=True)  # uncomment to run (may take a few hours)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Best training result\n",
+    "\n",
+    "With `is_quick_run = False` and without pretrained embedding, our algorithm's test accuracy on SNLI dataset is 78.5%; with pretrained GloVe embedding, we see an improved test accuracy on SNLI dataset to 81.9% ! On STS data, you should expect the Pearson correlation to be around 0.61.\n",
+    "\n",
+    "In addition to the training demonstrated in this notebook, we have also done benchmarking experiments on evaluated on both SNLI and STS data, with different hyperparameter configurations, which we include below.\n",
+    "\n",
+    "In both charts, we compare against Facebook's Infersent algorithm (https://research.fb.com/downloads/infersent/). The chart on the left shows the additional experiment result on SNLI (using CNN or RNN encoders). The chart on the right shows the best experiment result of Object2Vec on STS."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<img style=\"float:left\" src=\"o2v-exp-snli.png\" width=\"430\"> \n",
+    "<img style=\"float:middle\" src=\"o2v-exp-sts.png\" width=\"430\">"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Hyperparameter Tuning (Advanced) \n",
+    "with Hyperparameter Optimization (HPO) service in Sagemaker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To yield optimal performance out of any machine learning algorithm often requires a lot of effort on parameter tuning. \n",
+    "In this notebook demo, we have hidden the hard work of finding a combination of good parameters for the algorithm on SNLI data (again, the optimal parameters are only defined by running `set_training_environment` method with `is_quick_run=False`).\n",
+    "\n",
+    "If you are keen to explore how to tune HP on your own, you may find the code blocks below helpful."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To find the best HP combinations for our task, we can do parameter tuning by launching HPO jobs either from \n",
+    "- As a simple example, we demonstrate how to find the best `enc_dim` parameter using HPO service here"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3_uri_path = {}\n",
+    "\n",
+    "for split in [\"train\", \"validation\"]:\n",
+    "    s3_uri_path[split] = input_path + f\"{split}/snli-integer-{split}.jsonl\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "On a high level, a HPO tuning job is nothing but a collection of multiple training jobs with different HP setups; Sagemaker HPO service compares the performance of different training jobs according to the **HPO tuning metric**, which is specified in the `tuning_job_config`.\n",
+    "\n",
+    "- More info on how to manually launch hpo tuning jobs can be found here: \n",
+    "https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-ex-tuning-job.html"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.core.shapes import (\n",
+    "    HyperParameterTuningJobConfig,\n",
+    "    ParameterRanges,\n",
+    "    IntegerParameterRange,\n",
+    "    ResourceLimits,\n",
+    "    HyperParameterTuningJobObjective,\n",
+    ")\n",
+    "\n",
+    "tuning_job_config = HyperParameterTuningJobConfig(\n",
+    "    strategy=\"Bayesian\",\n",
+    "    hyper_parameter_tuning_job_objective=HyperParameterTuningJobObjective(\n",
+    "        type=\"Maximize\",\n",
+    "        metric_name=\"validation:accuracy\",\n",
+    "    ),\n",
+    "    resource_limits=ResourceLimits(\n",
+    "        max_number_of_training_jobs=3,\n",
+    "        max_parallel_training_jobs=3,\n",
+    "    ),\n",
+    "    parameter_ranges=ParameterRanges(\n",
+    "        categorical_parameter_ranges=[],\n",
+    "        continuous_parameter_ranges=[],\n",
+    "        integer_parameter_ranges=[\n",
+    "            IntegerParameterRange(name=\"enc_dim\", min_value=\"16\", max_value=\"1024\"),\n",
+    "        ],\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The tuning metric `MetricName` we use here is called `validation:accuracy`, together with `Type` set to `Maximize`, since we are trying to maximize accuracy here (in case you want to minimize mean squared error, you can switch the tuning objective accordingly to `validation:mean_squared_error` and `Minimize`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The syntax for defining the configuration of an individual training job in a HPO job is as below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.core.shapes import (\n",
+    "    HyperParameterTrainingJobDefinition,\n",
+    "    HyperParameterAlgorithmSpecification,\n",
+    ")\n",
+    "\n",
+    "training_job_definition = HyperParameterTrainingJobDefinition(\n",
+    "    algorithm_specification=HyperParameterAlgorithmSpecification(\n",
+    "        training_image=container,\n",
+    "        training_input_mode=\"File\",\n",
+    "    ),\n",
+    "    input_data_config=[\n",
+    "        Channel(\n",
+    "            channel_name=\"train\",\n",
+    "            data_source=DataSource(\n",
+    "                s3_data_source=S3DataSource(\n",
+    "                    s3_data_type=\"S3Prefix\",\n",
+    "                    s3_uri=s3_uri_path[\"train\"],\n",
+    "                    s3_data_distribution_type=\"FullyReplicated\",\n",
+    "                )\n",
+    "            ),\n",
+    "            content_type=\"application/jsonlines\",\n",
+    "            compression_type=\"None\",\n",
+    "        ),\n",
+    "        Channel(\n",
+    "            channel_name=\"validation\",\n",
+    "            data_source=DataSource(\n",
+    "                s3_data_source=S3DataSource(\n",
+    "                    s3_data_type=\"S3Prefix\",\n",
+    "                    s3_uri=s3_uri_path[\"validation\"],\n",
+    "                    s3_data_distribution_type=\"FullyReplicated\",\n",
+    "                )\n",
+    "            ),\n",
+    "            content_type=\"application/jsonlines\",\n",
+    "            compression_type=\"None\",\n",
+    "        ),\n",
+    "    ],\n",
+    "    output_data_config=OutputDataConfig(s3_output_path=output_path),\n",
+    "    resource_config=ResourceConfig(\n",
+    "        instance_type=\"ml.p3.8xlarge\",\n",
+    "        instance_count=1,\n",
+    "        volume_size_in_gb=20,\n",
+    "    ),\n",
+    "    role_arn=role,\n",
+    "    static_hyper_parameters={\n",
+    "        \"learning_rate\": \"0.0004\",\n",
+    "        \"mlp_dim\": \"512\",\n",
+    "        \"mlp_activation\": \"linear\",\n",
+    "        \"mlp_layers\": \"2\",\n",
+    "        \"output_layer\": \"softmax\",\n",
+    "        \"optimizer\": \"adam\",\n",
+    "        \"mini_batch_size\": \"8192\",\n",
+    "        \"epochs\": \"2\",\n",
+    "        \"bucket_width\": \"0\",\n",
+    "        \"early_stopping_tolerance\": \"0.01\",\n",
+    "        \"early_stopping_patience\": \"3\",\n",
+    "        \"dropout\": \"0\",\n",
+    "        \"weight_decay\": \"0\",\n",
+    "        \"enc0_max_seq_len\": \"82\",\n",
+    "        \"enc1_max_seq_len\": \"82\",\n",
+    "        \"enc0_network\": \"hcnn\",\n",
+    "        \"enc1_network\": \"enc0\",\n",
+    "        \"enc0_token_embedding_dim\": \"300\",\n",
+    "        \"enc0_layers\": \"auto\",\n",
+    "        \"enc0_cnn_filter_width\": \"3\",\n",
+    "        \"enc1_token_embedding_dim\": \"300\",\n",
+    "        \"enc1_layers\": \"auto\",\n",
+    "        \"enc1_cnn_filter_width\": \"3\",\n",
+    "        \"enc0_vocab_file\": \"\",\n",
+    "        \"enc1_vocab_file\": \"\",\n",
+    "        \"enc0_vocab_size\": str(vocab_size),\n",
+    "        \"enc1_vocab_size\": str(vocab_size),\n",
+    "        \"num_classes\": \"3\",\n",
+    "        \"_num_gpus\": \"auto\",\n",
+    "        \"_num_kv_servers\": \"auto\",\n",
+    "        \"_kvstore\": \"device\",\n",
+    "    },\n",
+    "    stopping_condition=StoppingCondition(max_runtime_in_seconds=43200),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.core.resources import HyperParameterTuningJob"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Disclaimer\n",
+    "\n",
+    "Running HPO tuning jobs means dispatching multiple training jobs with different HP setups; this could potentially incur a significant cost on your AWS account if you use the HP combinations that takes long hours to train.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tuning_job_name = \"hpo-o2v-test-{}\".format(datetime.now().strftime(\"%d%m%Y-%H-%M-%S\"))\n",
+    "tuning_job = HyperParameterTuningJob.create(\n",
+    "    hyper_parameter_tuning_job_name=tuning_job_name,\n",
+    "    hyper_parameter_tuning_job_config=tuning_job_config,\n",
+    "    training_job_definition=training_job_definition,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can then view and track the hyperparameter tuning jobs you launched on the sagemaker console (using the same account that you used to create the sagemaker client to launch these jobs)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Notebook CI Test Results\n",
+    "\n",
+    "This notebook was tested in multiple regions. The test results are as follows, except for us-west-2 which is shown at the top of the notebook.\n",
+    "\n",
+    "![This us-east-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-east-1/build_and_train_models|sm-introduction_to_object2vec_sentence_similarity|sm-introduction_to_object2vec_sentence_similarity.ipynb)\n",
+    "\n",
+    "![This us-east-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-east-2/build_and_train_models|sm-introduction_to_object2vec_sentence_similarity|sm-introduction_to_object2vec_sentence_similarity.ipynb)\n",
+    "\n",
+    "![This us-west-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-west-1/build_and_train_models|sm-introduction_to_object2vec_sentence_similarity|sm-introduction_to_object2vec_sentence_similarity.ipynb)\n",
+    "\n",
+    "![This ca-central-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ca-central-1/build_and_train_models|sm-introduction_to_object2vec_sentence_similarity|sm-introduction_to_object2vec_sentence_similarity.ipynb)\n",
+    "\n",
+    "![This sa-east-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/sa-east-1/build_and_train_models|sm-introduction_to_object2vec_sentence_similarity|sm-introduction_to_object2vec_sentence_similarity.ipynb)\n",
+    "\n",
+    "![This eu-west-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-1/build_and_train_models|sm-introduction_to_object2vec_sentence_similarity|sm-introduction_to_object2vec_sentence_similarity.ipynb)\n",
+    "\n",
+    "![This eu-west-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-2/build_and_train_models|sm-introduction_to_object2vec_sentence_similarity|sm-introduction_to_object2vec_sentence_similarity.ipynb)\n",
+    "\n",
+    "![This eu-west-3 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-3/build_and_train_models|sm-introduction_to_object2vec_sentence_similarity|sm-introduction_to_object2vec_sentence_similarity.ipynb)\n",
+    "\n",
+    "![This eu-central-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-central-1/build_and_train_models|sm-introduction_to_object2vec_sentence_similarity|sm-introduction_to_object2vec_sentence_similarity.ipynb)\n",
+    "\n",
+    "![This eu-north-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-north-1/build_and_train_models|sm-introduction_to_object2vec_sentence_similarity|sm-introduction_to_object2vec_sentence_similarity.ipynb)\n",
+    "\n",
+    "![This ap-southeast-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-southeast-1/build_and_train_models|sm-introduction_to_object2vec_sentence_similarity|sm-introduction_to_object2vec_sentence_similarity.ipynb)\n",
+    "\n",
+    "![This ap-southeast-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-southeast-2/build_and_train_models|sm-introduction_to_object2vec_sentence_similarity|sm-introduction_to_object2vec_sentence_similarity.ipynb)\n",
+    "\n",
+    "![This ap-northeast-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-northeast-1/build_and_train_models|sm-introduction_to_object2vec_sentence_similarity|sm-introduction_to_object2vec_sentence_similarity.ipynb)\n",
+    "\n",
+    "![This ap-northeast-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-northeast-2/build_and_train_models|sm-introduction_to_object2vec_sentence_similarity|sm-introduction_to_object2vec_sentence_similarity.ipynb)\n",
+    "\n",
+    "![This ap-south-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-south-1/build_and_train_models|sm-introduction_to_object2vec_sentence_similarity|sm-introduction_to_object2vec_sentence_similarity.ipynb)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "kernelspec": {
+   "display_name": "Python 3 (Data Science 3.0)",
+   "language": "python",
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/sagemaker-data-science-310-v1"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/      build_and_train_models/sm-jax_bring_your_own/sm-jax_bring_your_own-v3.ipynb
+++ b/      build_and_train_models/sm-jax_bring_your_own/sm-jax_bring_your_own-v3.ipynb
@@ -1,0 +1,507 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Training and Deploying ML Models using JAX on SageMaker (SDK v3)\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "This notebook's CI test result for us-west-2 is as follows. CI test results in other regions can be found at the end of the notebook. \n",
+    "\n",
+    "![This us-west-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-west-2/build_and_train_models|sm-jax_bring_your_own|sm-jax_bring_your_own.ipynb)\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Amazon SageMaker provides you the flexibility to train models using our pre-built machine learning containers or your own bespoke container. We'll refer to these strategies as Bring-Your-Own-Script **(BYOS)** and Bring-Your-Own-Container **(BYOC)** in this tutorial. \n",
+    "\n",
+    "### Bring Your Own JAX Script\n",
+    "\n",
+    "In this notebook, we'll show how to extend our optimized TensorFlow containers to train machine learning models using the increasingly popular [JAX library](https://github.com/google/jax). We'll train a fashion MNIST classification model using vanilla JAX, another using `jax.experimental.stax`, and a final model using the [higher level Trax library](https://github.com/google/trax).\n",
+    "\n",
+    "For all three patterns, we'll show how the JAX models can be serialized as standard TensorFlow [SavedModel format](https://www.tensorflow.org/guide/saved_model). This enables us to seamlessly deploy the models using the managed and optimized SageMaker TensorFlow inference containers.\n",
+    "\n",
+    "### Bring Your Own JAX Container\n",
+    "\n",
+    "We've included a dockerfile in this repo directory to show how you can build your own bespoke JAX container with support for GPUs on SageMaker. Unfortunately, the NVIDIA/CUDA Dockerhub containers have a [deletion policy](https://gitlab.com/nvidia/container-images/cuda/blob/master/doc/support-policy.md), so we're unable to assert that the container can be built through time. Nonetheless, you can trivially adapt a newer version of the container if your workload requires a custom container. For more information on running BYOC on SageMaker see the [documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/adapt-training-container.html).\n",
+    "\n",
+    "### SDK v3 note\n",
+    "\n",
+    "This notebook uses the **SageMaker Python SDK v3** APIs. The V2 framework estimator `sagemaker.tensorflow.TensorFlow` is replaced by `sagemaker.train.ModelTrainer` combined with `sagemaker.core.image_uris.retrieve` to select the managed TensorFlow container. Deployment uses the `sagemaker-core` resource classes (`Model`, `EndpointConfig`, `Endpoint`) instead of the V2 `estimator.deploy()` / `Predictor` pattern. The container-side training scripts in `training_scripts/` and their `requirements.txt` (which installs JAX) are unchanged."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install --upgrade 'sagemaker>=3.0'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from time import gmtime, strftime\n",
+    "\n",
+    "from sagemaker.train import ModelTrainer\n",
+    "from sagemaker.train.configs import SourceCode, Compute\n",
+    "from sagemaker.core import image_uris\n",
+    "from sagemaker.core.shapes import StoppingCondition\n",
+    "from sagemaker.core.helper.session_helper import Session, get_execution_role\n",
+    "\n",
+    "sess = Session()\n",
+    "role = get_execution_role()\n",
+    "region = sess.boto_region_name\n",
+    "print(f\"Region: {region}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Installing JAX in SageMaker TensorFlow Containers\n",
+    "\n",
+    "When using BYOS with managed SageMaker containers, you can trivially install extra dependencies by providing a `requirements.txt` within the `source_dir` that contains your training scripts. At runtime these dependencies will be installed prior to executing the training script, so we can utilize our optimized TensorFlow GPU container to utilize JAX with CUDA support.\n",
+    "\n",
+    "To be specific, any container that has the [sagemaker-training-toolkit](https://github.com/aws/sagemaker-training-toolkit) supports installing additional dependencies from `requirements.txt`. In the SDK v3 `ModelTrainer`, the `requirements.txt` path is passed via the `requirements` field of `SourceCode`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Serializing models as SavedModel format\n",
+    "In the upcoming training jobs we'll be training a vanilla JAX model, a Stax model, and a Trax model on the [fashion MNIST dataset](https://github.com/zalandoresearch/fashion-mnist).\n",
+    "The full details of the model can be seen in the `training_scripts/` directory, but it is worth calling out the methods for serialization.\n",
+    "\n",
+    "The JAX/Stax models utilize the new jax2tf converter: https://github.com/google/jax/tree/master/jax/experimental/jax2tf\n",
+    "\n",
+    "```python\n",
+    "def save_model_tf(prediction_function, params_to_save):\n",
+    "    tf_fun = jax2tf.convert(prediction_function, enable_xla=False)\n",
+    "    param_vars = tf.nest.map_structure(lambda param: tf.Variable(param), params_to_save)\n",
+    "\n",
+    "    tf_graph = tf.function(\n",
+    "        lambda inputs: tf_fun(param_vars, inputs),\n",
+    "        autograph=False,\n",
+    "        jit_compile=False,\n",
+    "    )\n",
+    "\n",
+    "```\n",
+    "\n",
+    "\n",
+    "The Trax model utilizes the new trax2keras functionality: https://github.com/google/trax/blob/master/trax/trax2keras.py\n",
+    "\n",
+    "```python\n",
+    "def save_model_tf(model_to_save):\n",
+    "    \"\"\"\n",
+    "    Serialize a TensorFlow graph from trained Trax Model\n",
+    "    :param model_to_save: Trax Model\n",
+    "    \"\"\"\n",
+    "    keras_layer = trax.AsKeras(model_to_save, batch_size=1)\n",
+    "    inputs = tf.keras.Input(shape=(28, 28, 1))\n",
+    "    hidden = keras_layer(inputs)\n",
+    "\n",
+    "    keras_model = tf.keras.Model(inputs=inputs, outputs=hidden)\n",
+    "    keras_model.save(\"/opt/ml/model/1\", save_format=\"tf\")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Retrieve the managed TensorFlow training and inference images\n",
+    "\n",
+    "In V2 the `TensorFlow` estimator resolved the container image automatically from `framework_version` / `py_version`. In V3 we retrieve the image URI explicitly with `image_uris.retrieve` and pass it to `ModelTrainer`. We retrieve both the training image (used to run the JAX scripts) and the inference image (managed TF Serving, used to host the SavedModel)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TF_FRAMEWORK_VERSION = \"2.10\"\n",
+    "TF_PY_VERSION = \"py39\"\n",
+    "TRAIN_INSTANCE_TYPE = \"ml.p3.2xlarge\"\n",
+    "INFERENCE_INSTANCE_TYPE = \"ml.m4.xlarge\"\n",
+    "\n",
+    "training_image = image_uris.retrieve(\n",
+    "    framework=\"tensorflow\",\n",
+    "    region=region,\n",
+    "    version=TF_FRAMEWORK_VERSION,\n",
+    "    py_version=TF_PY_VERSION,\n",
+    "    instance_type=TRAIN_INSTANCE_TYPE,\n",
+    "    image_scope=\"training\",\n",
+    ")\n",
+    "\n",
+    "inference_image = image_uris.retrieve(\n",
+    "    framework=\"tensorflow\",\n",
+    "    region=region,\n",
+    "    version=TF_FRAMEWORK_VERSION,\n",
+    "    py_version=TF_PY_VERSION,\n",
+    "    instance_type=INFERENCE_INSTANCE_TYPE,\n",
+    "    image_scope=\"inference\",\n",
+    ")\n",
+    "\n",
+    "print(\"Training image:\", training_image)\n",
+    "print(\"Inference image:\", inference_image)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train using Vanilla JAX\n",
+    "\n",
+    "Note: Our `source_dir` directory contains a `requirements.txt` that will install JAX with CUDA support. We pass it via `SourceCode(requirements=...)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vanilla_jax_trainer = ModelTrainer(\n",
+    "    training_image=training_image,\n",
+    "    role=role,\n",
+    "    base_job_name=\"jax\",\n",
+    "    source_code=SourceCode(\n",
+    "        source_dir=\"training_scripts\",\n",
+    "        entry_script=\"train_jax.py\",\n",
+    "        requirements=\"requirements.txt\",\n",
+    "    ),\n",
+    "    compute=Compute(\n",
+    "        instance_type=TRAIN_INSTANCE_TYPE,\n",
+    "        instance_count=1,\n",
+    "    ),\n",
+    "    stopping_condition=StoppingCondition(max_runtime_in_seconds=3600),\n",
+    "    hyperparameters={\"num_epochs\": 3},\n",
+    "    sagemaker_session=sess,\n",
+    ")\n",
+    "vanilla_jax_trainer.train(logs=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train Using JAX Medium-level API Stax"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stax_trainer = ModelTrainer(\n",
+    "    training_image=training_image,\n",
+    "    role=role,\n",
+    "    base_job_name=\"stax\",\n",
+    "    source_code=SourceCode(\n",
+    "        source_dir=\"training_scripts\",\n",
+    "        entry_script=\"train_stax.py\",\n",
+    "        requirements=\"requirements.txt\",\n",
+    "    ),\n",
+    "    compute=Compute(\n",
+    "        instance_type=TRAIN_INSTANCE_TYPE,\n",
+    "        instance_count=1,\n",
+    "    ),\n",
+    "    stopping_condition=StoppingCondition(max_runtime_in_seconds=3600),\n",
+    "    hyperparameters={\"num_epochs\": 3},\n",
+    "    sagemaker_session=sess,\n",
+    ")\n",
+    "stax_trainer.train(logs=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train Using JAX High-level API Trax"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trax_trainer = ModelTrainer(\n",
+    "    training_image=training_image,\n",
+    "    role=role,\n",
+    "    base_job_name=\"trax\",\n",
+    "    source_code=SourceCode(\n",
+    "        source_dir=\"training_scripts\",\n",
+    "        entry_script=\"train_trax.py\",\n",
+    "        requirements=\"requirements.txt\",\n",
+    "    ),\n",
+    "    compute=Compute(\n",
+    "        instance_type=TRAIN_INSTANCE_TYPE,\n",
+    "        instance_count=1,\n",
+    "    ),\n",
+    "    stopping_condition=StoppingCondition(max_runtime_in_seconds=3600),\n",
+    "    hyperparameters={\"train_steps\": 1000},\n",
+    "    sagemaker_session=sess,\n",
+    ")\n",
+    "trax_trainer.train(logs=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Deploy Models to managed TF Containers\n",
+    "\n",
+    "Since we've serialized the models as TensorFlow SavedModel format, we can host them on the managed TensorFlow Serving inference container. In V3 we do this with the `sagemaker-core` resource classes: we fetch the trained model artifact from each training job, create a `Model`, an `EndpointConfig`, and an `Endpoint`.\n",
+    "\n",
+    "We define a small helper that takes a completed `ModelTrainer` and deploys its output as a real-time endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.core.resources import Model, EndpointConfig, Endpoint\n",
+    "from sagemaker.core.shapes import ContainerDefinition, ProductionVariant\n",
+    "\n",
+    "\n",
+    "def deploy_trainer(trainer, name_prefix):\n",
+    "    \"\"\"Deploy a completed ModelTrainer's SavedModel output to a managed TF Serving endpoint.\"\"\"\n",
+    "    suffix = strftime(\"%Y-%m-%d-%H-%M-%S\", gmtime())\n",
+    "    model_name = f\"{name_prefix}-{suffix}-model\"\n",
+    "    endpoint_config_name = f\"{name_prefix}-{suffix}-config\"\n",
+    "    endpoint_name = f\"{name_prefix}-{suffix}\"\n",
+    "\n",
+    "    # Fetch the trained model artifacts from the training job.\n",
+    "    model_data = trainer._latest_training_job.model_artifacts.s3_model_artifacts\n",
+    "\n",
+    "    Model.create(\n",
+    "        model_name=model_name,\n",
+    "        primary_container=ContainerDefinition(\n",
+    "            image=inference_image,\n",
+    "            model_data_url=model_data,\n",
+    "        ),\n",
+    "        execution_role_arn=role,\n",
+    "    )\n",
+    "\n",
+    "    EndpointConfig.create(\n",
+    "        endpoint_config_name=endpoint_config_name,\n",
+    "        production_variants=[\n",
+    "            ProductionVariant(\n",
+    "                variant_name=\"AllTraffic\",\n",
+    "                model_name=model_name,\n",
+    "                instance_type=INFERENCE_INSTANCE_TYPE,\n",
+    "                initial_instance_count=1,\n",
+    "                initial_variant_weight=1,\n",
+    "            )\n",
+    "        ],\n",
+    "    )\n",
+    "\n",
+    "    endpoint = Endpoint.create(\n",
+    "        endpoint_name=endpoint_name,\n",
+    "        endpoint_config_name=endpoint_config_name,\n",
+    "    )\n",
+    "    endpoint.wait_for_status(\"InService\")\n",
+    "    return endpoint, model_name, endpoint_config_name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vanilla_jax_endpoint, vanilla_jax_model_name, vanilla_jax_config_name = deploy_trainer(\n",
+    "    vanilla_jax_trainer, \"jax\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trax_endpoint, trax_model_name, trax_config_name = deploy_trainer(trax_trainer, \"trax\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stax_endpoint, stax_model_name, stax_config_name = deploy_trainer(stax_trainer, \"stax\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test Inference Endpoints\n",
+    "This requires TF to be installed on your notebook's kernel as it is used to load testing data.\n",
+    "\n",
+    "In V3 we invoke the endpoint with `Endpoint.invoke`, sending the TF Serving JSON payload (`{\"instances\": ...}`) and parsing the `predictions` field from the response."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "import numpy as np\n",
+    "from matplotlib import pyplot as plt\n",
+    "\n",
+    "(x_train, y_train), (x_test, y_test) = tf.keras.datasets.fashion_mnist.load_data()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_image(endpoint, test_images, test_labels, image_number):\n",
+    "    np_img = np.expand_dims(np.expand_dims(test_images[image_number], axis=-1), axis=0).astype(\n",
+    "        \"float32\"\n",
+    "    )\n",
+    "\n",
+    "    payload = {\"instances\": np_img.tolist()}\n",
+    "    response = endpoint.invoke(\n",
+    "        body=json.dumps(payload).encode(\"utf-8\"),\n",
+    "        content_type=\"application/json\",\n",
+    "        accept=\"application/json\",\n",
+    "    ).body.read()\n",
+    "    result = json.loads(response)\n",
+    "    pred_y = np.argmax(result[\"predictions\"])\n",
+    "\n",
+    "    print(\"True Label:\", test_labels[image_number])\n",
+    "    print(\"Predicted Label:\", pred_y)\n",
+    "    plt.imshow(test_images[image_number])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_image(vanilla_jax_endpoint, x_test, y_test, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_image(stax_endpoint, x_test, y_test, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_image(trax_endpoint, x_test, y_test, 0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Optional: Delete the running endpoints"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Clean-Up: delete endpoints, endpoint configs, and models\n",
+    "for endpoint, config_name, model_name in [\n",
+    "    (vanilla_jax_endpoint, vanilla_jax_config_name, vanilla_jax_model_name),\n",
+    "    (stax_endpoint, stax_config_name, stax_model_name),\n",
+    "    (trax_endpoint, trax_config_name, trax_model_name),\n",
+    "]:\n",
+    "    endpoint.delete()\n",
+    "    EndpointConfig.get(config_name).delete()\n",
+    "    Model.get(model_name).delete()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Notebook CI Test Results\n",
+    "\n",
+    "This notebook was tested in multiple regions. The test results are as follows, except for us-west-2 which is shown at the top of the notebook.\n",
+    "\n",
+    "![This us-east-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-east-1/build_and_train_models|sm-jax_bring_your_own|sm-jax_bring_your_own.ipynb)\n",
+    "\n",
+    "![This us-east-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-east-2/build_and_train_models|sm-jax_bring_your_own|sm-jax_bring_your_own.ipynb)\n",
+    "\n",
+    "![This us-west-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-west-1/build_and_train_models|sm-jax_bring_your_own|sm-jax_bring_your_own.ipynb)\n",
+    "\n",
+    "![This ca-central-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ca-central-1/build_and_train_models|sm-jax_bring_your_own|sm-jax_bring_your_own.ipynb)\n",
+    "\n",
+    "![This sa-east-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/sa-east-1/build_and_train_models|sm-jax_bring_your_own|sm-jax_bring_your_own.ipynb)\n",
+    "\n",
+    "![This eu-west-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-1/build_and_train_models|sm-jax_bring_your_own|sm-jax_bring_your_own.ipynb)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "conda_tensorflow2_p310",
+   "language": "python",
+   "name": "conda_tensorflow2_p310"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/      build_and_train_models/sm-jumpstart_private_model_hub_import/sm-jumpstart_private_model_hub_import-v3.ipynb
+++ b/      build_and_train_models/sm-jumpstart_private_model_hub_import/sm-jumpstart_private_model_hub_import-v3.ipynb
@@ -1,0 +1,952 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b3b41849-e88e-49eb-a53e-a89fb6005d8e",
+   "metadata": {},
+   "source": [
+    "# Importing a custom Pytorch model into a SageMaker JumpStart private model hub. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a00e5075",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "This notebook's CI test result for us-west-2 is as follows. CI test results in other regions can be found at the end of the notebook.\n",
+    "\n",
+    "![This us-west-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-west-2/NOTEBOOK_PATH)\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f07eb2c-38f7-48b3-a8cd-b6e52ddb4b1c",
+   "metadata": {},
+   "source": [
+    "This notebook demostrates how to import custom machine learning model into an Amazon SageMaker JumpStart private model hub. We will start by creating a very simple ANN model with Pytorch. This model built from scratch will be our demo model. We will import it in the the model hub. And finally, we will deploy the model from the private model hub.\n",
+    "\n",
+    "The model is a simple ANN model with three fully connected layers. The model takes in 2D input features (X) and predicts a binary classification output (y).The synthetic dataset we're using is generated as follows:\n",
+    "- The input features (X) are randomly generated within the range of [-5, 5] for both dimensions.\n",
+    "- The target labels (y) are assigned based on whether the Euclidean distance of the input feature from the origin (0, 0) is less than 5 or not. If the distance is less than 5, the label is 1, otherwise, it's 0.\n",
+    "\n",
+    "The goal of the model is to learn the underlying relationship between the 2D input features and the binary target labels. The model is trained using the Binary Cross-Entropy loss function and the Adam optimizer.\n",
+    "\n",
+    "\n",
+    "Note: This notebook was tested in Amazon SageMaker Studio on ml.c5.large instance with Python 3 kernel."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9570a9ca-e6d6-43f9-81e5-a1951b243b47",
+   "metadata": {},
+   "source": [
+    "## 1. Set Up\n",
+    "\n",
+    "---\n",
+    "Before executing the notebook, there are some initial steps required for setup.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1c6b002-8dad-401c-bfe1-bc40f476cfd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install the SageMaker Python SDK v3 (sagemaker>=3.0) and restart the kernel afterwards.\n",
+    "# v3 is a modular SDK: sagemaker-core (primitives), sagemaker-train, sagemaker-serve, sagemaker-mlops.\n",
+    "!pip install --upgrade sagemaker boto3 botocore"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3a41c2a-bc24-4d64-b980-e67ce69cad9a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import boto3\n",
+    "import os\n",
+    "import json\n",
+    "import uuid\n",
+    "\n",
+    "# SageMaker Python SDK v3 imports.\n",
+    "from sagemaker.core.helper.session_helper import Session, get_execution_role\n",
+    "\n",
+    "import warnings\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "# A single v3 Session drives region resolution and SageMaker/S3 interactions.\n",
+    "sagemaker_session = Session()\n",
+    "region = sagemaker_session.boto_region_name\n",
+    "print(f\"Region: {region}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a393e03-e77b-45b4-addc-ad9ab4d02e74",
+   "metadata": {},
+   "source": [
+    "## 2. Generate synthetic data for training"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e36b9fc-9e73-4644-bbc1-f926b277e62d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate synthetic dataset\n",
+    "num_samples = 1000\n",
+    "X = np.random.rand(num_samples, 2) * 10 - 5  # Input features (2D)\n",
+    "y = np.where(X[:, 0] ** 2 + X[:, 1] ** 2 < 25, 1.0, 0.0)  # Target labels (binary classification)\n",
+    "\n",
+    "# Convert dataset to PyTorch tensors\n",
+    "X_tensor = torch.tensor(X, dtype=torch.float32)\n",
+    "y_tensor = torch.tensor(y, dtype=torch.float32)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f0af1ba-c0c1-4256-b7b7-7e4fef644bd4",
+   "metadata": {},
+   "source": [
+    "## 3. Define the Pytorch ANN model and training"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea27eba7-417b-482e-b23b-a07c388f7c70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ANN(nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super(ANN, self).__init__()\n",
+    "        self.fc1 = nn.Linear(2, 64)\n",
+    "        self.fc2 = nn.Linear(64, 32)\n",
+    "        self.fc3 = nn.Linear(32, 1)\n",
+    "        self.sigmoid = nn.Sigmoid()\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        x = self.fc1(x)\n",
+    "        x = torch.relu(x)\n",
+    "        x = self.fc2(x)\n",
+    "        x = torch.relu(x)\n",
+    "        x = self.fc3(x)\n",
+    "        x = self.sigmoid(x)\n",
+    "        return x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f755ff7a-6313-4e9b-be91-d4a45bd163e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the model\n",
+    "model = ANN()\n",
+    "\n",
+    "# Define the loss function and optimizer\n",
+    "criterion = nn.BCELoss()\n",
+    "optimizer = torch.optim.Adam(model.parameters(), lr=0.001)\n",
+    "\n",
+    "# Train the model\n",
+    "num_epochs = 1000\n",
+    "for epoch in range(num_epochs):\n",
+    "    # Forward pass\n",
+    "    outputs = model(X_tensor)\n",
+    "    loss = criterion(outputs, y_tensor.unsqueeze(1))\n",
+    "\n",
+    "    # Backward and optimize\n",
+    "    optimizer.zero_grad()\n",
+    "    loss.backward()\n",
+    "    optimizer.step()\n",
+    "\n",
+    "    if (epoch + 1) % 100 == 0:\n",
+    "        print(f\"Epoch [{epoch+1}/{num_epochs}], Loss: {loss.item():.4f}\")\n",
+    "\n",
+    "# Evaluate the model\n",
+    "with torch.no_grad():\n",
+    "    y_pred = (outputs > 0.5).float()\n",
+    "    accuracy = (y_pred == y_tensor.unsqueeze(1)).float().mean()\n",
+    "    print(f\"Accuracy: {accuracy.item():.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45b224f5-093c-4bff-aa58-a574730b5884",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot the decision boundary\n",
+    "plt.figure(figsize=(8, 6))\n",
+    "plt.scatter(X[:, 0], X[:, 1], c=y, cmap=\"viridis\")\n",
+    "\n",
+    "x1 = np.linspace(-5, 5, 100)\n",
+    "x2 = np.linspace(-5, 5, 100)\n",
+    "X1, X2 = np.meshgrid(x1, x2)\n",
+    "\n",
+    "with torch.no_grad():\n",
+    "    Z = model(torch.tensor(np.column_stack((X1.ravel(), X2.ravel())), dtype=torch.float32))\n",
+    "    Z = Z.reshape(X1.shape)\n",
+    "\n",
+    "plt.contourf(X1, X2, Z, levels=[0, 0.5, 1], cmap=\"viridis\", alpha=0.5)\n",
+    "plt.colorbar()\n",
+    "plt.title(\"Decision Boundary\")\n",
+    "plt.xlabel(\"Feature 1\")\n",
+    "plt.ylabel(\"Feature 2\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "71a9e9fb-8b25-4112-9656-e10fc9e15b50",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save the trained model\n",
+    "torch.save(model.state_dict(), \"model.pth\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "029277e2-80ff-470d-abce-2aa72e5571d9",
+   "metadata": {},
+   "source": [
+    "## 4. Creates a new instance of the model and evaluate "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f17518e-1c1f-4f60-bce4-f0f73b072b22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# creates a new instance of the ANN class\n",
+    "model2 = ANN()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c4320d4-5eaa-4a8f-8b45-7037140c89c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# loads the pre-trained model weights from the file 'model.pth' and assigns them to the model2 instance.\n",
+    "# set the model to evaluation mode. PyTorch, models have two modes: training mode and evaluation mode. Training mode is used during the training process, while evaluation mode is used for making predictions.\n",
+    "\n",
+    "model2.load_state_dict(torch.load(\"model.pth\"))\n",
+    "model2.eval()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c452efe-3b91-4a69-b56c-48122018d774",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Prepare the input data for evaluation\n",
+    "X_test = np.random.rand(1, 2) * 10 - 5  # Generate a random test sample\n",
+    "X_tensor = torch.tensor(X_test, dtype=torch.float32)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ef2d231-579c-4be4-984e-76ee5506e6a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run the model inference\n",
+    "with torch.no_grad():\n",
+    "    output = model2(X_tensor)\n",
+    "    y_pred = (output > 0.5).float().item()\n",
+    "\n",
+    "print(f\"Input: {X_test}\")\n",
+    "print(f\"Predicted output: {y_pred}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63f72b52-1aff-4db6-87ec-5f41732f8d07",
+   "metadata": {},
+   "source": [
+    "# 5. Create the model artifact"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "245eebfa-4c81-4ad9-b82c-1f331734f6b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!tar -czf model.tar.gz model.pth code/inference.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43582383-3c8a-437c-a67d-f8b44769ee38",
+   "metadata": {},
+   "source": [
+    "# 6. Deploy the model as a SageMaker Endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8d847bf-e783-4b5b-9113-365ad4aa26ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# v3 deploys a custom (bring-your-own script) model using sagemaker-core resource classes.\n",
+    "# There is no framework-specific PyTorchModel class in v3; instead we retrieve the framework\n",
+    "# inference image with image_uris and describe the container explicitly.\n",
+    "from sagemaker.core import image_uris\n",
+    "from sagemaker.core.resources import Model, EndpointConfig, Endpoint\n",
+    "from sagemaker.core.shapes.shapes import ContainerDefinition, ProductionVariant"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db69e86e-7376-4389-83a2-6fc161a707b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the default SageMaker bucket\n",
+    "default_bucket = sagemaker_session.default_bucket()\n",
+    "print(f\"The default SageMaker bucket is: {default_bucket}\")\n",
+    "\n",
+    "s3 = boto3.resource(\"s3\")\n",
+    "\n",
+    "key = \"demo-model/model.tar.gz\"\n",
+    "\n",
+    "# Upload the model artifact to Amazon S3\n",
+    "s3.Bucket(default_bucket).upload_file(\"model.tar.gz\", key)\n",
+    "\n",
+    "model_data = f\"s3://{default_bucket}/{key}\"\n",
+    "\n",
+    "role = get_execution_role(sagemaker_session)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6e75f49-da94-4295-b97e-96ea95e84e0e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Deploy the custom PyTorch model with sagemaker-core resource classes.\n",
+    "# 1) Retrieve the managed PyTorch inference container image for this region.\n",
+    "# 2) Create a Model whose primary container points at the model artifact and inference.py.\n",
+    "# 3) Create an EndpointConfig + Endpoint from that model.\n",
+    "unique_id = str(uuid.uuid4())[:8]\n",
+    "model_name = f\"custom-pytorch-model-{unique_id}\"\n",
+    "endpoint_name = f\"custom-pytorch-endpoint-{unique_id}\"\n",
+    "\n",
+    "inference_image_uri = image_uris.retrieve(\n",
+    "    framework=\"pytorch\",\n",
+    "    region=region,\n",
+    "    version=\"2.3.0\",\n",
+    "    py_version=\"py311\",\n",
+    "    instance_type=\"ml.m5.xlarge\",\n",
+    "    image_scope=\"inference\",\n",
+    ")\n",
+    "\n",
+    "Model.create(\n",
+    "    model_name=model_name,\n",
+    "    primary_container=ContainerDefinition(\n",
+    "        image=inference_image_uri,\n",
+    "        model_data_url=model_data,\n",
+    "        environment={\n",
+    "            \"SAGEMAKER_PROGRAM\": \"inference.py\",\n",
+    "            \"SAGEMAKER_SUBMIT_DIRECTORY\": model_data,\n",
+    "        },\n",
+    "    ),\n",
+    "    execution_role_arn=role,\n",
+    "    region=region,\n",
+    ")\n",
+    "\n",
+    "EndpointConfig.create(\n",
+    "    endpoint_config_name=endpoint_name,\n",
+    "    production_variants=[\n",
+    "        ProductionVariant(\n",
+    "            variant_name=\"AllTraffic\",\n",
+    "            model_name=model_name,\n",
+    "            initial_instance_count=1,\n",
+    "            instance_type=\"ml.m5.xlarge\",\n",
+    "            initial_variant_weight=1.0,\n",
+    "        )\n",
+    "    ],\n",
+    "    region=region,\n",
+    ")\n",
+    "\n",
+    "endpoint = Endpoint.create(\n",
+    "    endpoint_name=endpoint_name,\n",
+    "    endpoint_config_name=endpoint_name,\n",
+    "    region=region,\n",
+    ")\n",
+    "endpoint.wait_for_status(\"InService\")\n",
+    "\n",
+    "# Get the endpoint name\n",
+    "endpoint_name = endpoint.endpoint_name\n",
+    "\n",
+    "print(f\"The deployed endpoint name is: {endpoint_name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e92d2a9a-b439-48cc-b557-2b388faf4b91",
+   "metadata": {},
+   "source": [
+    "# 7. Performing inference using the SageMaker endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53cc148e-7dc1-4798-914c-6359eb84c20d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the endpoint name\n",
+    "endpoint_name = endpoint_name\n",
+    "\n",
+    "\n",
+    "# Define a function to preprocess the input data\n",
+    "def preprocess_input(X):\n",
+    "    X_tensor = torch.tensor(X, dtype=torch.float32)\n",
+    "    return X_tensor\n",
+    "\n",
+    "\n",
+    "# Define a function to postprocess the model output\n",
+    "def postprocess_output(output):\n",
+    "    y_pred = (output > 0.5).float()\n",
+    "    return y_pred.item()\n",
+    "\n",
+    "\n",
+    "# Prepare the input data\n",
+    "X_test = np.random.rand(1, 2) * 10 - 5  # Generate a random test sample\n",
+    "\n",
+    "# Preprocess the input data\n",
+    "X_tensor = preprocess_input(X_test)\n",
+    "\n",
+    "# Convert the input data to JSON\n",
+    "input_data = {\"features\": X_tensor.tolist()}\n",
+    "payload = json.dumps(input_data)\n",
+    "\n",
+    "# Invoke the SageMaker endpoint with the v3 core Endpoint resource\n",
+    "response = endpoint.invoke(body=payload, content_type=\"application/json\")\n",
+    "\n",
+    "# Postprocess the model output\n",
+    "result = json.loads(response.body.read().decode())\n",
+    "output = postprocess_output(torch.tensor(result[\"output\"]))\n",
+    "\n",
+    "print(f\"Input: {X_test}\")\n",
+    "print(f\"Predicted output: {output}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c5f2507-cb1d-4956-8325-162d7f1309ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# delete the endpoint (and its endpoint config + model) using v3 core resources\n",
+    "\n",
+    "\n",
+    "def del_endpoint(ep_name):\n",
+    "    try:\n",
+    "        ep = Endpoint.get(endpoint_name=ep_name, region=region)\n",
+    "        print(f\"Endpoint '{ep_name}' still exists. Deleting.....\")\n",
+    "        try:\n",
+    "            EndpointConfig.get(endpoint_config_name=ep_name, region=region).delete()\n",
+    "        except Exception:\n",
+    "            pass\n",
+    "        ep.delete()\n",
+    "        print(f\"Endpoint '{ep_name}' has been deleted.\")\n",
+    "    except Exception as e:\n",
+    "        print(f\"Endpoint '{ep_name}' could not be described (likely already deleted): {e}\")\n",
+    "\n",
+    "\n",
+    "del_endpoint(endpoint_name)\n",
+    "\n",
+    "# Clean up the standalone model resource created above\n",
+    "try:\n",
+    "    Model.get(model_name=model_name, region=region).delete()\n",
+    "    print(f\"Model '{model_name}' has been deleted.\")\n",
+    "except Exception as e:\n",
+    "    print(f\"Model '{model_name}' could not be deleted: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91a5a4b8-b630-4dd1-8c12-dad632009510",
+   "metadata": {},
+   "source": [
+    "# 8. Let's import the custom model into the SageMaker Jumpstart private model hub"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00c4c421-f597-4623-afcd-ef33b78401a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# v3: the JumpStart private hub is managed through sagemaker-core.\n",
+    "from sagemaker.core.jumpstart.hub.hub import Hub"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67bd8ae3-deab-48eb-af38-3fc5940a1a88",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Grab the info we need for the hub content document.\n",
+    "model_data = f\"s3://{default_bucket}/{key}\"\n",
+    "\n",
+    "from sagemaker.core import image_uris\n",
+    "\n",
+    "image_uri = image_uris.retrieve(\n",
+    "    framework=\"pytorch\",\n",
+    "    region=region,\n",
+    "    version=\"2.3.0\",\n",
+    "    py_version=\"py311\",\n",
+    "    image_scope=\"inference\",\n",
+    "    instance_type=\"ml.c5.xlarge\",\n",
+    ")\n",
+    "image_uri"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd0d7a00-9fc5-4865-83e8-1ac3a8a3957e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "default_bucket = sagemaker_session.default_bucket()\n",
+    "print(default_bucket)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17746541-73a8-4803-b5a9-c28f6db787ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the private model hub details. Names are suffixed with a unique id so the\n",
+    "# notebook can be re-run without ResourceInUse collisions.\n",
+    "HUB_NAME = f\"Custom-Model-Hub-{unique_id}\"\n",
+    "HUB_DISPLAY_NAME = HUB_NAME\n",
+    "\n",
+    "REGION = region\n",
+    "\n",
+    "# The SageMaker control-plane client used for hub creation and content import.\n",
+    "sm_client = boto3.client(\"sagemaker\", region_name=region)\n",
+    "print(sagemaker_session.get_caller_identity_arn())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "76fe7163-9f08-4158-8d9a-4990eb4636bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the private model hub.\n",
+    "# NOTE: sagemaker-core's Hub.create()/describe() rely on Session.create_hub/describe_hub, which are\n",
+    "# not exposed on the core Session yet, so we use the native boto3 SageMaker CreateHub API directly.\n",
+    "# The boto3 CreateHub/DescribeHub calls are the same control-plane APIs the SDK wraps.\n",
+    "try:\n",
+    "    sm_client.create_hub(\n",
+    "        HubName=HUB_NAME,\n",
+    "        HubDescription=(\n",
+    "            \"This is a Curated Hub. Replace this with a description which explains \"\n",
+    "            \"the purpose of this Hub.\"\n",
+    "        ),\n",
+    "        HubDisplayName=HUB_DISPLAY_NAME,\n",
+    "        S3StorageConfig={\"S3OutputPath\": f\"s3://{default_bucket}/{HUB_NAME}\"},\n",
+    "    )\n",
+    "    print(f\"Successfully created Hub with name {HUB_NAME} in {REGION}\")\n",
+    "except Exception as e:\n",
+    "    if \"ResourceInUse\" in str(e):\n",
+    "        print(f\"A hub with the name {HUB_NAME} already exists in your account.\")\n",
+    "    else:\n",
+    "        raise e\n",
+    "\n",
+    "# Instantiate the core Hub object for subsequent list/describe operations.\n",
+    "hub = Hub(hub_name=HUB_NAME, sagemaker_session=sagemaker_session, bucket_name=default_bucket)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2a075ab-1f5b-4634-ae24-577d706c7089",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# below is a metadata dict for the models in Jumpstart. this information is used while training or hosting the models by Jumpstart.\n",
+    "# you might need to tweek based on the model that you are importing\n",
+    "\n",
+    "hub_model_dict = {\n",
+    "    \"Url\": \"https://anyuniversity.edu\",\n",
+    "    \"MinSdkVersion\": \"2.189.0\",\n",
+    "    \"TrainingSupported\": False,\n",
+    "    \"IncrementalTrainingSupported\": False,\n",
+    "    \"HostingArtifactUri\": model_data,\n",
+    "    \"HostingScriptUri\": model_data,\n",
+    "    \"HostingUseScriptUri\": False,\n",
+    "    \"InferenceDependencies\": [],\n",
+    "    \"InferenceEnvironmentVariables\": [\n",
+    "        {\n",
+    "            \"Name\": \"SAGEMAKER_PROGRAM\",\n",
+    "            \"Type\": \"text\",\n",
+    "            \"Default\": \"inference.py\",\n",
+    "            \"Scope\": \"container\",\n",
+    "            \"RequiredForModelClass\": True,\n",
+    "        },\n",
+    "        {\n",
+    "            \"Name\": \"SAGEMAKER_SUBMIT_DIRECTORY\",\n",
+    "            \"Type\": \"text\",\n",
+    "            \"Default\": model_data,\n",
+    "            \"Scope\": \"container\",\n",
+    "            \"RequiredForModelClass\": False,\n",
+    "        },\n",
+    "        {\n",
+    "            \"Name\": \"TS_MAX_RESPONSE_SIZE\",\n",
+    "            \"Type\": \"text\",\n",
+    "            \"Default\": \"100000000\",\n",
+    "            \"Scope\": \"container\",\n",
+    "            \"RequiredForModelClass\": True,\n",
+    "        },\n",
+    "        {\n",
+    "            \"Name\": \"TS_MAX_REQUEST_SIZE\",\n",
+    "            \"Type\": \"text\",\n",
+    "            \"Default\": \"100000000\",\n",
+    "            \"Scope\": \"container\",\n",
+    "            \"RequiredForModelClass\": True,\n",
+    "        },\n",
+    "    ],\n",
+    "    \"DefaultInferenceInstanceType\": \"ml.c5.4xlarge\",\n",
+    "    \"SupportedInferenceInstanceTypes\": [\"ml.c5.4xlarge\", \"ml.c5.9xlarge\", \"ml.g4dn.2xlarge\"],\n",
+    "    \"InferenceEnableNetworkIsolation\": False,\n",
+    "    \"ValidationSupported\": False,\n",
+    "    \"ResourceNameBase\": \"Custom-Model-Hub1\",\n",
+    "    \"HostingInstanceTypeVariants\": {\n",
+    "        \"Variants\": {\n",
+    "            \"c5\": {\"Properties\": {\"ImageUri\": image_uri}},\n",
+    "            \"ml.c5.4xlarge\": {\"Properties\": {\"ResourceRequirements\": {\"MinMemoryMb\": 16384}}},\n",
+    "            \"ml.c5.9xlarge\": {\"Properties\": {\"ResourceRequirements\": {\"MinMemoryMb\": 32768}}},\n",
+    "        }\n",
+    "    },\n",
+    "    \"HostingArtifactS3DataType\": \"S3Prefix\",\n",
+    "    \"HostingArtifactCompressionType\": \"Gzip\",\n",
+    "    \"HostingResourceRequirements\": {\"MinMemoryMb\": 16384},\n",
+    "    \"DynamicContainerDeploymentSupported\": True,\n",
+    "    \"Dependencies\": [],\n",
+    "    \"HostingEcrUri\": image_uri,\n",
+    "    \"Task\": \"blog model\",\n",
+    "    \"Framework\": \"custom\",\n",
+    "    \"SageMakerSdkPredictorSpecifications\": {\n",
+    "        \"SupportedContentTypes\": [\"application/x-image\"],\n",
+    "        \"SupportedAcceptTypes\": [\n",
+    "            \"application/json\",\n",
+    "            \"application/json;verbose\",\n",
+    "            \"application/json;n_predictions=2\",\n",
+    "        ],\n",
+    "        \"DefaultContentType\": \"application/x-image\",\n",
+    "        \"DefaultAcceptType\": \"application/json\",\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "# Convert the dictionary to a JSON string\n",
+    "hub_doc = json.dumps(hub_model_dict)\n",
+    "\n",
+    "# If you need to parse it back into a dictionary (which you shouldn't need to do in this case)\n",
+    "# hub_model_dict = json.loads(hub_doc)\n",
+    "\n",
+    "print(hub_doc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc2e8e1d-80fd-47d2-971d-36cae2b31c9e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# importing to the hub\n",
+    "\n",
+    "sm_client.import_hub_content(\n",
+    "    HubContentName=\"blog-model-test0213\",\n",
+    "    HubContentType=\"Model\",\n",
+    "    DocumentSchemaVersion=\"2.2.0\",\n",
+    "    HubName=HUB_NAME,\n",
+    "    HubContentDocument=hub_doc,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82113bbc-733e-4355-810f-35edcccf4c8d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# list the models from the private hub\n",
+    "hub.list_models()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a9b75377-43ec-4d8e-89b7-926ae2a603bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# retrieve the HUB's arn via the native DescribeHub API\n",
+    "HUB_ARN = sm_client.describe_hub(HubName=HUB_NAME)[\"HubArn\"]\n",
+    "print(HUB_ARN)\n",
+    "\n",
+    "# get the model id\n",
+    "model_id = hub.list_models()[\"hub_content_summaries\"][0][\"HubContentName\"]\n",
+    "print(model_id)\n",
+    "\n",
+    "# get the model version\n",
+    "version = hub.list_models()[\"hub_content_summaries\"][0][\"HubContentVersion\"]\n",
+    "print(version)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7acac730-686f-4604-a333-33da04d477bd",
+   "metadata": {},
+   "source": [
+    "# 9. Deploy the model from private model hub as a real time inference endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22612990-32ec-464f-8fb2-669d2bd24322",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Deploy the model straight from the private model hub.\n",
+    "#\n",
+    "# NOTE ON THE V3 PATH: the high-level ModelBuilder.from_jumpstart_config() JumpStart path does not\n",
+    "# yet support *custom* content imported into a private hub -- ModelBuilder._is_jumpstart_model_id()\n",
+    "# only checks the public JumpStart catalog and ignores the hub ARN, so a private custom model is\n",
+    "# mis-routed to the HuggingFace path. Until that is supported, we read the model definition back\n",
+    "# from the private hub with DescribeHubContent and deploy it with the sagemaker-core resource\n",
+    "# classes (same primitives used earlier in this notebook).\n",
+    "hub_content = sm_client.describe_hub_content(\n",
+    "    HubName=HUB_NAME,\n",
+    "    HubContentType=\"Model\",\n",
+    "    HubContentName=model_id,\n",
+    "    HubContentVersion=version,\n",
+    ")\n",
+    "hub_doc = json.loads(hub_content[\"HubContentDocument\"])\n",
+    "\n",
+    "# Pull the container image, model artifact, and inference env out of the hub content document.\n",
+    "hub_image_uri = hub_doc[\"HostingEcrUri\"]\n",
+    "hub_model_data = hub_doc[\"HostingArtifactUri\"]\n",
+    "hub_env = {\n",
+    "    v[\"Name\"]: v[\"Default\"]\n",
+    "    for v in hub_doc.get(\"InferenceEnvironmentVariables\", [])\n",
+    "    if \"Default\" in v\n",
+    "}\n",
+    "hub_instance_type = hub_doc.get(\"DefaultInferenceInstanceType\", \"ml.c5.4xlarge\")\n",
+    "\n",
+    "unique_id2 = str(uuid.uuid4())[:8]\n",
+    "hub_model_name = f\"hub-model-{unique_id2}\"\n",
+    "endpoint_name = f\"hub-endpoint-{unique_id2}\"\n",
+    "\n",
+    "core_model = Model.create(\n",
+    "    model_name=hub_model_name,\n",
+    "    primary_container=ContainerDefinition(\n",
+    "        image=hub_image_uri,\n",
+    "        model_data_url=hub_model_data,\n",
+    "        environment=hub_env,\n",
+    "    ),\n",
+    "    execution_role_arn=role,\n",
+    "    region=region,\n",
+    ")\n",
+    "\n",
+    "EndpointConfig.create(\n",
+    "    endpoint_config_name=endpoint_name,\n",
+    "    production_variants=[\n",
+    "        ProductionVariant(\n",
+    "            variant_name=\"AllTraffic\",\n",
+    "            model_name=hub_model_name,\n",
+    "            initial_instance_count=1,\n",
+    "            instance_type=hub_instance_type,\n",
+    "            initial_variant_weight=1.0,\n",
+    "        )\n",
+    "    ],\n",
+    "    region=region,\n",
+    ")\n",
+    "\n",
+    "hub_endpoint = Endpoint.create(\n",
+    "    endpoint_name=endpoint_name,\n",
+    "    endpoint_config_name=endpoint_name,\n",
+    "    region=region,\n",
+    ")\n",
+    "hub_endpoint.wait_for_status(\"InService\")\n",
+    "\n",
+    "endpoint_name = hub_endpoint.endpoint_name\n",
+    "endpoint_name"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd8fff0d-4fc2-4d8c-a60a-ca357d85c271",
+   "metadata": {},
+   "source": [
+    "# 10. Lets invoke the newly deployed endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7caa18a-5784-42b2-80e0-3c9a9da640f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Prepare the input data\n",
+    "X_test = np.random.rand(1, 2) * 10 - 5  # Generate a random test sample\n",
+    "\n",
+    "# Preprocess the input data\n",
+    "X_tensor = preprocess_input(X_test)\n",
+    "\n",
+    "# Convert the input data to JSON\n",
+    "input_data = {\"features\": X_tensor.tolist()}\n",
+    "payload = json.dumps(input_data)\n",
+    "\n",
+    "# Invoke the SageMaker endpoint with the v3 core Endpoint resource\n",
+    "response = hub_endpoint.invoke(body=payload, content_type=\"application/json\")\n",
+    "\n",
+    "# Postprocess the model output\n",
+    "result = json.loads(response.body.read().decode())\n",
+    "output = postprocess_output(torch.tensor(result[\"output\"]))\n",
+    "\n",
+    "print(f\"Input: {X_test}\")\n",
+    "print(f\"Predicted output: {output}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a972d0b2-a159-4b7e-8a5b-128cbacee9aa",
+   "metadata": {},
+   "source": [
+    "# 11. Clean up"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d86317c7-f6c9-4322-88c4-a831bb19e193",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean up the endpoint deployed from the private hub, plus its config and model.\n",
+    "del_endpoint(endpoint_name)\n",
+    "\n",
+    "try:\n",
+    "    core_model.delete()\n",
+    "    print(f\"Model '{core_model.model_name}' has been deleted.\")\n",
+    "except Exception as e:\n",
+    "    print(f\"Hub-deployed model could not be deleted: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09c10aec",
+   "metadata": {},
+   "source": [
+    "## Notebook CI Test Results\n",
+    "\n",
+    "This notebook was tested in multiple regions. The test results are as follows, except for us-west-2 which is shown at the top of the notebook.\n",
+    "\n",
+    "\n",
+    "![This us-east-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-east-1/NOTEBOOK_PATH)\n",
+    "\n",
+    "![This us-east-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-east-2/NOTEBOOK_PATH)\n",
+    "\n",
+    "![This us-west-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-west-1/NOTEBOOK_PATH)\n",
+    "\n",
+    "![This ca-central-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ca-central-1/NOTEBOOK_PATH)\n",
+    "\n",
+    "![This sa-east-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/sa-east-1/NOTEBOOK_PATH)\n",
+    "\n",
+    "![This eu-west-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-1/NOTEBOOK_PATH)\n",
+    "\n",
+    "![This eu-west-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-2/NOTEBOOK_PATH)\n",
+    "\n",
+    "![This eu-west-3 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-3/NOTEBOOK_PATH)\n",
+    "\n",
+    "![This eu-central-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-central-1/NOTEBOOK_PATH)\n",
+    "\n",
+    "![This eu-north-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-north-1/NOTEBOOK_PATH)\n",
+    "\n",
+    "![This ap-southeast-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-southeast-1/NOTEBOOK_PATH)\n",
+    "\n",
+    "![This ap-southeast-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-southeast-2/NOTEBOOK_PATH)\n",
+    "\n",
+    "![This ap-northeast-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-northeast-1/NOTEBOOK_PATH)\n",
+    "\n",
+    "![This ap-northeast-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-northeast-2/NOTEBOOK_PATH)\n",
+    "\n",
+    "![This ap-south-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-south-1/NOTEBOOK_PATH)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/      build_and_train_models/sm-jumpstart_private_model_hub_import/sm-jumpstart_private_model_hub_import_llama3-8B-v3.ipynb
+++ b/      build_and_train_models/sm-jumpstart_private_model_hub_import/sm-jumpstart_private_model_hub_import_llama3-8B-v3.ipynb
@@ -1,0 +1,1774 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Import Fine-tuned LLaMA 3 models on SageMaker JumpStart to private model hub (SageMaker Python SDK v3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0679163a-387a-4ba6-8ce0-d5571614c0dc",
+   "metadata": {
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    },
+    "tags": []
+   },
+   "source": [
+    "This notebook's CI test result for us-west-2 is as follows. CI test results in other regions can be found at the end of the notebook.\n",
+    "\n",
+    "![This us-west-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-west-2/introduction_to_amazon_algorithms|jumpstart-foundation-models|llama-3-finetuning.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "251624f9-1eb6-4051-a774-0a4ba83cabf5",
+   "metadata": {
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "In this demo notebook, we demonstrate how to use the SageMaker Python SDK to deploy pre-trained Llama 3 model as well as fine-tune it for your dataset in domain adaptation or instruction tuning format. We will then import the model into a jumpstart private model hub.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3d9b99d-639b-40f3-91e3-1fe00ee032a4",
+   "metadata": {
+    "collapsed": true,
+    "jp-MarkdownHeadingCollapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    },
+    "tags": []
+   },
+   "source": [
+    "### Model License information\n",
+    "---\n",
+    "To perform inference on these models, you need to pass custom_attributes='accept_eula=true' as part of header. This means you have read and accept the end-user-license-agreement (EULA) of the model. EULA can be found in model card description or from https://ai.meta.com/resources/models-and-libraries/llama-downloads/. By default, this notebook sets custom_attributes='accept_eula=false', so all inference requests will fail until you explicitly change this custom attribute.\n",
+    "\n",
+    "Note: Custom_attributes used to pass EULA are key/value pairs. The key and value are separated by '=' and pairs are separated by ';'. If the user passes the same key more than once, the last value is kept and passed to the script handler (i.e., in this case, used for conditional logic). For example, if 'accept_eula=false; accept_eula=true' is passed to the server, then 'accept_eula=true' is kept and passed to the script handler.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "019c4fcd-d6c5-4381-8425-1d224c0ac197",
+   "metadata": {
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    },
+    "tags": []
+   },
+   "source": [
+    "### Set up\n",
+    "\n",
+    "---\n",
+    "We begin by installing and upgrading necessary packages. Restart the kernel after executing the cell below for the first time.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SageMaker Python SDK v3 is required for this notebook. Install/upgrade it\n",
+    "# together with the datasets library used for dataset preparation.\n",
+    "!pip install --upgrade \"sagemaker>=3.0\" datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56b9122c-a661-4667-bf36-454892567f54",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "import logging\n",
+    "\n",
+    "\n",
+    "# Suppress warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "\n",
+    "# Suppress INFO messages\n",
+    "logging.getLogger().setLevel(logging.ERROR)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13274b9b-87bd-4090-a6aa-294570c31e0e",
+   "metadata": {},
+   "source": [
+    "## Deploy Pre-trained Model\n",
+    "\n",
+    "---\n",
+    "\n",
+    "First we will deploy the Llama-2 model as a SageMaker endpoint. To train/deploy 8B and 70B models, please change model_id to \"meta-textgeneration-llama-3-8b\" and \"meta-textgeneration-llama-3-70b\" respectively.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7e01401-82db-4d49-9457-f930f4138618",
+   "metadata": {
+    "jumpStartAlterations": [
+     "modelIdVersion"
+    ],
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Pin a full semantic version (not a wildcard like \"2.*\"). V3's\n",
+    "# ModelTrainer.from_jumpstart_config validates the JumpStart hub content version\n",
+    "# via describe_hub_content, which requires a full semver (min length 5); a\n",
+    "# wildcard would raise a ParamValidationError on HubContentVersion.\n",
+    "model_id, model_version = \"meta-textgeneration-llama-3-8b\", \"2.9.0\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# V3: deploy a JumpStart model with ModelBuilder.from_jumpstart_config.\n",
+    "# (V2 used sagemaker.jumpstart.model.JumpStartModel, which was removed in V3.)\n",
+    "import uuid\n",
+    "from sagemaker.serve.model_builder import ModelBuilder\n",
+    "from sagemaker.core.jumpstart.configs import JumpStartConfig\n",
+    "from sagemaker.train.configs import Compute\n",
+    "\n",
+    "unique_id = str(uuid.uuid4())[:8]\n",
+    "pretrained_endpoint_name = f\"llama3-8b-pretrained-{unique_id}\"\n",
+    "\n",
+    "# Please set accept_eula=True to accept the model EULA before deploying.\n",
+    "pretrained_config = JumpStartConfig(\n",
+    "    model_id=model_id,\n",
+    "    model_version=model_version,\n",
+    "    accept_eula=True,\n",
+    ")\n",
+    "pretrained_model_builder = ModelBuilder.from_jumpstart_config(\n",
+    "    jumpstart_config=pretrained_config,\n",
+    "    compute=Compute(instance_type=\"ml.g5.2xlarge\"),\n",
+    ")\n",
+    "pretrained_model = pretrained_model_builder.build()\n",
+    "pretrained_endpoint = pretrained_model_builder.deploy(endpoint_name=pretrained_endpoint_name)\n",
+    "print(f\"Pretrained endpoint: {pretrained_endpoint.endpoint_name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8017c4ef-eb89-4da6-8e28-c800adbfc4b8",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Invoke the endpoint\n",
+    "\n",
+    "---\n",
+    "Next, we invoke the endpoint with some sample queries. Later, in this notebook, we will fine-tune this model with a custom dataset and carry out inference using the fine-tuned model. We will also show comparison between results obtained via the pre-trained and the fine-tuned models.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b795a085-048f-42b2-945f-0cd339c1cf91",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def print_response(payload, response):\n",
+    "    print(payload[\"inputs\"])\n",
+    "    print(f\"> {response.get('generated_text')}\")\n",
+    "    print(\"\\n==================================\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# V3: invoke the endpoint with core Endpoint.invoke instead of predictor.predict.\n",
+    "import json\n",
+    "\n",
+    "payload = {\n",
+    "    \"inputs\": \"I believe the meaning of life is\",\n",
+    "    \"parameters\": {\n",
+    "        \"max_new_tokens\": 64,\n",
+    "        \"top_p\": 0.9,\n",
+    "        \"temperature\": 0.6,\n",
+    "        \"return_full_text\": False,\n",
+    "    },\n",
+    "}\n",
+    "try:\n",
+    "    # Please change custom_attributes to \"accept_eula=true\" to run inference.\n",
+    "    result = pretrained_endpoint.invoke(\n",
+    "        body=json.dumps(payload),\n",
+    "        content_type=\"application/json\",\n",
+    "        custom_attributes=\"accept_eula=false\",\n",
+    "    )\n",
+    "    response = json.loads(result.body.read().decode(\"utf-8\"))\n",
+    "    print_response(payload, response)\n",
+    "except Exception as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a6773e6-7cf2-4cea-bce6-905d5995d857",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "To learn about additional use cases of pre-trained model, please checkout the notebook [Text completion: Run Llama 3 models in SageMaker JumpStart](https://github.com/aws/amazon-sagemaker-examples/blob/main/introduction_to_amazon_algorithms/jumpstart-foundation-models/llama-3-text-completion.ipynb).\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e19e16f-d459-40c6-9d6b-0272938b3878",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Dataset preparation for fine-tuning\n",
+    "\n",
+    "---\n",
+    "\n",
+    "You can fine-tune on the dataset with domain adaptation format or instruction tuning format. Please find more details in the section [Dataset instruction](#Dataset-instruction). In this demo, we will use a subset of [Dolly dataset](https://huggingface.co/datasets/databricks/databricks-dolly-15k) in an instruction tuning format. Dolly dataset contains roughly 15,000 instruction following records for various categories such as question answering, summarization, information extraction etc. It is available under Apache 2.0 license. We will select the summarization examples for fine-tuning.\n",
+    "\n",
+    "\n",
+    "Training data is formatted in JSON lines (.jsonl) format, where each line is a dictionary representing a single data sample. All training data must be in a single folder, however it can be saved in multiple jsonl files. The training folder can also contain a template.json file describing the input and output formats.\n",
+    "\n",
+    "To train your model on a collection of unstructured dataset (text files), please see the section [Example fine-tuning with Domain-Adaptation dataset format](#Example-fine-tuning-with-Domain-Adaptation-dataset-format) in the Appendix.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6dd20a0d-15a5-49b0-a330-a75755d046ed",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from datasets import load_dataset\n",
+    "\n",
+    "dolly_dataset = load_dataset(\"databricks/databricks-dolly-15k\", split=\"train\")\n",
+    "\n",
+    "# To train for question answering/information extraction, you can replace the assertion in next line to example[\"category\"] == \"closed_qa\"/\"information_extraction\".\n",
+    "summarization_dataset = dolly_dataset.filter(lambda example: example[\"category\"] == \"summarization\")\n",
+    "summarization_dataset = summarization_dataset.remove_columns(\"category\")\n",
+    "\n",
+    "# We split the dataset into two where test data is used to evaluate at the end.\n",
+    "train_and_test_dataset = summarization_dataset.train_test_split(test_size=0.1)\n",
+    "\n",
+    "# Dumping the training data to a local file to be used for training.\n",
+    "train_and_test_dataset[\"train\"].to_json(\"train.jsonl\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9fbf002-3ee3-4cc8-8fce-871939f1bd19",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "train_and_test_dataset[\"train\"][0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b2e5489-33dc-4623-92da-f6fc97bd25ab",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "Next, we create a prompt template for using the data in an instruction / input format for the training job (since we are instruction fine-tuning the model in this example), and also for inferencing the deployed endpoint.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90451114-7cf5-445c-88e3-02ccaa5d3a4b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "template = {\n",
+    "    \"prompt\": \"Below is an instruction that describes a task, paired with an input that provides further context. \"\n",
+    "    \"Write a response that appropriately completes the request.\\n\\n\"\n",
+    "    \"### Instruction:\\n{instruction}\\n\\n### Input:\\n{context}\\n\\n\",\n",
+    "    \"completion\": \" {response}\",\n",
+    "}\n",
+    "with open(\"template.json\", \"w\") as f:\n",
+    "    json.dump(template, f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a22171b1-1cec-4cec-9ce4-db62761633d9",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Upload dataset to S3\n",
+    "---\n",
+    "\n",
+    "We will upload the prepared dataset to S3 which will be used for fine-tuning.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# V3: sagemaker.s3.S3Uploader was removed. Upload with Session.upload_data.\n",
+    "import random\n",
+    "from sagemaker.core.helper.session_helper import Session\n",
+    "\n",
+    "sagemaker_session = Session()\n",
+    "output_bucket = sagemaker_session.default_bucket()\n",
+    "train_data_prefix = \"dolly_dataset\"\n",
+    "\n",
+    "train_data_location = sagemaker_session.upload_data(\n",
+    "    path=\"train.jsonl\", bucket=output_bucket, key_prefix=train_data_prefix\n",
+    ")\n",
+    "sagemaker_session.upload_data(\n",
+    "    path=\"template.json\", bucket=output_bucket, key_prefix=train_data_prefix\n",
+    ")\n",
+    "# Training channel is the S3 folder that holds train.jsonl + template.json.\n",
+    "train_data_channel = f\"s3://{output_bucket}/{train_data_prefix}\"\n",
+    "print(f\"Training data: {train_data_channel}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86e61340-bc81-477d-aaf1-f37e8c554863",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Train the model\n",
+    "---\n",
+    "Next, we fine-tune the LLaMA 3 8B model on the summarization dataset from Dolly. Finetuning scripts are based on scripts provided by [this repo](https://github.com/facebookresearch/llama-recipes/tree/main). To learn more about the fine-tuning scripts, please checkout section [5. Few notes about the fine-tuning method](#5.-Few-notes-about-the-fine-tuning-method). For a list of supported hyper-parameters and their default values, please see section [3. Supported Hyper-parameters for fine-tuning](#3.-Supported-Hyper-parameters-for-fine-tuning).\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# V3: fine-tune a JumpStart model with ModelTrainer.from_jumpstart_config.\n",
+    "# (V2 used sagemaker.jumpstart.estimator.JumpStartEstimator, removed in V3.)\n",
+    "from sagemaker.train.model_trainer import ModelTrainer\n",
+    "from sagemaker.core.training.configs import InputData\n",
+    "\n",
+    "finetune_config = JumpStartConfig(\n",
+    "    model_id=model_id,\n",
+    "    model_version=model_version,\n",
+    "    accept_eula=True,  # Please accept the model EULA to fine-tune.\n",
+    ")\n",
+    "model_trainer = ModelTrainer.from_jumpstart_config(\n",
+    "    jumpstart_config=finetune_config,\n",
+    "    compute=Compute(instance_type=\"ml.g5.12xlarge\"),  # For Llama-3-70b use ml.g5.48xlarge\n",
+    "    # By default instruction tuning is off; set instruction_tuned=True to use it.\n",
+    "    hyperparameters={\n",
+    "        \"instruction_tuned\": \"True\",\n",
+    "        \"epoch\": \"1\",\n",
+    "        \"max_input_length\": \"1024\",\n",
+    "    },\n",
+    "    sagemaker_session=sagemaker_session,\n",
+    ")\n",
+    "model_trainer.train(\n",
+    "    input_data_config=[InputData(channel_name=\"training\", data_source=train_data_channel)]\n",
+    ")\n",
+    "\n",
+    "# Get the model artifacts path after training.\n",
+    "training_job = model_trainer._latest_training_job\n",
+    "model_artifacts = training_job.model_artifacts.s3_model_artifacts\n",
+    "print(f\"Model artifacts: {model_artifacts}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The fine-tuned model artifact S3 URI.\n",
+    "model_path = model_artifacts\n",
+    "model_path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e3889d9-1567-41ad-9375-fb738db629fa",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Studio Kernel Dying issue:  If your studio kernel dies and you lose reference to the estimator object, please see section [6. Studio Kernel Dead/Creating JumpStart Model from the training Job](#6.-Studio-Kernel-Dead/Creating-JumpStart-Model-from-the-training-Job) on how to deploy endpoint using the training job name and the model id. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e9decbf-08c6-4cb4-8644-4a96afb5bebf",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Deploy the fine-tuned model\n",
+    "---\n",
+    "Next, we deploy fine-tuned model. We will compare the performance of fine-tuned and pre-trained model.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# V3: deploy the fine-tuned model by chaining ModelBuilder off the trainer.\n",
+    "finetuned_endpoint_name = f\"llama3-8b-finetuned-{unique_id}\"\n",
+    "finetuned_model_builder = ModelBuilder(model=model_trainer)\n",
+    "finetuned_model = finetuned_model_builder.build()\n",
+    "finetuned_endpoint = finetuned_model_builder.deploy(endpoint_name=finetuned_endpoint_name)\n",
+    "print(f\"Fine-tuned endpoint: {finetuned_endpoint.endpoint_name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb57904a-9631-45fe-bc3f-ae2fbb992960",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Evaluate the pre-trained and fine-tuned model\n",
+    "---\n",
+    "Next, we use the test data to evaluate the performance of the fine-tuned model and compare it with the pre-trained model. \n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from IPython.display import display, HTML\n",
+    "\n",
+    "test_dataset = train_and_test_dataset[\"test\"]\n",
+    "\n",
+    "(\n",
+    "    inputs,\n",
+    "    ground_truth_responses,\n",
+    "    responses_before_finetuning,\n",
+    "    responses_after_finetuning,\n",
+    ") = (\n",
+    "    [],\n",
+    "    [],\n",
+    "    [],\n",
+    "    [],\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def predict_and_print(datapoint):\n",
+    "    # For instruction fine-tuning, we insert a special key between input and output\n",
+    "    input_output_demarkation_key = \"\\n\\n### Response:\\n\"\n",
+    "\n",
+    "    payload = {\n",
+    "        \"inputs\": template[\"prompt\"].format(\n",
+    "            instruction=datapoint[\"instruction\"], context=datapoint[\"context\"]\n",
+    "        )\n",
+    "        + input_output_demarkation_key,\n",
+    "        \"parameters\": {\"max_new_tokens\": 100},\n",
+    "    }\n",
+    "    inputs.append(payload[\"inputs\"])\n",
+    "    ground_truth_responses.append(datapoint[\"response\"])\n",
+    "    # Please change custom_attributes to \"accept_eula=true\" to run inference.\n",
+    "    pretrained_result = pretrained_endpoint.invoke(\n",
+    "        body=json.dumps(payload),\n",
+    "        content_type=\"application/json\",\n",
+    "        custom_attributes=\"accept_eula=false\",\n",
+    "    )\n",
+    "    pretrained_response = json.loads(pretrained_result.body.read().decode(\"utf-8\"))\n",
+    "    responses_before_finetuning.append(pretrained_response.get(\"generated_text\"))\n",
+    "    # Fine-tuned Llama 3 models don't require accept_eula=true.\n",
+    "    finetuned_result = finetuned_endpoint.invoke(\n",
+    "        body=json.dumps(payload),\n",
+    "        content_type=\"application/json\",\n",
+    "    )\n",
+    "    finetuned_response = json.loads(finetuned_result.body.read().decode(\"utf-8\"))\n",
+    "    responses_after_finetuning.append(finetuned_response.get(\"generated_text\"))\n",
+    "\n",
+    "\n",
+    "try:\n",
+    "    for i, datapoint in enumerate(test_dataset.select(range(5))):\n",
+    "        predict_and_print(datapoint)\n",
+    "\n",
+    "    df = pd.DataFrame(\n",
+    "        {\n",
+    "            \"Inputs\": inputs,\n",
+    "            \"Ground Truth\": ground_truth_responses,\n",
+    "            \"Response from non-finetuned model\": responses_before_finetuning,\n",
+    "            \"Response from fine-tuned model\": responses_after_finetuning,\n",
+    "        }\n",
+    "    )\n",
+    "    display(HTML(df.to_html()))\n",
+    "except Exception as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d4260a1-61cd-4fb8-aa1a-6fb21a47e323",
+   "metadata": {},
+   "source": [
+    "### Clean up resources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# V3: delete model, endpoint, and endpoint config for both endpoints.\n",
+    "from sagemaker.core.resources import EndpointConfig\n",
+    "\n",
+    "for _model, _endpoint in [\n",
+    "    (pretrained_model, pretrained_endpoint),\n",
+    "    (finetuned_model, finetuned_endpoint),\n",
+    "]:\n",
+    "    try:\n",
+    "        _endpoint_config = EndpointConfig.get(endpoint_config_name=_endpoint.endpoint_name)\n",
+    "        _model.delete()\n",
+    "        _endpoint.delete()\n",
+    "        _endpoint_config.delete()\n",
+    "    except Exception as e:\n",
+    "        print(e)\n",
+    "print(\"Pretrained and fine-tuned resources cleaned up.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b21eccf4-bde5-4f88-9472-df32818d6378",
+   "metadata": {},
+   "source": [
+    "### Import the fine tuned model to Jumpstart private model hub\n",
+    "---\n",
+    "Next, we will prepare the model artifact and upload it into the Sagemaker's default S3 bucket \n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# V3: the private model hub is managed with sagemaker.core.resources.Hub.\n",
+    "# (V2 used sagemaker.jumpstart.hub.hub.Hub, which was removed in V3.)\n",
+    "import utils\n",
+    "import boto3\n",
+    "from sagemaker.core.helper.session_helper import Session\n",
+    "\n",
+    "sess = Session()\n",
+    "default_bucket = sess.default_bucket()\n",
+    "print(default_bucket)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad9a224d-4f51-42e3-a588-48a5c20c204d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# download model artifacts\n",
+    "utils.download_model_from_s3(model_path)\n",
+    "\n",
+    "# Create the model.tar.gz\n",
+    "print(\"Creating the model artifact.....\")\n",
+    "utils.package_llama_model('downloaded_model', 'model.tar.gz')  # this process take a while\n",
+    "print(\"Created the model artifact!!!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8fd4aec-723f-4d0f-9c3a-eb801faefb58",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# upload model artifact to S3\n",
+    "# we will upload it to the output folder in model_path variable\n",
+    "\n",
+    "model_upload_path = model_path.rsplit('/', 2)[0] + '/'\n",
+    "\n",
+    "\n",
+    "print(f\"Uploading the model artifact to s3: {model_upload_path}\")\n",
+    "\n",
+    "s3_artifact_uri = utils.upload_model_to_s3(model_upload_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the private model hub details to create one.\n",
+    "HUB_NAME = \"Custom-Model-HubZ\"\n",
+    "HUB_DISPLAY_NAME = \"Custom-Model-HubZ\"\n",
+    "REGION = \"us-east-1\"\n",
+    "\n",
+    "sm_client = boto3.client(\"sagemaker\", region_name=REGION)\n",
+    "print(sess.get_caller_identity_arn())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# V3: create the private hub with the Hub resource class.\n",
+    "from sagemaker.core.resources import Hub\n",
+    "\n",
+    "try:\n",
+    "    hub = Hub.create(\n",
+    "        hub_name=HUB_NAME,\n",
+    "        hub_description=\"This is a Curated Hub. Replace this with a description which explains the purpose of this Hub.\",\n",
+    "        hub_display_name=HUB_DISPLAY_NAME,\n",
+    "        region=REGION,\n",
+    "    )\n",
+    "    print(f\"Successfully created Hub with name {HUB_NAME} in {REGION}\")\n",
+    "except Exception as e:\n",
+    "    if \"ResourceInUse\" in str(e):\n",
+    "        print(f\"A hub with the name {HUB_NAME} already exists in your account.\")\n",
+    "        hub = Hub.get(hub_name=HUB_NAME, region=REGION)\n",
+    "    else:\n",
+    "        raise e"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7111bea-ad35-4089-9653-79cfdbba9a94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Retrieve to update the HubContentDocument with the fine-tuned model artifacts\n",
+    "\n",
+    "import json\n",
+    "hub_content = json.loads(utils.get_hub_content_document())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26323462-c0a3-4417-a5a4-3f29f2b2d4b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_hostingartifact_uri = s3_artifact_uri\n",
+    "\n",
+    "utils.update_hosting_uris(hub_content, new_hostingartifact_uri)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d1d707d-e5d5-450e-a43d-ab124ae95983",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Convert the dictionary to a JSON string\n",
+    "import json\n",
+    "hub_doc = json.dumps(hub_content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# importing to the hub (boto3 import_hub_content; no high-level V3 wrapper)\n",
+    "HUB_CONTENT_NAME = f\"fine-tuned-llama3-8B-{unique_id}\"\n",
+    "sm_client.import_hub_content(\n",
+    "    HubContentName=HUB_CONTENT_NAME,\n",
+    "    HubContentType=\"Model\",\n",
+    "    DocumentSchemaVersion=\"2.3.0\",\n",
+    "    HubName=HUB_NAME,\n",
+    "    HubContentDocument=hub_doc,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# list the models from the private hub (V3 Hub has no list_models; use boto3)\n",
+    "hub_contents = sm_client.list_hub_contents(HubName=HUB_NAME, HubContentType=\"Model\")\n",
+    "hub_contents[\"HubContentSummaries\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# deploy the fine-tuned model from the private hub as an endpoint\n",
+    "\n",
+    "# retrieve the hub's ARN\n",
+    "HUB_ARN = hub.hub_arn\n",
+    "print(HUB_ARN)\n",
+    "\n",
+    "# find the model we just imported by name (instead of a hardcoded index)\n",
+    "summaries = sm_client.list_hub_contents(HubName=HUB_NAME, HubContentType=\"Model\")[\n",
+    "    \"HubContentSummaries\"\n",
+    "]\n",
+    "target = next(s for s in summaries if s[\"HubContentName\"] == HUB_CONTENT_NAME)\n",
+    "hub_model_id = target[\"HubContentName\"]\n",
+    "hub_model_version = target[\"HubContentVersion\"]\n",
+    "print(hub_model_id, hub_model_version)\n",
+    "\n",
+    "# V3: deploy from the private hub via ModelBuilder.from_jumpstart_config with hub_name.\n",
+    "hub_endpoint_name = f\"llama3-8b-from-hub-{unique_id}\"\n",
+    "hub_jumpstart_config = JumpStartConfig(\n",
+    "    model_id=hub_model_id,\n",
+    "    model_version=hub_model_version,\n",
+    "    hub_name=HUB_ARN,\n",
+    "    accept_eula=True,\n",
+    ")\n",
+    "hub_model_builder = ModelBuilder.from_jumpstart_config(\n",
+    "    jumpstart_config=hub_jumpstart_config,\n",
+    "    compute=Compute(instance_type=\"ml.g5.12xlarge\"),\n",
+    ")\n",
+    "hub_model = hub_model_builder.build()\n",
+    "hub_endpoint = hub_model_builder.deploy(endpoint_name=hub_endpoint_name)\n",
+    "endpoint_name = hub_endpoint.endpoint_name\n",
+    "endpoint_name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# invoke the endpoint (V3 core Endpoint.invoke)\n",
+    "payload = {\n",
+    "    \"inputs\": \"Write a poem about the spring season.\",\n",
+    "    \"parameters\": {\n",
+    "        \"max_new_tokens\": 256,\n",
+    "        \"temperature\": 0.7,\n",
+    "        \"top_p\": 0.9,\n",
+    "        \"do_sample\": True,\n",
+    "    },\n",
+    "}\n",
+    "try:\n",
+    "    result = hub_endpoint.invoke(\n",
+    "        body=json.dumps(payload),\n",
+    "        content_type=\"application/json\",\n",
+    "        custom_attributes=\"accept_eula=true\",  # Required for Llama models\n",
+    "    )\n",
+    "    response_body = json.loads(result.body.read().decode(\"utf-8\"))\n",
+    "    print(response_body)\n",
+    "except Exception as e:\n",
+    "    print(f\"Error invoking endpoint: {str(e)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6b0a0f5-ef34-40db-8ab7-c24a5d14b525",
+   "metadata": {},
+   "source": [
+    "### Clean up resources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean up the hub-deployed endpoint, model, and endpoint config.\n",
+    "try:\n",
+    "    hub_endpoint_config = EndpointConfig.get(endpoint_config_name=endpoint_name)\n",
+    "    hub_model.delete()\n",
+    "    hub_endpoint.delete()\n",
+    "    hub_endpoint_config.delete()\n",
+    "    print(\"Hub-deployed resources cleaned up.\")\n",
+    "except Exception as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "759ce98f-a35a-4c64-9fae-50894b5e9f37",
+   "metadata": {},
+   "source": [
+    "# Appendix"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d1c8c86-bfe2-4828-a7aa-dbd7a5ee075f",
+   "metadata": {},
+   "source": [
+    "### 1. Supported Inference Parameters\n",
+    "\n",
+    "---\n",
+    "This model supports the following inference payload parameters:\n",
+    "\n",
+    "* **max_new_tokens:** Model generates text until the output length (excluding the input context length) reaches max_new_tokens. If specified, it must be a positive integer.\n",
+    "* **temperature:** Controls the randomness in the output. Higher temperature results in output sequence with low-probability words and lower temperature results in output sequence with high-probability words. If `temperature` -> 0, it results in greedy decoding. If specified, it must be a positive float.\n",
+    "* **top_p:** In each step of text generation, sample from the smallest possible set of words with cumulative probability `top_p`. If specified, it must be a float between 0 and 1.\n",
+    "* **return_full_text:** If True, input text will be part of the output generated text. If specified, it must be boolean. The default value for it is False.\n",
+    "\n",
+    "You may specify any subset of the parameters mentioned above while invoking an endpoint. \n",
+    "\n",
+    "\n",
+    "### Notes\n",
+    "- If `max_new_tokens` is not defined, the model may generate up to the maximum total tokens allowed, which is 8K for these models. This may result in endpoint query timeout errors, so it is recommended to set `max_new_tokens` when possible. For 8B and 70B models, we recommend to set `max_new_tokens` no greater than 1500 and 500 respectively, while keeping the total number of tokens less than 8K.\n",
+    "- In order to support a 8k context length, this model has restricted query payloads to only utilize a batch size of 1. Payloads with larger batch sizes will receive an endpoint error prior to inference.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30d5df7e-95a5-47dc-b5d2-0178ebfc6b6f",
+   "metadata": {},
+   "source": [
+    "### 2. Dataset formatting instruction for training\n",
+    "\n",
+    "---\n",
+    "\n",
+    "####  Fine-tune the Model on a New Dataset\n",
+    "We currently offer two types of fine-tuning: instruction fine-tuning and domain adaption fine-tuning. You can easily switch to one of the training \n",
+    "methods by specifying parameter `instruction_tuned` being 'True' or 'False'.\n",
+    "\n",
+    "\n",
+    "#### 2.1. Domain adaptation fine-tuning\n",
+    "The Text Generation model can also be fine-tuned on any domain specific dataset. After being fine-tuned on the domain specific dataset, the model\n",
+    "is expected to generate domain specific text and solve various NLP tasks in that specific domain with **few shot prompting**.\n",
+    "\n",
+    "Below are the instructions for how the training data should be formatted for input to the model.\n",
+    "\n",
+    "- **Input:** A train and an optional validation directory. Each directory contains a CSV/JSON/TXT file. \n",
+    "  - For CSV/JSON files, the train or validation data is used from the column called 'text' or the first column if no column called 'text' is found.\n",
+    "  - The number of files under train and validation (if provided) should equal to one, respectively. \n",
+    "- **Output:** A trained model that can be deployed for inference. \n",
+    "\n",
+    "Below is an example of a TXT file for fine-tuning the Text Generation model. The TXT file is SEC filings of Amazon from year 2021 to 2022.\n",
+    "\n",
+    "```Note About Forward-Looking Statements\n",
+    "This report includes estimates, projections, statements relating to our\n",
+    "business plans, objectives, and expected operating results that are \u201cforward-\n",
+    "looking statements\u201d within the meaning of the Private Securities Litigation\n",
+    "Reform Act of 1995, Section 27A of the Securities Act of 1933, and Section 21E\n",
+    "of the Securities Exchange Act of 1934. Forward-looking statements may appear\n",
+    "throughout this report, including the following sections: \u201cBusiness\u201d (Part I,\n",
+    "Item 1 of this Form 10-K), \u201cRisk Factors\u201d (Part I, Item 1A of this Form 10-K),\n",
+    "and \u201cManagement\u2019s Discussion and Analysis of Financial Condition and Results\n",
+    "of Operations\u201d (Part II, Item 7 of this Form 10-K). These forward-looking\n",
+    "statements generally are identified by the words \u201cbelieve,\u201d \u201cproject,\u201d\n",
+    "\u201cexpect,\u201d \u201canticipate,\u201d \u201cestimate,\u201d \u201cintend,\u201d \u201cstrategy,\u201d \u201cfuture,\u201d\n",
+    "\u201copportunity,\u201d \u201cplan,\u201d \u201cmay,\u201d \u201cshould,\u201d \u201cwill,\u201d \u201cwould,\u201d \u201cwill be,\u201d \u201cwill\n",
+    "continue,\u201d \u201cwill likely result,\u201d and similar expressions. Forward-looking\n",
+    "statements are based on current expectations and assumptions that are subject\n",
+    "to risks and uncertainties that may cause actual results to differ materially.\n",
+    "We describe risks and uncertainties that could cause actual results and events\n",
+    "to differ materially in \u201cRisk Factors,\u201d \u201cManagement\u2019s Discussion and Analysis\n",
+    "of Financial Condition and Results of Operations,\u201d and \u201cQuantitative and\n",
+    "Qualitative Disclosures about Market Risk\u201d (Part II, Item 7A of this Form\n",
+    "10-K). Readers are cautioned not to place undue reliance on forward-looking\n",
+    "statements, which speak only as of the date they are made. We undertake no\n",
+    "obligation to update or revise publicly any forward-looking statements,\n",
+    "whether because of new information, future events, or otherwise.\n",
+    "GENERAL\n",
+    "Embracing Our Future ...\n",
+    "```\n",
+    "\n",
+    "\n",
+    "#### 2.2. Instruction fine-tuning\n",
+    "The Text generation model can be instruction-tuned on any text data provided that the data \n",
+    "is in the expected format. The instruction-tuned model can be further deployed for inference. \n",
+    "Below are the instructions for how the training data should be formatted for input to the \n",
+    "model.\n",
+    "\n",
+    "Below are the instructions for how the training data should be formatted for input to the model.\n",
+    "\n",
+    "- **Input:** A train and an optional validation directory. Train and validation directories should contain one or multiple JSON lines (`.jsonl`) formatted files. In particular, train directory can also contain an optional `*.json` file describing the input and output formats. \n",
+    "  - The best model is selected according to the validation loss, calculated at the end of each epoch.\n",
+    "  If a validation set is not given, an (adjustable) percentage of the training data is\n",
+    "  automatically split and used for validation.\n",
+    "  - The training data must be formatted in a JSON lines (`.jsonl`) format, where each line is a dictionary\n",
+    "representing a single data sample. All training data must be in a single folder, however\n",
+    "it can be saved in multiple jsonl files. The `.jsonl` file extension is mandatory. The training\n",
+    "folder can also contain a `template.json` file describing the input and output formats. If no\n",
+    "template file is given, the following template will be used:\n",
+    "  ```json\n",
+    "  {\n",
+    "    \"prompt\": \"Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.\\n\\n### Instruction:\\n{instruction}\\n\\n### Input:\\n{context}\",\n",
+    "    \"completion\": \"{response}\"\n",
+    "  }\n",
+    "  ```\n",
+    "  - In this case, the data in the JSON lines entries must include `instruction`, `context` and `response` fields. If a custom template is provided it must also use `prompt` and `completion` keys to define\n",
+    "  the input and output templates.\n",
+    "  Below is a sample custom template:\n",
+    "\n",
+    "  ```json\n",
+    "  {\n",
+    "    \"prompt\": \"question: {question} context: {context}\",\n",
+    "    \"completion\": \"{answer}\"\n",
+    "  }\n",
+    "  ```\n",
+    "Here, the data in the JSON lines entries must include `question`, `context` and `answer` fields. \n",
+    "- **Output:** A trained model that can be deployed for inference. \n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4edf0c9-3c95-4e4b-932e-5d8a839d4070",
+   "metadata": {},
+   "source": [
+    "#### 2.3. Example fine-tuning with Domain-Adaptation dataset format\n",
+    "---\n",
+    "We provide a subset of SEC filings data of Amazon in domain adaptation dataset format. It is downloaded from publicly available [EDGAR](https://www.sec.gov/edgar/searchedgar/companysearch). Instruction of accessing the data is shown [here](https://www.sec.gov/os/accessing-edgar-data).\n",
+    "\n",
+    "License: [Creative Commons Attribution-ShareAlike License (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/legalcode).\n",
+    "\n",
+    "Please uncomment the following code to fine-tune the model on dataset in domain adaptation format.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Appendix example: domain-adaptation fine-tuning with ModelTrainer (V3).\n",
+    "# This is an optional illustrative example. Uncomment the code below to run a\n",
+    "# domain-adaptation fine-tuning job on the sample SEC filings dataset.\n",
+    "#\n",
+    "# import boto3\n",
+    "#\n",
+    "# appendix_model_id = \"meta-textgeneration-llama-3-8b\"\n",
+    "# region_name = boto3.Session().region_name\n",
+    "#\n",
+    "# appendix_config = JumpStartConfig(\n",
+    "#     model_id=appendix_model_id,\n",
+    "#     accept_eula=True,\n",
+    "# )\n",
+    "# appendix_trainer = ModelTrainer.from_jumpstart_config(\n",
+    "#     jumpstart_config=appendix_config,\n",
+    "#     compute=Compute(instance_type=\"ml.g5.24xlarge\"),\n",
+    "#     hyperparameters={\"instruction_tuned\": \"False\", \"epoch\": \"5\"},\n",
+    "# )\n",
+    "# appendix_trainer.train(\n",
+    "#     input_data_config=[\n",
+    "#         InputData(\n",
+    "#             channel_name=\"training\",\n",
+    "#             data_source=f\"s3://jumpstart-cache-prod-{region_name}/training-datasets/sec_amazon\",\n",
+    "#         )\n",
+    "#     ]\n",
+    "# )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19f7e4f8-970f-4a1d-b6ee-86bc77b8b9a9",
+   "metadata": {},
+   "source": [
+    "### 3. Supported Hyper-parameters for fine-tuning\n",
+    "---\n",
+    "- epoch: The number of passes that the fine-tuning algorithm takes through the training dataset. Must be an integer greater than 1. Default: 5\n",
+    "- learning_rate: The rate at which the model weights are updated after working through each batch of training examples. Must be a positive float greater than 0. Default: 1e-4.\n",
+    "- instruction_tuned: Whether to instruction-train the model or not. Must be 'True' or 'False'. Default: 'False'\n",
+    "- per_device_train_batch_size: The batch size per GPU core/CPU for training. Must be a positive integer. Default: 4.\n",
+    "- per_device_eval_batch_size: The batch size per GPU core/CPU for evaluation. Must be a positive integer. Default: 1\n",
+    "- max_train_samples: For debugging purposes or quicker training, truncate the number of training examples to this value. Value -1 means using all of training samples. Must be a positive integer or -1. Default: -1. \n",
+    "- max_val_samples: For debugging purposes or quicker training, truncate the number of validation examples to this value. Value -1 means using all of validation samples. Must be a positive integer or -1. Default: -1. \n",
+    "- max_input_length: Maximum total input sequence length after tokenization. Sequences longer than this will be truncated. If -1, max_input_length is set to the minimum of 1024 and the maximum model length defined by the tokenizer. If set to a positive value, max_input_length is set to the minimum of the provided value and the model_max_length defined by the tokenizer. Must be a positive integer or -1. Default: -1. \n",
+    "- validation_split_ratio: If validation channel is none, ratio of train-validation split from the train data. Must be between 0 and 1. Default: 0.2. \n",
+    "- train_data_split_seed: If validation data is not present, this fixes the random splitting of the input training data to training and validation data used by the algorithm. Must be an integer. Default: 0.\n",
+    "- preprocessing_num_workers: The number of processes to use for the preprocessing. If None, main process is used for preprocessing. Default: \"None\"\n",
+    "- lora_r: Lora R. Must be a positive integer. Default: 8.\n",
+    "- lora_alpha: Lora Alpha. Must be a positive integer. Default: 32\n",
+    "- lora_dropout: Lora Dropout. must be a positive float between 0 and 1. Default: 0.05. \n",
+    "- int8_quantization: If True, model is loaded with 8 bit precision for training. Default for 8B: False. Default for 70B: True.\n",
+    "- enable_fsdp: If True, training uses Fully Sharded Data Parallelism. Default for 8B: True. Default for 70B: False.\n",
+    "\n",
+    "Note 1: int8_quantization is not supported with FSDP. Also, int8_quantization = 'False' and enable_fsdp = 'False' is not supported due to CUDA memory issues for any of the g5 family instances. Thus, we recommend setting exactly one of int8_quantization or enable_fsdp to be 'True'\n",
+    "Note 2: Due to the size of the model, 70B model can not be fine-tuned with enable_fsdp = 'True' for any of the supported instance types.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72b6d023-3487-4571-8b52-f332790c1ad7",
+   "metadata": {},
+   "source": [
+    "### 4. Supported Instance types for fine-tuning Llama 3\n",
+    "\n",
+    "---\n",
+    "We have tested our scripts on the following instances types for fine-tuning Llama 3:\n",
+    "\n",
+    "| Model | Model ID | All Supported Instances Types for fine-tuning |\n",
+    "| - | - | - |\n",
+    "| Llama 3 8B | meta-textgeneration-llama-3-8b | ml.g5.12xlarge, ml.g5.24xlarge, ml.g5.48xlarge, ml.p3dn.24xlarge, ml.g4dn.12xlarge |\n",
+    "| Llama 3 8B Instruct | meta-textgeneration-llama-3-8b-instruct | ml.g5.12xlarge, ml.g5.24xlarge, ml.g5.48xlarge, ml.p3dn.24xlarge, ml.g4dn.12xlarge  |\n",
+    "| Llama 3 70B | meta-textgeneration-llama-3-70b | ml.g5.48xlarge, ml.p4d.24xlarge |\n",
+    "| Llama 3 70B Instruct | meta-textgeneration-llama-3-70b-instruct | ml.g5.48xlarge, ml.p4d.24xlarge |\n",
+    "\n",
+    "Other instance types may also work to fine-tune. Note: When using p3 instances, training will be done with 32 bit precision as bfloat16 is not supported on these instances. Thus, training job would consume double the amount of CUDA memory when training on p3 instances compared to g5 instances.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "770d4350-cf4d-40a0-be1c-eba44efd33ab",
+   "metadata": {},
+   "source": [
+    "### 5. Few notes about the fine-tuning method\n",
+    "\n",
+    "---\n",
+    "- Fine-tuning scripts are based on [this repo](https://github.com/facebookresearch/llama-recipes/tree/main). \n",
+    "- Instruction tuning dataset is first converted into domain adaptation dataset format before fine-tuning. \n",
+    "- Fine-tuning scripts utilize Fully Sharded Data Parallel (FSDP) as well as Low Rank Adaptation (LoRA) method fine-tuning the models\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "909ce841-3a2c-4c08-a102-b94148036a5a",
+   "metadata": {},
+   "source": [
+    "### 6. Studio Kernel Dead/Creating JumpStart Model from the training Job\n",
+    "---\n",
+    "Due to the size of the Llama 70B model, training job may take several hours and the studio kernel may die during the training phase. However, during this time, training is still running in SageMaker. If this happens, you can still deploy the endpoint using the training job name with the following code:\n",
+    "\n",
+    "How to find the training job name? Go to Console -> SageMaker -> Training -> Training Jobs -> Identify the training job name and substitute in the following cell. \n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NOTE (V3): the V2 JumpStartEstimator.attach(training_job_name) helper, used to\n",
+    "# re-create an estimator from a running/finished training job, is not available in\n",
+    "# V3. If your kernel dies during training, the training job keeps running in\n",
+    "# SageMaker. To deploy afterwards, look up the completed training job and build a\n",
+    "# ModelBuilder from its TrainingJob resource, then deploy. Example (illustrative):\n",
+    "#\n",
+    "#   from sagemaker.core.resources import TrainingJob\n",
+    "#   from sagemaker.serve.model_builder import ModelBuilder\n",
+    "#   training_job = TrainingJob.get(training_job_name=\"<training-job-name>\")\n",
+    "#   model_builder = ModelBuilder(model=training_job)\n",
+    "#   model_builder.build()\n",
+    "#   model_builder.deploy(endpoint_name=\"<endpoint-name>\")\n",
+    "#\n",
+    "# This cell is reference-only and intentionally performs no action."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7be1219",
+   "metadata": {},
+   "source": [
+    "## Notebook CI Test Results\n",
+    "\n",
+    "This notebook was tested in multiple regions. The test results are as follows, except for us-west-2 which is shown at the top of the notebook.\n",
+    "\n",
+    "![This us-east-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-east-1/introduction_to_amazon_algorithms|jumpstart-foundation-models|llama-3-finetuning.ipynb)\n",
+    "\n",
+    "![This us-east-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-east-2/introduction_to_amazon_algorithms|jumpstart-foundation-models|llama-3-finetuning.ipynb)\n",
+    "\n",
+    "![This us-west-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-west-1/introduction_to_amazon_algorithms|jumpstart-foundation-models|llama-3-finetuning.ipynb)\n",
+    "\n",
+    "![This ca-central-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ca-central-1/introduction_to_amazon_algorithms|jumpstart-foundation-models|llama-3-finetuning.ipynb)\n",
+    "\n",
+    "![This sa-east-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/sa-east-1/introduction_to_amazon_algorithms|jumpstart-foundation-models|llama-3-finetuning.ipynb)\n",
+    "\n",
+    "![This eu-west-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-1/introduction_to_amazon_algorithms|jumpstart-foundation-models|llama-3-finetuning.ipynb)\n",
+    "\n",
+    "![This eu-west-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-2/introduction_to_amazon_algorithms|jumpstart-foundation-models|llama-3-finetuning.ipynb)\n",
+    "\n",
+    "![This eu-west-3 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-3/introduction_to_amazon_algorithms|jumpstart-foundation-models|llama-3-finetuning.ipynb)\n",
+    "\n",
+    "![This eu-central-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-central-1/introduction_to_amazon_algorithms|jumpstart-foundation-models|llama-3-finetuning.ipynb)\n",
+    "\n",
+    "![This eu-north-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-north-1/introduction_to_amazon_algorithms|jumpstart-foundation-models|llama-3-finetuning.ipynb)\n",
+    "\n",
+    "![This ap-southeast-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-southeast-1/introduction_to_amazon_algorithms|jumpstart-foundation-models|llama-3-finetuning.ipynb)\n",
+    "\n",
+    "![This ap-southeast-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-southeast-2/introduction_to_amazon_algorithms|jumpstart-foundation-models|llama-3-finetuning.ipynb)\n",
+    "\n",
+    "![This ap-northeast-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-northeast-1/introduction_to_amazon_algorithms|jumpstart-foundation-models|llama-3-finetuning.ipynb)\n",
+    "\n",
+    "![This ap-northeast-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-northeast-2/introduction_to_amazon_algorithms|jumpstart-foundation-models|llama-3-finetuning.ipynb)\n",
+    "\n",
+    "![This ap-south-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-south-1/introduction_to_amazon_algorithms|jumpstart-foundation-models|llama-3-finetuning.ipynb)"
+   ]
+  }
+ ],
+ "metadata": {
+  "availableInstances": [
+   {
+    "_defaultOrder": 0,
+    "_isFastLaunch": true,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 4,
+    "name": "ml.t3.medium",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 1,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 8,
+    "name": "ml.t3.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 2,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.t3.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 3,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.t3.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 4,
+    "_isFastLaunch": true,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 8,
+    "name": "ml.m5.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 5,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.m5.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 6,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.m5.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 7,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 64,
+    "name": "ml.m5.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 8,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 128,
+    "name": "ml.m5.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 9,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 192,
+    "name": "ml.m5.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 10,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 256,
+    "name": "ml.m5.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 11,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 384,
+    "name": "ml.m5.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 12,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 8,
+    "name": "ml.m5d.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 13,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.m5d.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 14,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.m5d.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 15,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 64,
+    "name": "ml.m5d.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 16,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 128,
+    "name": "ml.m5d.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 17,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 192,
+    "name": "ml.m5d.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 18,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 256,
+    "name": "ml.m5d.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 19,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 384,
+    "name": "ml.m5d.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 20,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": true,
+    "memoryGiB": 0,
+    "name": "ml.geospatial.interactive",
+    "supportedImageNames": [
+     "sagemaker-geospatial-v1-0"
+    ],
+    "vcpuNum": 0
+   },
+   {
+    "_defaultOrder": 21,
+    "_isFastLaunch": true,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 4,
+    "name": "ml.c5.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 22,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 8,
+    "name": "ml.c5.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 23,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.c5.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 24,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.c5.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 25,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 72,
+    "name": "ml.c5.9xlarge",
+    "vcpuNum": 36
+   },
+   {
+    "_defaultOrder": 26,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 96,
+    "name": "ml.c5.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 27,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 144,
+    "name": "ml.c5.18xlarge",
+    "vcpuNum": 72
+   },
+   {
+    "_defaultOrder": 28,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 192,
+    "name": "ml.c5.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 29,
+    "_isFastLaunch": true,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.g4dn.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 30,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.g4dn.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 31,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 64,
+    "name": "ml.g4dn.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 32,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 128,
+    "name": "ml.g4dn.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 33,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 4,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 192,
+    "name": "ml.g4dn.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 34,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 256,
+    "name": "ml.g4dn.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 35,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 61,
+    "name": "ml.p3.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 36,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 4,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 244,
+    "name": "ml.p3.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 37,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 488,
+    "name": "ml.p3.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 38,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 768,
+    "name": "ml.p3dn.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 39,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.r5.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 40,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.r5.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 41,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 64,
+    "name": "ml.r5.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 42,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 128,
+    "name": "ml.r5.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 43,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 256,
+    "name": "ml.r5.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 44,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 384,
+    "name": "ml.r5.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 45,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 512,
+    "name": "ml.r5.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 46,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 768,
+    "name": "ml.r5.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 47,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.g5.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 48,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.g5.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 49,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 64,
+    "name": "ml.g5.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 50,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 128,
+    "name": "ml.g5.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 51,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 256,
+    "name": "ml.g5.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 52,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 4,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 192,
+    "name": "ml.g5.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 53,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 4,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 384,
+    "name": "ml.g5.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 54,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 768,
+    "name": "ml.g5.48xlarge",
+    "vcpuNum": 192
+   },
+   {
+    "_defaultOrder": 55,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 1152,
+    "name": "ml.p4d.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 56,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 1152,
+    "name": "ml.p4de.24xlarge",
+    "vcpuNum": 96
+   }
+  ],
+  "instance_type": "ml.t3.medium",
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/      build_and_train_models/sm-lightgbm_catboost_tabular_classification-v3.ipynb
+++ b/      build_and_train_models/sm-lightgbm_catboost_tabular_classification-v3.ipynb
@@ -1,0 +1,773 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8c2218f9",
+   "metadata": {},
+   "source": [
+    "# Tabular classification with Amazon SageMaker LightGBM and CatBoost algorithm (V3)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "214a9c13",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "This notebook's CI test result for us-west-2 is as follows. CI test results in other regions can be found at the end of the notebook. \n",
+    "\n",
+    "![This us-west-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-west-2/build_and_train_models|sm-lightgbm_catboost_tabular_classification.ipynb)\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "v3note",
+   "metadata": {},
+   "source": [
+    "> **SageMaker Python SDK v3 note:** This notebook has been migrated to the SageMaker Python SDK **v3**. The JumpStart LightGBM/CatBoost tabular-classification workflow now uses the high-level v3 JumpStart training API `ModelTrainer.from_jumpstart_config(...)` (from `sagemaker-train`) wrapped by the v3 `HyperparameterTuner` (from `sagemaker.train.tuner`) for Automatic Model Tuning, and deploys the best tuning job with `sagemaker-core` resource classes (`Model`/`EndpointConfig`/`Endpoint`). It no longer uses the v2 generic `Estimator`, `sagemaker.tuner`, or the top-level `image_uris`/`model_uris`/`script_uris` helpers (these now live under `sagemaker.core`). Install with `pip install sagemaker` (v3).\n\n---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef998835",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "This notebook demonstrates the use of Amazon SageMaker\u2019s implementation of the [LightGBM](https://lightgbm.readthedocs.io/en/latest/) and [CatBoost](https://catboost.ai/en/docs/) algorithm to train and host a tabular multiclass classification model. Tabular classification is the task of assigning a class to an example of structured or relational data. The Amazon SageMaker API for tabular classification can be used for classification of an example in two classes (binary classification) or more than two classes (multi-class classification).\n",
+    "\n",
+    "\n",
+    "In this notebook, we demonstrate two use cases of tabular classification models:\n",
+    "\n",
+    "* How to train a tabular model on an example dataset to do multi-class classification.\n",
+    "* How to use the trained tabular model to perform inference, i.e., classifying new samples.\n",
+    "\n",
+    "Note: This notebook was tested in Amazon SageMaker Studio on ml.t3.medium instance with Python 3 (Data Science) kernel.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa8b34fe",
+   "metadata": {},
+   "source": [
+    "1. [Set Up](#1.-Set-Up)\n",
+    "2. [Train A Tabular Model on MNIST Dataset](#2.-Train-a-Tabular-Model-on-MNIST-Dataset)\n",
+    "    * [Retrieve Training Artifacts](#2.1.-Retrieve-Training-Artifacts)\n",
+    "    * [Set Training Parameters](#2.2.-Set-Training-Parameters)\n",
+    "    * [Train with Automatic Model Tuning](#2.3.-Train-with-Automatic-Model-Tuning)   \n",
+    "    * [Start Training](#2.4.-Start-Training)\n",
+    "3. [Deploy and Run Inference on the Trained Tabular Model](#3.-Deploy-and-Run-Inference-on-the-Trained-Tabular-Model)\n",
+    "4. [Evaluate the Prediction Results Returned from the Endpoint](#4.-Evaluate-the-Prediction-Results-Returned-from-the-Endpoint)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4eaf3c2",
+   "metadata": {},
+   "source": [
+    "## 1. Set Up\n",
+    "\n",
+    "---\n",
+    "Before executing the notebook, there are some initial steps required for setup. This notebook requires latest version of sagemaker and ipywidgets.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "003e4758",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install sagemaker ipywidgets --upgrade --quiet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f5f8ae5",
+   "metadata": {},
+   "source": [
+    "\n",
+    "---\n",
+    "To train and host on Amazon SageMaker, we need to setup and authenticate the use of AWS services. Here, we use the execution role associated with the current notebook instance as the AWS account role with SageMaker access. It has necessary permissions, including access to your data in S3.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ade4907f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3, json\n",
+    "from sagemaker.core.helper.session_helper import Session, get_execution_role\n",
+    "\n",
+    "sess = Session()\n",
+    "aws_role = get_execution_role()\n",
+    "aws_region = sess.boto_region_name"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "782a079f",
+   "metadata": {},
+   "source": [
+    "## 2. Train a Tabular Model on MNIST Dataset\n",
+    "\n",
+    "---\n",
+    "In this demonstration, we will train a tabular algorithm on the\n",
+    "[MNIST](http://yann.lecun.com/exdb/mnist/) dataset. \n",
+    "The dataset contains examples of individual pixel values from each 28 x 28 grayscale image to predict the digit label of 10 classes {0, 1, 2, 3, ..., 9}. The MNIST dataset is downloaded from [THE MNIST DATABASE](http://yann.lecun.com/exdb/mnist/). \n",
+    "\n",
+    "Below is the table of the first 5 examples in the MNIST dataset.\n",
+    "\n",
+    "| Target | Feature_0 | Feature_1 | Feature_2 | ... | Feature_291 | Feature_293 | Feature_294 | ... | Feature_783 |  Feature_784  |\n",
+    "|:------:|:---------:|:---------:|:---------:|:---:|:-----------:|:-----------:|:-----------:|:---:|:-----------:|:-------------:|\n",
+    "|   7    |    0.0    |    0.0    |    0.0    | ... |   0.00000   |   0.25781   |   0.05469   | ... |     0.0     |      0.0      |\n",
+    "|   2    |    0.0    |    0.0    |    0.0    | ... |   0.00000   |   0.29687   |   0.96484   | ... |     0.0     |      0.0      |\n",
+    "|   1    |    0.0    |    0.0    |    0.0    | ... |   0.00000   |   0.00000   |   0.00000   | ... |     0.0     |      0.0      |\n",
+    "|   0    |    0.0    |    0.0    |    0.0    | ... |   0.98828   |   0.98046   |   0.98046   | ... |     0.0     |      0.0      |\n",
+    "|   4    |    0.0    |    0.0    |    0.0    | ... |   0.20703   |   0.00000   |   0.00000   | ... |     0.0     |      0.0      |\n",
+    "\n",
+    "If you want to bring your own dataset, below are the instructions on how the training data should be formatted as input to the model.\n",
+    "\n",
+    "A S3 path should contain two sub-directories 'train/', 'validation/' (optional), and a json-format file named 'categorical_index.json' (optional). Each sub-directory contains a 'data.csv' file (The MNIST dataset used in this example has been prepared and saved in `training_dataset_s3_path` shown below).\n",
+    "* The 'data.csv' files under sub-directory 'train/' and 'validation/' are for training and validation, respectively. The validation data is used to compute a validation score at the end of each boosting iteration. An early stopping is applied when the validation score stops improving. If the validation data is not provided, a 20% of training data is randomly sampled to serve as the validation data. \n",
+    "\n",
+    "* The first column of the 'data.csv' should have the corresponding target variable. The rest of other columns should have the corresponding predictor variables (features). \n",
+    "\n",
+    "* If the predictors include categorical feature(s), a json-format file named 'categorical_index.json' should be included in the input directory to indicate the column index(es) of the categorical features. Within the json-format file, it should have a python directory where the key is a string of 'cat_index_list' and the value is a list of unique integer(s). Each integer in the list indicates the column index of categorical features in the 'data.csv'. The range of each integer should be more than 0 (index 0 indicates the target) and less than the total number of columns.   \n",
+    "\n",
+    "* All the categorical features and the target must be encoded as non-negative integers (```int```) less than ```Int32.MaxValue``` (2147483647). It is best to use a contiguous range of integers started from zero.\n",
+    "\n",
+    "* Note. The number of json-format files should be no more than 1 in the input directory.  \n",
+    "\n",
+    "\n",
+    "Citations:\n",
+    "\n",
+    "- [LeCun et al., 1998a] Y. LeCun, L. Bottou, Y. Bengio, and P. Haffner. 'Gradient-based learning applied to document recognition.' Proceedings of the IEEE, 86(11):2278-2324, November 1998"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bcd6302d",
+   "metadata": {},
+   "source": [
+    "### 2.1. Select the JumpStart Model\n",
+    "\n",
+    "___\n",
+    "\n",
+    "In v3, we no longer manually retrieve the training container, source code, and pre-trained model artifact. Instead we identify the JumpStart model with a `JumpStartConfig` (specifying the `model_id`), and `ModelTrainer.from_jumpstart_config(...)` resolves the training image, training source code, pre-trained model artifact, and default hyperparameters automatically.\n",
+    "\n",
+    "For the training algorithm, we have two choices in this demonstration.\n",
+    "* [LightGBM](https://lightgbm.readthedocs.io/en/latest/): To use this algorithm, specify `train_model_id` as `lightgbm-classification-model` in the cell below.\n",
+    "* [CatBoost](https://catboost.ai/en/docs/): To use this algorithm, specify `train_model_id` as `catboost-classification-model` in the cell below.\n",
+    "\n",
+    "___"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09049994",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Choose the JumpStart tabular classification model: \"lightgbm-classification-model\"\n",
+    "# or \"catboost-classification-model\". The v3 ModelTrainer.from_jumpstart_config(...) call\n",
+    "# below resolves the training image, source code, pre-trained artifact and default\n",
+    "# hyperparameters automatically from this model_id.\n",
+    "train_model_id, train_model_version, train_scope = \"lightgbm-classification-model\", \"*\", \"training\"\n",
+    "training_instance_type = \"ml.m5.xlarge\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f47078a",
+   "metadata": {},
+   "source": [
+    "### 2.2. Set Training Parameters\n",
+    "\n",
+    "---\n",
+    "\n",
+    "Now that we are done with all the setup that is needed, we are ready to train our tabular algorithm. To begin, let us create a [``sageMaker.estimator.Estimator``](https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html) object. This estimator will launch the training job. \n",
+    "\n",
+    "There are two kinds of parameters that need to be set for training. The first one are the parameters for the training job. These include: (i) Training data path. This is S3 folder in which the input data is stored, (ii) Output path: This the s3 folder in which the training output is stored. (iii) Training instance type: This indicates the type of machine on which to run the training.\n",
+    "\n",
+    "The second set of parameters are algorithm specific training hyper-parameters. \n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a60a885",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sample training data is available in this bucket\n",
+    "training_data_bucket = f\"jumpstart-cache-prod-{aws_region}\"\n",
+    "training_data_prefix = \"training-datasets/tabular_multiclass/\"\n",
+    "\n",
+    "training_dataset_s3_path = f\"s3://{training_data_bucket}/{training_data_prefix}\"\n",
+    "\n",
+    "output_bucket = sess.default_bucket()\n",
+    "output_prefix = \"jumpstart-example-tabular-training\"\n",
+    "default_bucket_prefix = sess.default_bucket_prefix\n",
+    "\n",
+    "# If a default bucket prefix is specified, append it to the s3 path\n",
+    "if default_bucket_prefix:\n",
+    "    output_prefix = f\"{default_bucket_prefix}/{output_prefix}\"\n",
+    "\n",
+    "s3_output_location = f\"s3://{output_bucket}/{output_prefix}/output\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba07adda",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "For algorithm specific hyper-parameters, we start by fetching python dictionary of the training hyper-parameters that the algorithm accepts with their default values. This can then be overridden to custom values.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e426b631",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.core import hyperparameters\n",
+    "\n",
+    "# Retrieve the default hyper-parameters for fine-tuning the model\n",
+    "hyperparameters = hyperparameters.retrieve_default(\n",
+    "    model_id=train_model_id, model_version=train_model_version\n",
+    ")\n",
+    "\n",
+    "# [Optional] Override default hyperparameters with custom values\n",
+    "hyperparameters[\"num_boost_round\"] = (\n",
+    "    \"500\"  # The same hyperparameter is named as \"iterations\" for CatBoost\n",
+    ")\n",
+    "print(hyperparameters)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d1fe56c",
+   "metadata": {},
+   "source": [
+    "### 2.3. Train with Automatic Model Tuning  \n",
+    "\n",
+    "\n",
+    "Amazon SageMaker automatic model tuning, also known as hyperparameter tuning, finds the best version of a model by running many training jobs on your dataset using the algorithm and ranges of hyperparameters that you specify. It then chooses the hyperparameter values that result in a model that performs the best, as measured by a metric that you choose. We will use a HyperparameterTuner object to interact with Amazon SageMaker hyperparameter tuning APIs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "71a58757",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.core.parameter import ContinuousParameter, IntegerParameter\n",
+    "\n",
+    "use_amt = True\n",
+    "\n",
+    "if train_model_id == \"lightgbm-classification-model\":\n",
+    "    hyperparameter_ranges = {\n",
+    "        \"learning_rate\": ContinuousParameter(1e-4, 1, scaling_type=\"Logarithmic\"),\n",
+    "        \"num_boost_round\": IntegerParameter(2, 30),\n",
+    "        \"early_stopping_rounds\": IntegerParameter(2, 30),\n",
+    "        \"num_leaves\": IntegerParameter(10, 50),\n",
+    "        \"feature_fraction\": ContinuousParameter(0, 1),\n",
+    "        \"bagging_fraction\": ContinuousParameter(0, 1),\n",
+    "        \"bagging_freq\": IntegerParameter(1, 10),\n",
+    "        \"max_depth\": IntegerParameter(5, 30),\n",
+    "        \"min_data_in_leaf\": IntegerParameter(5, 50),\n",
+    "    }\n",
+    "\n",
+    "if train_model_id == \"catboost-classification-model\":\n",
+    "    hyperparameter_ranges = {\n",
+    "        \"learning_rate\": ContinuousParameter(0.00001, 0.1, scaling_type=\"Logarithmic\"),\n",
+    "        \"iterations\": IntegerParameter(50, 1000),\n",
+    "        \"early_stopping_rounds\": IntegerParameter(1, 10),\n",
+    "        \"depth\": IntegerParameter(1, 10),\n",
+    "        \"l2_leaf_reg\": IntegerParameter(1, 10),\n",
+    "        \"random_strength\": ContinuousParameter(0.01, 10, scaling_type=\"Logarithmic\"),\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6d81994",
+   "metadata": {},
+   "source": [
+    "### 2.4. Start Training"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d00983ba",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "We create a `ModelTrainer` from the JumpStart config, then wrap it in the v3 `HyperparameterTuner` to launch an Automatic Model Tuning (hyperparameter tuning) job. The tuner runs multiple training jobs over the hyperparameter ranges defined above and selects the best one by minimizing the `multi_logloss` objective.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69bb3c7d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.train import ModelTrainer\n",
+    "from sagemaker.train.configs import Compute, InputData\n",
+    "from sagemaker.train.tuner import HyperparameterTuner\n",
+    "from sagemaker.core.jumpstart import JumpStartConfig\n",
+    "from sagemaker.core.shapes import OutputDataConfig\n",
+    "from sagemaker.core.common_utils import name_from_base\n",
+    "\n",
+    "training_job_name = name_from_base(f\"jumpstart-{train_model_id}-training\")\n",
+    "\n",
+    "# Build the ModelTrainer from the JumpStart config. The training image, source code,\n",
+    "# pre-trained model artifact and environment are resolved automatically from the model ID.\n",
+    "# JumpStartConfig resolves the latest hub content version when model_version is left unset.\n",
+    "jumpstart_config = JumpStartConfig(model_id=train_model_id)\n",
+    "\n",
+    "tabular_trainer = ModelTrainer.from_jumpstart_config(\n",
+    "    jumpstart_config=jumpstart_config,\n",
+    "    role=aws_role,\n",
+    "    sagemaker_session=sess,\n",
+    "    compute=Compute(\n",
+    "        instance_type=training_instance_type,\n",
+    "        instance_count=1,\n",
+    "    ),\n",
+    "    hyperparameters=hyperparameters,\n",
+    "    output_data_config=OutputDataConfig(s3_output_path=s3_output_location),\n",
+    "    base_job_name=training_job_name,\n",
+    ")\n",
+    "\n",
+    "if use_amt:\n",
+    "    # The JumpStart ModelTrainer auto-attaches JumpStart identification tags as Tag\n",
+    "    # objects. The HyperparameterTuner serializes tags assuming the dict form\n",
+    "    # (tag[\"Key\"]), so we clear these Tag objects before tuning to avoid a\n",
+    "    # 'Tag' object is not subscriptable error. The tuning job still gets the\n",
+    "    # JumpStart URI tags that the tuner adds internally in dict form.\n",
+    "    tabular_trainer.tags = []\n",
+    "\n",
+    "    tuner = HyperparameterTuner(\n",
+    "        model_trainer=tabular_trainer,\n",
+    "        objective_metric_name=\"multi_logloss\",\n",
+    "        hyperparameter_ranges=hyperparameter_ranges,\n",
+    "        metric_definitions=[\n",
+    "            {\"Name\": \"multi_logloss\", \"Regex\": \"multi_logloss: ([0-9\\\\.]+)\"}\n",
+    "        ],\n",
+    "        max_jobs=10,\n",
+    "        max_parallel_jobs=2,\n",
+    "        objective_type=\"Minimize\",\n",
+    "        base_tuning_job_name=training_job_name,\n",
+    "    )\n",
+    "\n",
+    "    tuner.tune(\n",
+    "        inputs=[InputData(channel_name=\"training\", data_source=training_dataset_s3_path)],\n",
+    "    )\n",
+    "else:\n",
+    "    # Launch a single SageMaker Training job by passing the s3 path of the training data\n",
+    "    tabular_trainer.train(\n",
+    "        input_data_config=[\n",
+    "            InputData(channel_name=\"training\", data_source=training_dataset_s3_path)\n",
+    "        ],\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2fb57b46",
+   "metadata": {},
+   "source": [
+    "## 3. Deploy and Run Inference on the Trained Tabular Model\n",
+    "\n",
+    "---\n",
+    "\n",
+    "In this section, we deploy the best model found by tuning (or the single trained model if AMT is disabled) to a real-time endpoint and make predictions. For each example, the model outputs the probability of the sample for each class; the predicted class label is the class with the maximum probability.\n",
+    "\n",
+    "The v3 `HyperparameterTuner` does not expose a `deploy()` helper, so we deploy explicitly with `sagemaker-core`: we take the best training job's model artifact, pair it with the JumpStart inference container image and inference source code (retrieved via `sagemaker.core.image_uris` and `sagemaker.core.script_uris`), and create a `Model`, `EndpointConfig`, and `Endpoint`.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08f4cb6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.core import image_uris, script_uris\n",
+    "from sagemaker.core.resources import TrainingJob, Model, EndpointConfig, Endpoint\n",
+    "from sagemaker.core.shapes import ContainerDefinition, ProductionVariant\n",
+    "from sagemaker.core.common_utils import name_from_base\n",
+    "\n",
+    "inference_instance_type = \"ml.m5.large\"\n",
+    "\n",
+    "# Retrieve the inference docker container uri\n",
+    "deploy_image_uri = image_uris.retrieve(\n",
+    "    region=aws_region,\n",
+    "    framework=None,\n",
+    "    image_scope=\"inference\",\n",
+    "    model_id=train_model_id,\n",
+    "    model_version=train_model_version,\n",
+    "    instance_type=inference_instance_type,\n",
+    ")\n",
+    "# Retrieve the inference script uri (source directory tarball). The JumpStart inference\n",
+    "# container downloads and runs inference.py from this SAGEMAKER_SUBMIT_DIRECTORY.\n",
+    "deploy_source_uri = script_uris.retrieve(\n",
+    "    model_id=train_model_id, model_version=train_model_version, script_scope=\"inference\"\n",
+    ")\n",
+    "\n",
+    "# Identify the best model artifact produced by tuning (or the single training job).\n",
+    "if use_amt:\n",
+    "    best_training_job_name = tuner.best_training_job()\n",
+    "else:\n",
+    "    best_training_job_name = tabular_trainer._latest_training_job.training_job_name\n",
+    "print(f\"Best training job: {best_training_job_name}\")\n",
+    "\n",
+    "model_data = TrainingJob.get(best_training_job_name).model_artifacts.s3_model_artifacts\n",
+    "\n",
+    "model_name = name_from_base(f\"jumpstart-example-{train_model_id}-model\")\n",
+    "endpoint_config_name = name_from_base(f\"jumpstart-example-{train_model_id}-config\")\n",
+    "endpoint_name = name_from_base(f\"jumpstart-example-{train_model_id}-\")\n",
+    "\n",
+    "# The trained artifact does not bundle the inference script, so we point the container at\n",
+    "# the JumpStart inference source directory via SAGEMAKER_SUBMIT_DIRECTORY.\n",
+    "tabular_model = Model.create(\n",
+    "    model_name=model_name,\n",
+    "    primary_container=ContainerDefinition(\n",
+    "        image=deploy_image_uri,\n",
+    "        model_data_url=model_data,\n",
+    "        environment={\n",
+    "            \"SAGEMAKER_PROGRAM\": \"inference.py\",\n",
+    "            \"SAGEMAKER_SUBMIT_DIRECTORY\": deploy_source_uri,\n",
+    "            \"MODEL_CACHE_ROOT\": \"/opt/ml/model\",\n",
+    "            \"SAGEMAKER_ENV\": \"1\",\n",
+    "            \"SAGEMAKER_MODEL_SERVER_WORKERS\": \"1\",\n",
+    "        },\n",
+    "    ),\n",
+    "    execution_role_arn=aws_role,\n",
+    ")\n",
+    "\n",
+    "endpoint_config = EndpointConfig.create(\n",
+    "    endpoint_config_name=endpoint_config_name,\n",
+    "    production_variants=[\n",
+    "        ProductionVariant(\n",
+    "            variant_name=\"AllTraffic\",\n",
+    "            model_name=model_name,\n",
+    "            instance_type=inference_instance_type,\n",
+    "            initial_instance_count=1,\n",
+    "            initial_variant_weight=1,\n",
+    "        )\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "predictor = Endpoint.create(\n",
+    "    endpoint_name=endpoint_name,\n",
+    "    endpoint_config_name=endpoint_config_name,\n",
+    ")\n",
+    "predictor.wait_for_status(\"InService\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6cdaa61",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "Next, we download a hold-out MNIST test data from the S3 bucket for inference.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "206f3735",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jumpstart_assets_bucket = f\"jumpstart-cache-prod-{aws_region}\"\n",
+    "test_data_prefix = \"training-datasets/tabular_multiclass/test\"\n",
+    "test_data_file_name = \"data.csv\"\n",
+    "\n",
+    "boto3.client(\"s3\").download_file(\n",
+    "    jumpstart_assets_bucket, f\"{test_data_prefix}/{test_data_file_name}\", test_data_file_name\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e42ae192",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "Next, we read the MNIST test data into pandas data frame, prepare the ground truth target and predicting features to send into the endpoint. \n",
+    "\n",
+    "Below is the screenshot of the first 5 examples in the MNIST test set. All of the test examples with features \n",
+    "from ```Feature_1``` to ```Feature_784``` are sent into the deployed model to get model predictions, \n",
+    "to estimate the ground truth ```Target``` column. For each test example, the model will output \n",
+    "a vector of ```num_classes``` elements, where each element is the probability of the example for each class in the model. \n",
+    "The ```num_classes``` is 10 in this case. Next, the predicted class label is obtained by taking the class label \n",
+    "with the maximum probability over others. \n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33f97980",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "newline, bold, unbold = \"\\n\", \"\\033[1m\", \"\\033[0m\"\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from sklearn.metrics import accuracy_score\n",
+    "from sklearn.metrics import f1_score\n",
+    "from sklearn.metrics import confusion_matrix\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# read the data\n",
+    "test_data = pd.read_csv(test_data_file_name, header=None)\n",
+    "test_data.columns = [\"Target\"] + [f\"Feature_{i}\" for i in range(1, test_data.shape[1])]\n",
+    "\n",
+    "num_examples, num_columns = test_data.shape\n",
+    "print(\n",
+    "    f\"{bold}The test dataset contains {num_examples} examples and {num_columns} columns.{unbold}\\n\"\n",
+    ")\n",
+    "\n",
+    "# prepare the ground truth target and predicting features to send into the endpoint.\n",
+    "ground_truth_label, features = test_data.iloc[:, :1], test_data.iloc[:, 1:]\n",
+    "\n",
+    "print(f\"{bold}The first 5 observations of the data: {unbold} \\n\")\n",
+    "test_data.head(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "003a2d1c",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "The following code queries the endpoint you have created to get the prediction for each test example. \n",
+    "The `query_endpoint()` function returns a array-like of shape (num_examples, num_classes), where each row indicates \n",
+    "the probability of the example for each class in the model. The num_classes is 10 in above test data. \n",
+    "Next, the predicted class label is obtained by taking the class label with the maximum probability over others for each example. \n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cbc8fd83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "content_type = \"text/csv\"\n",
+    "\n",
+    "\n",
+    "def query_endpoint(encoded_tabular_data):\n",
+    "    response = predictor.invoke(\n",
+    "        body=encoded_tabular_data, content_type=content_type\n",
+    "    )\n",
+    "    return response\n",
+    "\n",
+    "\n",
+    "def parse_response(query_response):\n",
+    "    model_predictions = json.loads(query_response.body.read())\n",
+    "    predicted_probabilities = model_predictions[\"probabilities\"]\n",
+    "    return np.array(predicted_probabilities)\n",
+    "\n",
+    "\n",
+    "# split the test data into smaller size of batches to query the endpoint due to the large size of test data.\n",
+    "batch_size = 1500\n",
+    "predict_prob = []\n",
+    "for i in np.arange(0, num_examples, step=batch_size):\n",
+    "    query_response_batch = query_endpoint(\n",
+    "        features.iloc[i : (i + batch_size), :].to_csv(header=False, index=False).encode(\"utf-8\")\n",
+    "    )\n",
+    "    predict_prob_batch = parse_response(query_response_batch)  # prediction probability per batch\n",
+    "    predict_prob.append(predict_prob_batch)\n",
+    "\n",
+    "\n",
+    "predict_prob = np.concatenate(predict_prob, axis=0)\n",
+    "predict_label = np.argmax(\n",
+    "    predict_prob, axis=1\n",
+    ")  # Note. For binary classification, the model returns a array-like of shape (num_examples, 1),\n",
+    "# where each row is the probability of the positive label 1, assuming there are positive label (encoded as 1) and negative label (encoded as 0) in the target.\n",
+    "# To get the probability for both label 0 and 1, execute following code:\n",
+    "# predict_prob = np.vstack((1.0 - predict_prob, predict_prob)).transpose()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0224fb1",
+   "metadata": {},
+   "source": [
+    "## 4. Evaluate the Prediction Results Returned from the Endpoint\n",
+    "\n",
+    "---\n",
+    "We evaluate the predictions results returned from the endpoint by following two ways.\n",
+    "\n",
+    "* Visualize the predictions results by plotting the confusion matrix.\n",
+    "\n",
+    "* Measure the prediction results quantitatively.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03d331de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize the predictions results by plotting the confusion matrix.\n",
+    "conf_matrix = confusion_matrix(y_true=ground_truth_label.values, y_pred=predict_label)\n",
+    "fig, ax = plt.subplots(figsize=(7.5, 7.5))\n",
+    "ax.matshow(conf_matrix, cmap=plt.cm.Blues, alpha=0.3)\n",
+    "for i in range(conf_matrix.shape[0]):\n",
+    "    for j in range(conf_matrix.shape[1]):\n",
+    "        ax.text(x=j, y=i, s=conf_matrix[i, j], va=\"center\", ha=\"center\", size=\"xx-large\")\n",
+    "\n",
+    "plt.xlabel(\"Predictions\", fontsize=18)\n",
+    "plt.ylabel(\"Actuals\", fontsize=18)\n",
+    "plt.title(\"Confusion Matrix\", fontsize=18)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d2d2d65",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Measure the prediction results quantitatively.\n",
+    "eval_accuracy = accuracy_score(ground_truth_label.values, predict_label)\n",
+    "eval_f1_macro = f1_score(ground_truth_label.values, predict_label, average=\"macro\")\n",
+    "eval_f1_micro = f1_score(ground_truth_label.values, predict_label, average=\"micro\")\n",
+    "\n",
+    "print(\n",
+    "    f\"{bold}Evaluation result on test data{unbold}:{newline}\"\n",
+    "    f\"{bold}{accuracy_score.__name__}{unbold}: {eval_accuracy}{newline}\"\n",
+    "    f\"{bold}F1 Macro{unbold}: {eval_f1_macro}{newline}\"\n",
+    "    f\"{bold}F1 Micro{unbold}: {eval_f1_micro}{newline}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e36f57c5",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "Next, we delete the endpoint corresponding to the finetuned model.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ff6901e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Delete the SageMaker endpoint and the attached resources\n",
+    "predictor.delete()\n",
+    "endpoint_config.delete()\n",
+    "tabular_model.delete()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "db26128b",
+   "metadata": {},
+   "source": [
+    "## Notebook CI Test Results\n",
+    "\n",
+    "This notebook was tested in multiple regions. The test results are as follows, except for us-west-2 which is shown at the top of the notebook.\n",
+    "\n",
+    "![This us-east-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-east-1/build_and_train_models|sm-lightgbm_catboost_tabular_classification.ipynb)\n",
+    "\n",
+    "![This us-east-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-east-2/build_and_train_models|sm-lightgbm_catboost_tabular_classification.ipynb)\n",
+    "\n",
+    "![This us-west-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-west-1/build_and_train_models|sm-lightgbm_catboost_tabular_classification.ipynb)\n",
+    "\n",
+    "![This ca-central-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ca-central-1/build_and_train_models|sm-lightgbm_catboost_tabular_classification.ipynb)\n",
+    "\n",
+    "![This sa-east-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/sa-east-1/build_and_train_models|sm-lightgbm_catboost_tabular_classification.ipynb)\n",
+    "\n",
+    "![This eu-west-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-1/build_and_train_models|sm-lightgbm_catboost_tabular_classification.ipynb)\n",
+    "\n",
+    "![This eu-west-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-2/build_and_train_models|sm-lightgbm_catboost_tabular_classification.ipynb)\n",
+    "\n",
+    "![This eu-west-3 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-3/build_and_train_models|sm-lightgbm_catboost_tabular_classification.ipynb)\n",
+    "\n",
+    "![This eu-central-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-central-1/build_and_train_models|sm-lightgbm_catboost_tabular_classification.ipynb)\n",
+    "\n",
+    "![This eu-north-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-north-1/build_and_train_models|sm-lightgbm_catboost_tabular_classification.ipynb)\n",
+    "\n",
+    "![This ap-southeast-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-southeast-1/build_and_train_models|sm-lightgbm_catboost_tabular_classification.ipynb)\n",
+    "\n",
+    "![This ap-southeast-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-southeast-2/build_and_train_models|sm-lightgbm_catboost_tabular_classification.ipynb)\n",
+    "\n",
+    "![This ap-northeast-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-northeast-1/build_and_train_models|sm-lightgbm_catboost_tabular_classification.ipynb)\n",
+    "\n",
+    "![This ap-northeast-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-northeast-2/build_and_train_models|sm-lightgbm_catboost_tabular_classification.ipynb)\n",
+    "\n",
+    "![This ap-south-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-south-1/build_and_train_models|sm-lightgbm_catboost_tabular_classification.ipynb)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (Data Science 3.0)",
+   "language": "python",
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/sagemaker-data-science-310-v1"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/      build_and_train_models/sm-linear_learner_mnist-v3.ipynb
+++ b/      build_and_train_models/sm-linear_learner_mnist-v3.ipynb
@@ -1,0 +1,732 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# An Introduction to Linear Learner with MNIST\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "This notebook's CI test result for us-west-2 is as follows. CI test results in other regions can be found at the end of the notebook. \n",
+    "\n",
+    "![This us-west-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-west-2/build_and_train_models|sm-linear_learner_mnist.ipynb)\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "_**Making a Binary Prediction of Whether a Handwritten Digit is a 0**_\n",
+    "\n",
+    "1. [Introduction](#Introduction)\n",
+    "2. [Prerequisites and Preprocessing](#Prequisites-and-Preprocessing)\n",
+    "   1. [Permissions and environment variables](#Permissions-and-environment-variables)\n",
+    "   2. [Data ingestion](#Data-ingestion)\n",
+    "   3. [Data inspection](#Data-inspection)\n",
+    "   4. [Data conversion](#Data-conversion)\n",
+    "3. [Training the linear model](#Training-the-linear-model)\n",
+    "   1. [Training the Linear Learner model with SageMaker Training](#Training-with-sagemaker-training)\n",
+    "   2. [Training with Automatic Model Tuning (HPO)](#Training-with-automatic-model-tuning-HPO)\n",
+    "4. [Set up hosting for the model](#Set-up-hosting-for-the-model)\n",
+    "5. [Validate the model for use](#Validate-the-model-for-use)\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "Welcome to our example introducing Amazon SageMaker's Linear Learner Algorithm!  Today, we're analyzing the [MNIST](https://en.wikipedia.org/wiki/MNIST_database) dataset which consists of images of handwritten digits, from zero to nine.  We'll use the individual pixel values from each 28 x 28 grayscale image to predict a yes or no label of whether the digit is a 0 or some other digit (1, 2, 3, ... 9).\n",
+    "\n",
+    "The method that we'll use is a linear binary classifier.  Linear models are supervised learning algorithms used for solving either classification or regression problems.  As input, the model is given labeled examples ( **`x`**, `y`). **`x`** is a high dimensional vector and `y` is a numeric label.  Since we are doing binary classification, the algorithm expects the label to be either 0 or 1 (but Amazon SageMaker Linear Learner also supports regression on continuous values of `y`).  The algorithm learns a linear function, or linear threshold function for classification, mapping the vector **`x`** to an approximation of the label `y`.\n",
+    "\n",
+    "Amazon SageMaker's Linear Learner algorithm extends upon typical linear models by training many models in parallel, in a computationally efficient manner.  Each model has a different set of hyperparameters, and then the algorithm finds the set that optimizes a specific criteria.  This can provide substantially more accurate models than typical linear algorithms at the same, or lower, cost.\n",
+    "\n",
+    "To get started, we need to set up the environment with a few prerequisite steps, for permissions, configurations, and so on."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prequisites and Preprocessing\n",
+    "\n",
+    "### Permissions and environment variables\n",
+    "\n",
+    "_This notebook was created and tested on an ml.m4.xlarge notebook instance._\n",
+    "\n",
+    "Let's start by specifying:\n",
+    "\n",
+    "- The S3 buckets and prefixes that you want to use for training and model data and where original data is located.  These should be within the same region as the Notebook Instance, training, and hosting.\n",
+    "- The IAM role arn used to give training and hosting access to your data. See the documentation for how to create these.  Note, if more than one role is required for notebook instances, training, and/or hosting, please replace the boto regexp with a the appropriate full IAM role arn string(s)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook has been migrated to the **SageMaker Python SDK v3**. Install with:\n",
+    "\n",
+    "```\n",
+    "pip install 'sagemaker>=3.0'\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "import boto3\n",
+    "from sagemaker.core.helper.session_helper import Session, get_execution_role\n",
+    "\n",
+    "sess = Session()\n",
+    "\n",
+    "region = boto3.Session().region_name\n",
+    "\n",
+    "# S3 bucket where the original mnist data is downloaded and stored.\n",
+    "downloaded_data_bucket = f\"sagemaker-example-files-prod-{region}\"\n",
+    "downloaded_data_prefix = \"datasets/image/MNIST\"\n",
+    "\n",
+    "# S3 bucket for saving code and model artifacts.\n",
+    "# Feel free to specify a different bucket and prefix\n",
+    "bucket = sess.default_bucket()\n",
+    "prefix = \"sagemaker/DEMO-linear-mnist\"\n",
+    "default_bucket_prefix = sess.default_bucket_prefix\n",
+    "\n",
+    "# If a default bucket prefix is specified, append it to the s3 path\n",
+    "if default_bucket_prefix:\n",
+    "    prefix = f\"{default_bucket_prefix}/{prefix}\"\n",
+    "\n",
+    "# Define IAM role\n",
+    "role = get_execution_role()\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Data ingestion\n",
+    "\n",
+    "Next, we read the MNIST dataset [1] from an existing repository into memory, for preprocessing prior to training. It was downloaded from this [link](http://deeplearning.net/data/mnist/mnist.pkl.gz) and stored on the `downloaded_data_bucket`. Processing could be done *in situ* by Amazon Athena, Apache Spark in Amazon EMR, Amazon Redshift, etc., assuming the dataset is present in the appropriate location. Then, the next step would be to transfer the data to S3 for use in training. For small datasets, such as this one, reading into memory isn't onerous, though it would be for larger datasets.\n",
+    "> [1] Y. LeCun, L. Bottou, Y. Bengio, and P. Haffner. Gradient-based learning applied to document recognition. Proceedings of the IEEE, 86(11):2278-2324, November 1998."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "import pickle, gzip, numpy, json\n",
+    "\n",
+    "# Load the dataset\n",
+    "s3 = boto3.client(\"s3\")\n",
+    "s3.download_file(downloaded_data_bucket, f\"{downloaded_data_prefix}/mnist.pkl.gz\", \"mnist.pkl.gz\")\n",
+    "with gzip.open(\"mnist.pkl.gz\", \"rb\") as f:\n",
+    "    train_set, valid_set, test_set = pickle.load(f, encoding=\"latin1\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Data inspection\n",
+    "\n",
+    "Once the dataset is imported, it's typical as part of the machine learning process to inspect the data, understand the distributions, and determine what type(s) of preprocessing might be needed. You can perform those tasks right here in the notebook. As an example, let's go ahead and look at one of the digits that is part of the dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "plt.rcParams[\"figure.figsize\"] = (2, 10)\n",
+    "\n",
+    "\n",
+    "def show_digit(img, caption=\"\", subplot=None):\n",
+    "    if subplot is None:\n",
+    "        _, (subplot) = plt.subplots(1, 1)\n",
+    "    imgr = img.reshape((28, 28))\n",
+    "    subplot.axis(\"off\")\n",
+    "    subplot.imshow(imgr, cmap=\"gray\")\n",
+    "    plt.title(caption)\n",
+    "\n",
+    "\n",
+    "show_digit(train_set[0][30], f\"This is a {train_set[1][30]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Data conversion\n",
+    "\n",
+    "Since algorithms have particular input and output requirements, converting the dataset is also part of the process that a data scientist goes through prior to initiating training. The Amazon SageMaker Linear Learner algorithm accepts either `recordIO-wrapped protobuf` or `CSV`. In this v3 example we use **CSV**: the first column is the label and the remaining columns are the 784 pixel features. The data we have today is a pickle-ized numpy array on disk, which we convert to CSV below.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import io\n",
+    "import numpy as np\n",
+    "\n",
+    "train_set_vectors = np.array([t.tolist() for t in train_set[0]]).astype(\"float32\")\n",
+    "train_set_labels = np.where(np.array([t.tolist() for t in train_set[1]]) == 0, 1, 0).astype(\n",
+    "    \"float32\"\n",
+    ")\n",
+    "\n",
+    "validation_set_vectors = np.array([t.tolist() for t in valid_set[0]]).astype(\"float32\")\n",
+    "validation_set_labels = np.where(np.array([t.tolist() for t in valid_set[1]]) == 0, 1, 0).astype(\n",
+    "    \"float32\"\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def to_csv_bytes(vectors, labels):\n",
+    "    # Linear Learner text/csv format: first column is the label, rest are features.\n",
+    "    buf = io.BytesIO()\n",
+    "    matrix = np.column_stack([labels, vectors]).astype(\"float32\")\n",
+    "    np.savetxt(buf, matrix, delimiter=\",\", fmt=\"%g\")\n",
+    "    buf.seek(0)\n",
+    "    return buf\n",
+    "\n",
+    "\n",
+    "train_set_buf = to_csv_bytes(train_set_vectors, train_set_labels)\n",
+    "validation_set_buf = to_csv_bytes(validation_set_vectors, validation_set_labels)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Upload training data\n",
+    "Now that we've created our CSV data, we'll need to upload it to S3, so that Amazon SageMaker training can use it.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "import os\n",
+    "\n",
+    "key = \"csv-data\"\n",
+    "boto3.resource(\"s3\").Bucket(bucket).Object(os.path.join(prefix, \"train\", key)).upload_fileobj(\n",
+    "    train_set_buf\n",
+    ")\n",
+    "boto3.resource(\"s3\").Bucket(bucket).Object(os.path.join(prefix, \"validation\", key)).upload_fileobj(\n",
+    "    validation_set_buf\n",
+    ")\n",
+    "s3_train_data = f\"s3://{bucket}/{prefix}/train/{key}\"\n",
+    "print(f\"uploaded training data location: {s3_train_data}\")\n",
+    "s3_validation_data = f\"s3://{bucket}/{prefix}/validation/{key}\"\n",
+    "print(f\"uploaded validation data location: {s3_validation_data}\")\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's also setup an output S3 location for the model artifact that will be output as the result of training with the algorithm."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_location = f\"s3://{bucket}/{prefix}/output\"\n",
+    "print(f\"training artifacts will be uploaded to: {output_location}\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Training the linear model\n",
+    "\n",
+    "Once we have the data preprocessed and available in the correct format for training, the next step is to actually train the model using the data. Since this data is relatively small, it isn't meant to show off the performance of the Linear Learner training algorithm, although we have tested it on multi-terabyte datasets.\n",
+    "\n",
+    "Training can be done by either calling SageMaker Training with a set of hyperparameters values to train with, or by leveraging SageMaker Automatic Model Tuning ([AMT](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning.html)). AMT, also known as hyperparameter tuning (HPO), finds the best version of a model by running many training jobs on your dataset using the algorithm and ranges of hyperparameters that you specify. It then chooses the hyperparameter values that result in a model that performs the best, as measured by a metric that you choose.\n",
+    "\n",
+    "In this notebook, both methods are used for demonstration purposes, but the model that the HPO job creates is the one that is eventually hosted. You can instead choose to deploy the model created by the standalone training job by changing the below variable `deploy_amt_model` to False.\n",
+    "\n",
+    "### Training with SageMaker Training\n",
+    "\n",
+    "We'll use the Amazon SageMaker Python SDK to kick off training, and monitor status until it is completed.  In this example that takes between 7 and 11 minutes. Despite the dataset being small, provisioning hardware and loading the algorithm container take time upfront.\n",
+    "\n",
+    "First, let's specify our container. We retrieve the image for the Linear Learner Algorithm according to the region."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.core import image_uris\n",
+    "\n",
+    "container = image_uris.retrieve(region=region, framework=\"linear-learner\")\n",
+    "deploy_amt_model = True\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then we create an [estimator from the SageMaker Python SDK](https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html) using the Linear Learner container image and we setup the training parameters and hyperparameters configuration. Notice:\n",
+    "- `feature_dim` is set to 784, which is the number of pixels in each 28 x 28 image.\n",
+    "- `predictor_type` is set to 'binary_classifier' since we are trying to predict whether the image is or is not a 0.\n",
+    "- `mini_batch_size` is set to 200.  This value can be tuned for relatively minor improvements in fit and speed, but selecting a reasonable value relative to the dataset is appropriate in most cases."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "from sagemaker.core.resources import TrainingJob\n",
+    "from sagemaker.core.shapes import (\n",
+    "    AlgorithmSpecification,\n",
+    "    Channel,\n",
+    "    DataSource,\n",
+    "    S3DataSource,\n",
+    "    ResourceConfig,\n",
+    "    OutputDataConfig,\n",
+    "    StoppingCondition,\n",
+    ")\n",
+    "\n",
+    "output_location = f\"s3://{bucket}/{prefix}/output\"\n",
+    "print(f\"training artifacts will be uploaded to: {output_location}\")\n",
+    "\n",
+    "training_job_name = \"DEMO-ll-mnist-\" + time.strftime(\"%Y-%m-%d-%H-%M-%S\", time.gmtime())\n",
+    "\n",
+    "\n",
+    "def csv_channel(channel_name, s3_uri):\n",
+    "    return Channel(\n",
+    "        channel_name=channel_name,\n",
+    "        data_source=DataSource(\n",
+    "            s3_data_source=S3DataSource(\n",
+    "                s3_data_type=\"S3Prefix\",\n",
+    "                s3_uri=s3_uri,\n",
+    "                s3_data_distribution_type=\"FullyReplicated\",\n",
+    "            )\n",
+    "        ),\n",
+    "        content_type=\"text/csv\",\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "linear_training_job = TrainingJob.create(\n",
+    "    training_job_name=training_job_name,\n",
+    "    role_arn=role,\n",
+    "    algorithm_specification=AlgorithmSpecification(\n",
+    "        training_image=container,\n",
+    "        training_input_mode=\"File\",\n",
+    "    ),\n",
+    "    hyper_parameters={\n",
+    "        \"feature_dim\": \"784\",\n",
+    "        \"predictor_type\": \"binary_classifier\",\n",
+    "        \"mini_batch_size\": \"200\",\n",
+    "    },\n",
+    "    input_data_config=[csv_channel(\"train\", s3_train_data)],\n",
+    "    output_data_config=OutputDataConfig(s3_output_path=output_location),\n",
+    "    resource_config=ResourceConfig(\n",
+    "        instance_type=\"ml.c4.xlarge\",\n",
+    "        instance_count=1,\n",
+    "        volume_size_in_gb=10,\n",
+    "    ),\n",
+    "    stopping_condition=StoppingCondition(max_runtime_in_seconds=3600),\n",
+    ")\n",
+    "linear_training_job.wait()\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Training with Automatic Model Tuning ([HPO](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning.html)) <a id='AMT'></a>\n",
+    "***\n",
+    "As mentioned above, instead of manually configuring our hyper parameter values and training with SageMaker Training, we'll use Amazon SageMaker Automatic Model Tuning.\n",
+    "        \n",
+    "The code sample below shows you how to use the HyperParameterTuner. For recommended default hyparameter ranges, check the [Amazon SageMaker Linear Learner HPs documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/linear-learner.html).\n",
+    "\n",
+    "The tuning job will take 8 to 10 minutes to complete.\n",
+    "***"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "from sagemaker.core.resources import HyperParameterTuningJob\n",
+    "from sagemaker.core.shapes import (\n",
+    "    HyperParameterTuningJobConfig,\n",
+    "    HyperParameterTrainingJobDefinition,\n",
+    "    HyperParameterAlgorithmSpecification,\n",
+    "    ParameterRanges,\n",
+    "    ContinuousParameterRange,\n",
+    "    IntegerParameterRange,\n",
+    "    HyperParameterTuningJobObjective,\n",
+    "    ResourceLimits,\n",
+    ")\n",
+    "\n",
+    "job_name = \"DEMO-ll-mni-\" + time.strftime(\"%Y-%m-%d-%H-%M-%S\", time.gmtime())\n",
+    "print(\"Tuning job name:\", job_name)\n",
+    "\n",
+    "# Linear Learner tunable hyper parameters can be found here\n",
+    "# https://docs.aws.amazon.com/sagemaker/latest/dg/linear-learner-tuning.html\n",
+    "parameter_ranges = ParameterRanges(\n",
+    "    continuous_parameter_ranges=[\n",
+    "        ContinuousParameterRange(name=\"wd\", min_value=\"1e-7\", max_value=\"1\", scaling_type=\"Auto\"),\n",
+    "        ContinuousParameterRange(\n",
+    "            name=\"learning_rate\", min_value=\"1e-5\", max_value=\"1\", scaling_type=\"Auto\"\n",
+    "        ),\n",
+    "    ],\n",
+    "    integer_parameter_ranges=[\n",
+    "        IntegerParameterRange(\n",
+    "            name=\"mini_batch_size\", min_value=\"100\", max_value=\"2000\", scaling_type=\"Auto\"\n",
+    "        ),\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "# Increase the total number of training jobs run by AMT, for increased accuracy\n",
+    "# (and training time).\n",
+    "max_jobs = 6\n",
+    "# Change parallel training jobs run by AMT to reduce total training time,\n",
+    "# constrained by your account limits.\n",
+    "# if max_jobs=max_parallel_jobs then Bayesian search turns to Random.\n",
+    "max_parallel_jobs = 2\n",
+    "\n",
+    "hp_tuning_job = HyperParameterTuningJob.create(\n",
+    "    hyper_parameter_tuning_job_name=job_name,\n",
+    "    hyper_parameter_tuning_job_config=HyperParameterTuningJobConfig(\n",
+    "        strategy=\"Bayesian\",\n",
+    "        hyper_parameter_tuning_job_objective=HyperParameterTuningJobObjective(\n",
+    "            type=\"Maximize\", metric_name=\"validation:binary_f_beta\"\n",
+    "        ),\n",
+    "        resource_limits=ResourceLimits(\n",
+    "            max_number_of_training_jobs=max_jobs, max_parallel_training_jobs=max_parallel_jobs\n",
+    "        ),\n",
+    "        parameter_ranges=parameter_ranges,\n",
+    "    ),\n",
+    "    training_job_definition=HyperParameterTrainingJobDefinition(\n",
+    "        algorithm_specification=HyperParameterAlgorithmSpecification(\n",
+    "            training_image=container,\n",
+    "            training_input_mode=\"File\",\n",
+    "        ),\n",
+    "        role_arn=role,\n",
+    "        input_data_config=[\n",
+    "            csv_channel(\"train\", s3_train_data),\n",
+    "            csv_channel(\"validation\", s3_validation_data),\n",
+    "        ],\n",
+    "        output_data_config=OutputDataConfig(s3_output_path=output_location),\n",
+    "        resource_config=ResourceConfig(\n",
+    "            instance_type=\"ml.c4.xlarge\",\n",
+    "            instance_count=1,\n",
+    "            volume_size_in_gb=10,\n",
+    "        ),\n",
+    "        stopping_condition=StoppingCondition(max_runtime_in_seconds=3600),\n",
+    "        static_hyper_parameters={\n",
+    "            \"feature_dim\": \"784\",\n",
+    "            \"predictor_type\": \"binary_classifier\",\n",
+    "        },\n",
+    "    ),\n",
+    ")\n",
+    "hp_tuning_job.wait()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up hosting for the model\n",
+    "Now that we've trained our model, we can deploy it behind an Amazon SageMaker real-time hosted endpoint. This will allow us to make predictions (or inference) from the model dynamically.\n",
+    "\n",
+    "In v3 we use the `sagemaker-core` resource classes (`Model`, `EndpointConfig`, `Endpoint`) directly. We locate the best training job from the tuning job (or use the standalone training job), fetch its model artifact, and create the hosting resources.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "from sagemaker.core.resources import Model, EndpointConfig, Endpoint\n",
+    "from sagemaker.core.shapes import ContainerDefinition, ProductionVariant\n",
+    "\n",
+    "# Pick which training job's artifacts to host.\n",
+    "if deploy_amt_model:\n",
+    "    # Refresh the tuning job to populate best_training_job after completion.\n",
+    "    hp_tuning_job.refresh()\n",
+    "    best_job_name = hp_tuning_job.best_training_job.training_job_name\n",
+    "    source_training_job = TrainingJob.get(best_job_name)\n",
+    "else:\n",
+    "    source_training_job = linear_training_job\n",
+    "\n",
+    "model_artifact = source_training_job.model_artifacts.s3_model_artifacts\n",
+    "\n",
+    "# Linear Learner uses the same image for training and inference.\n",
+    "inference_image = image_uris.retrieve(region=region, framework=\"linear-learner\")\n",
+    "\n",
+    "suffix = time.strftime(\"%Y-%m-%d-%H-%M-%S\", time.gmtime())\n",
+    "model_name = f\"DEMO-ll-model-{suffix}\"\n",
+    "endpoint_config_name = f\"DEMO-ll-epc-{suffix}\"\n",
+    "endpoint_name = f\"DEMO-ll-ep-{suffix}\"\n",
+    "\n",
+    "ll_model = Model.create(\n",
+    "    model_name=model_name,\n",
+    "    primary_container=ContainerDefinition(\n",
+    "        image=inference_image,\n",
+    "        model_data_url=model_artifact,\n",
+    "    ),\n",
+    "    execution_role_arn=role,\n",
+    ")\n",
+    "\n",
+    "ll_endpoint_config = EndpointConfig.create(\n",
+    "    endpoint_config_name=endpoint_config_name,\n",
+    "    production_variants=[\n",
+    "        ProductionVariant(\n",
+    "            variant_name=\"AllTraffic\",\n",
+    "            model_name=model_name,\n",
+    "            initial_instance_count=1,\n",
+    "            instance_type=\"ml.m4.xlarge\",\n",
+    "            initial_variant_weight=1.0,\n",
+    "        )\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "linear_endpoint = Endpoint.create(\n",
+    "    endpoint_name=endpoint_name,\n",
+    "    endpoint_config_name=endpoint_config_name,\n",
+    ")\n",
+    "linear_endpoint.wait_for_status(\"InService\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Validate the model for use\n",
+    "Finally, we can now validate the model for use. We can pass HTTP POST requests to the endpoint to get back predictions. We send CSV-formatted records and parse the JSON response returned by the Linear Learner algorithm.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import io\n",
+    "import json\n",
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "def ll_predict(records):\n",
+    "    # records: 2D array-like of float features. Serialize to CSV, invoke, parse JSON.\n",
+    "    arr = np.array(records, dtype=\"float32\")\n",
+    "    if arr.ndim == 1:\n",
+    "        arr = arr.reshape(1, -1)\n",
+    "    buf = io.StringIO()\n",
+    "    np.savetxt(buf, arr, delimiter=\",\", fmt=\"%g\")\n",
+    "    response = linear_endpoint.invoke(\n",
+    "        body=buf.getvalue().encode(\"utf-8\"),\n",
+    "        content_type=\"text/csv\",\n",
+    "        accept=\"application/json\",\n",
+    "    )\n",
+    "    payload = response.body.read()\n",
+    "    if isinstance(payload, bytes):\n",
+    "        payload = payload.decode(\"utf-8\")\n",
+    "    return json.loads(payload)\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's try getting a prediction for a single record."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = ll_predict(train_set[0][30:31])\n",
+    "print(result)\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "OK, a single prediction works.  We see that for one record our endpoint returned some JSON which contains `predictions`, including the `score` and `predicted_label`.  In this case, `score` will be a continuous value between [0, 1] representing the probability we think the digit is a 0 or not.  `predicted_label` will take a value of either `0` or `1` where (somewhat counterintuitively) `1` denotes that we predict the image is a 0, while `0` denotes that we are predicting the image is not of a 0.\n",
+    "\n",
+    "Let's do a whole batch of images and evaluate our predictive accuracy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "predictions = []\n",
+    "for array in np.array_split(test_set[0], 100):\n",
+    "    result = ll_predict(array)\n",
+    "    predictions += [r[\"predicted_label\"] for r in result[\"predictions\"]]\n",
+    "\n",
+    "predictions = np.array(predictions)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "pd.crosstab(\n",
+    "    np.where(test_set[1] == 0, 1, 0), predictions, rownames=[\"actuals\"], colnames=[\"predictions\"]\n",
+    ")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we can see from the confusion matrix above, we predict 931 images of 0 correctly, while we predict 44 images as 0s that aren't, and miss predicting 49 images of 0."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### (Optional) Delete the Endpoint\n",
+    "\n",
+    "If you're ready to be done with this notebook, please run the delete_endpoint line in the cell below.  This will remove the hosted endpoint you created and avoid any charges from a stray instance being left on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linear_endpoint.delete()\n",
+    "ll_endpoint_config.delete()\n",
+    "ll_model.delete()\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Notebook CI Test Results\n",
+    "\n",
+    "This notebook was tested in multiple regions. The test results are as follows, except for us-west-2 which is shown at the top of the notebook.\n",
+    "\n",
+    "![This us-east-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-east-1/build_and_train_models|sm-linear_learner_mnist.ipynb)\n",
+    "\n",
+    "![This us-east-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-east-2/build_and_train_models|sm-linear_learner_mnist.ipynb)\n",
+    "\n",
+    "![This us-west-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-west-1/build_and_train_models|sm-linear_learner_mnist.ipynb)\n",
+    "\n",
+    "![This ca-central-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ca-central-1/build_and_train_models|sm-linear_learner_mnist.ipynb)\n",
+    "\n",
+    "![This sa-east-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/sa-east-1/build_and_train_models|sm-linear_learner_mnist.ipynb)\n",
+    "\n",
+    "![This eu-west-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-1/build_and_train_models|sm-linear_learner_mnist.ipynb)\n",
+    "\n",
+    "![This eu-west-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-2/build_and_train_models|sm-linear_learner_mnist.ipynb)\n",
+    "\n",
+    "![This eu-west-3 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-3/build_and_train_models|sm-linear_learner_mnist.ipynb)\n",
+    "\n",
+    "![This eu-central-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-central-1/build_and_train_models|sm-linear_learner_mnist.ipynb)\n",
+    "\n",
+    "![This eu-north-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-north-1/build_and_train_models|sm-linear_learner_mnist.ipynb)\n",
+    "\n",
+    "![This ap-southeast-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-southeast-1/build_and_train_models|sm-linear_learner_mnist.ipynb)\n",
+    "\n",
+    "![This ap-southeast-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-southeast-2/build_and_train_models|sm-linear_learner_mnist.ipynb)\n",
+    "\n",
+    "![This ap-northeast-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-northeast-1/build_and_train_models|sm-linear_learner_mnist.ipynb)\n",
+    "\n",
+    "![This ap-northeast-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-northeast-2/build_and_train_models|sm-linear_learner_mnist.ipynb)\n",
+    "\n",
+    "![This ap-south-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-south-1/build_and_train_models|sm-linear_learner_mnist.ipynb)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "instance_type": "ml.t3.medium",
+  "kernelspec": {
+   "display_name": "Python 3 (Data Science 3.0)",
+   "language": "python",
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/sagemaker-data-science-310-v1"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  },
+  "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/      build_and_train_models/sm-managed_spot_training_xgboost/abalone.py
+++ b/      build_and_train_models/sm-managed_spot_training_xgboost/abalone.py
@@ -1,0 +1,111 @@
+"""XGBoost script-mode entry point for the Managed Spot Training example.
+
+This script is executed inside the SageMaker XGBoost (framework/script mode)
+container. It reads libsvm-formatted training and validation data from the
+SageMaker channel directories, trains an XGBoost model, and writes the model
+artifact to the model directory.
+
+Managed Spot Training checkpointing is enabled through the
+``sagemaker_xgboost_container.checkpointing`` helpers so the job can resume from
+the last saved checkpoint after a Spot interruption. Checkpoints are written to
+``/opt/ml/checkpoints`` (the container-local path that SageMaker syncs with the
+``checkpoint_s3_uri`` you configure on the trainer).
+"""
+import argparse
+import logging
+import os
+import pickle as pkl
+
+import xgboost as xgb
+from sagemaker_xgboost_container import checkpointing
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Default local checkpoint directory used by managed spot training.
+CHECKPOINTS_DIR = "/opt/ml/checkpoints"
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser()
+
+    # Hyperparameters are passed to the script as command-line arguments.
+    parser.add_argument("--max_depth", type=int, default=5)
+    parser.add_argument("--eta", type=float, default=0.2)
+    parser.add_argument("--gamma", type=float, default=4)
+    parser.add_argument("--min_child_weight", type=float, default=6)
+    parser.add_argument("--subsample", type=float, default=0.7)
+    parser.add_argument("--alpha", type=float, default=0)
+    parser.add_argument("--objective", type=str, default="reg:squarederror")
+    parser.add_argument("--num_round", type=int, default=50)
+    parser.add_argument("--verbosity", type=int, default=2)
+
+    # SageMaker specific arguments. Defaults are set in the environment variables.
+    parser.add_argument("--model_dir", type=str, default=os.environ.get("SM_MODEL_DIR"))
+    parser.add_argument("--train", type=str, default=os.environ.get("SM_CHANNEL_TRAIN"))
+    parser.add_argument(
+        "--validation", type=str, default=os.environ.get("SM_CHANNEL_VALIDATION")
+    )
+
+    # Use parse_known_args so the script tolerates extra hyperparameters that
+    # SageMaker injects during Automatic Model Tuning (e.g.
+    # ``_tuning_objective_metric``) as well as any additional tunable
+    # hyperparameters not explicitly declared above.
+    args, _ = parser.parse_known_args()
+    return args
+
+
+def _find_data_file(channel_dir):
+    """Return the path to the single data file inside a channel directory."""
+    files = [
+        os.path.join(channel_dir, f)
+        for f in os.listdir(channel_dir)
+        if os.path.isfile(os.path.join(channel_dir, f))
+    ]
+    if not files:
+        raise ValueError(f"No data files found in channel directory: {channel_dir}")
+    return files[0]
+
+
+def main():
+    args = _parse_args()
+
+    # Load the libsvm data into XGBoost DMatrix objects.
+    dtrain = xgb.DMatrix(f"{_find_data_file(args.train)}?format=libsvm")
+
+    watchlist = [(dtrain, "train")]
+    if args.validation:
+        dval = xgb.DMatrix(f"{_find_data_file(args.validation)}?format=libsvm")
+        watchlist.append((dval, "validation"))
+
+    train_hp = {
+        "max_depth": args.max_depth,
+        "eta": args.eta,
+        "gamma": args.gamma,
+        "min_child_weight": args.min_child_weight,
+        "subsample": args.subsample,
+        "alpha": args.alpha,
+        "objective": args.objective,
+        "verbosity": args.verbosity,
+    }
+
+    # Enable managed-spot-training checkpointing. checkpointing.train() loads any
+    # existing checkpoint, resumes from the last completed iteration, and saves a
+    # checkpoint per round so the job can survive Spot interruptions.
+    train_args = dict(
+        params=train_hp,
+        dtrain=dtrain,
+        evals=watchlist,
+        num_boost_round=args.num_round,
+    )
+    bst = checkpointing.train(train_args, checkpoint_dir=CHECKPOINTS_DIR)
+
+    # Persist the trained model to the model directory so SageMaker uploads it.
+    os.makedirs(args.model_dir, exist_ok=True)
+    model_location = os.path.join(args.model_dir, "xgboost-model")
+    pkl.dump(bst, open(model_location, "wb"))
+    logger.info("Stored trained model at %s", model_location)
+
+
+if __name__ == "__main__":
+    main()

--- a/      build_and_train_models/sm-managed_spot_training_xgboost/abalone.py
+++ b/      build_and_train_models/sm-managed_spot_training_xgboost/abalone.py
@@ -56,12 +56,21 @@ def _parse_args():
 
 
 def _find_data_file(channel_dir):
-    """Return the path to the single data file inside a channel directory."""
-    files = [
-        os.path.join(channel_dir, f)
-        for f in os.listdir(channel_dir)
-        if os.path.isfile(os.path.join(channel_dir, f))
-    ]
+    """Return the path to the single data file inside a channel directory.
+
+    ``channel_dir`` is a SageMaker-managed channel path, but we still resolve
+    each entry and confirm it stays within the channel directory so that no
+    symlink or unexpected entry can escape it via ``..`` sequences.
+    """
+    base = os.path.realpath(channel_dir)
+    files = []
+    for name in os.listdir(base):
+        candidate = os.path.realpath(os.path.join(base, name))
+        if os.path.commonpath([base, candidate]) != base:
+            # Entry resolves outside the channel directory; skip it.
+            continue
+        if os.path.isfile(candidate):
+            files.append(candidate)
     if not files:
         raise ValueError(f"No data files found in channel directory: {channel_dir}")
     return files[0]
@@ -103,7 +112,8 @@ def main():
     # Persist the trained model to the model directory so SageMaker uploads it.
     os.makedirs(args.model_dir, exist_ok=True)
     model_location = os.path.join(args.model_dir, "xgboost-model")
-    pkl.dump(bst, open(model_location, "wb"))
+    with open(model_location, "wb") as model_file:
+        pkl.dump(bst, model_file)
     logger.info("Stored trained model at %s", model_location)
 
 

--- a/      build_and_train_models/sm-managed_spot_training_xgboost/sm-managed_spot_training_xgboost-v3.ipynb
+++ b/      build_and_train_models/sm-managed_spot_training_xgboost/sm-managed_spot_training_xgboost-v3.ipynb
@@ -1,0 +1,538 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Managed Spot Training for XGBoost (V3)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "This notebook's CI test result for us-west-2 is as follows. CI test results in other regions can be found at the end of the notebook. \n",
+    "\n",
+    "![This us-west-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-west-2/build_and_train_models|sm-managed_spot_training_xgboost|sm-managed_spot_training_xgboost.ipynb)\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **SageMaker Python SDK v3 note:** This notebook has been migrated to the SageMaker Python SDK **v3**. Managed Spot Training for XGBoost now uses `ModelTrainer` (from `sagemaker-train`) instead of the v2 `Estimator`/`sagemaker.xgboost.XGBoost`. Spot training is configured through the structured `Compute` (`enable_managed_spot_training=True`), `StoppingCondition` (`max_runtime_in_seconds` / `max_wait_time_in_seconds`), and `CheckpointConfig` (`s3_uri`) config objects. Automatic Model Tuning uses the v3 `HyperparameterTuner` (from `sagemaker.train.tuner`) with parameter ranges from `sagemaker.core.parameter`, and container/session helpers come from `sagemaker.core`. Install with `pip install sagemaker` (v3).\n\n---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "This notebook shows usage of SageMaker Managed Spot infrastructure for XGBoost training. Below we show how Spot instances can be used for the 'algorithm mode' and 'script mode' training methods with the XGBoost container. \n",
+    "\n",
+    "[Managed Spot Training](https://docs.aws.amazon.com/sagemaker/latest/dg/model-managed-spot-training.html) uses Amazon EC2 Spot instance to run training jobs instead of on-demand instances. You can specify which training jobs use spot instances and a stopping condition that specifies how long Amazon SageMaker waits for a job to run using Amazon EC2 Spot instances."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook was tested in Amazon SageMaker Studio on a ml.t3.medium instance with Python 3 (Data Science) kernel.\n",
+    "\n",
+    "In this notebook we will perform XGBoost training as described [here](). See the original notebook for more details on the data. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setup variables and define functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install sagemaker --upgrade --quiet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "\n",
+    "import io\n",
+    "import os\n",
+    "import boto3\n",
+    "from sagemaker.core.helper.session_helper import Session, get_execution_role\n",
+    "\n",
+    "sagemaker_session = Session()\n",
+    "role = get_execution_role()\n",
+    "region = sagemaker_session.boto_region_name\n",
+    "\n",
+    "# S3 bucket for saving code and model artifacts.\n",
+    "# Feel free to specify a different bucket here if you wish.\n",
+    "bucket = sagemaker_session.default_bucket()\n",
+    "prefix = \"sagemaker/DEMO-xgboost-spot\"\n",
+    "default_bucket_prefix = sagemaker_session.default_bucket_prefix\n",
+    "\n",
+    "# If a default bucket prefix is specified, append it to the s3 path\n",
+    "if default_bucket_prefix:\n",
+    "    prefix = f\"{default_bucket_prefix}/{prefix}\"\n",
+    "\n",
+    "# customize to your bucket where you have would like to store the data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Fetching the dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "s3 = boto3.client(\"s3\")\n",
+    "# Load the dataset\n",
+    "FILE_DATA = \"abalone\"\n",
+    "s3.download_file(\n",
+    "    f\"sagemaker-example-files-prod-{region}\",\n",
+    "    f\"datasets/tabular/uci_abalone/abalone.libsvm\",\n",
+    "    FILE_DATA,\n",
+    ")\n",
+    "sagemaker_session.upload_data(FILE_DATA, bucket=bucket, key_prefix=prefix + \"/train\")\n",
+    "sagemaker_session.upload_data(FILE_DATA, bucket=bucket, key_prefix=prefix + \"/validation\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Obtaining the latest XGBoost container\n",
+    "We obtain the new container by specifying the framework version (1.7-1). This version specifies the upstream XGBoost framework version (1.7) and an additional SageMaker version (1). If you have an existing XGBoost workflow based on the previous (1.0-1, 1.2-2, 1.3-1 or 1.5-1) container, this would be the only change necessary to get the same workflow working with the new container.\n",
+    "\n",
+    "In v3, the `image_uris` helper lives under `sagemaker.core`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.core import image_uris\n",
+    "\n",
+    "container = image_uris.retrieve(\"xgboost\", region, \"1.7-1\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Training the XGBoost model\n",
+    "\n",
+    "After setting training parameters, we kick off training, and poll for status until training is completed, which in this example, takes few minutes.\n",
+    "\n",
+    "To run training on SageMaker in v3 we construct a `ModelTrainer` (from `sagemaker-train`), which replaces the v2 `Estimator`. It accepts structured configuration objects:\n",
+    "\n",
+    "* __training_image__: The XGBoost container image URI retrieved above.\n",
+    "* __role__: Role ARN.\n",
+    "* __hyperparameters__: A dictionary passed to the algorithm as hyperparameters.\n",
+    "* __compute__: A `Compute` object describing the instance type/count (and, below, the managed spot training flag). __Note__: This particular mode does not currently support training on GPU instance types.\n",
+    "* __sagemaker_session__ *(optional)*: The session used to train on SageMaker."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If Spot instances are used, the training job can be interrupted, causing it to take longer to start or finish. If a training job is interrupted, a checkpointed snapshot can be used to resume from a previously saved point and can save training time (and cost).\n",
+    "\n",
+    "To enable checkpointing for Managed Spot Training using SageMaker XGBoost we configure three things through v3 config objects: \n",
+    "\n",
+    "1. Set `Compute(enable_managed_spot_training=True)` - the structured v3 equivalent of the v2 `use_spot_instances` boolean. \n",
+    "\n",
+    "2. Set `StoppingCondition(max_wait_time_in_seconds=...)` - the amount of time you are willing to wait for Spot infrastructure to become available. Some instance types are harder to get at Spot prices and you may have to wait longer. You are not charged for time spent waiting for Spot infrastructure to become available, you're only charged for actual compute time spent once Spot instances have been successfully procured. \n",
+    "\n",
+    "3. Set `CheckpointConfig(s3_uri=...)` - this tells SageMaker an S3 location where to save checkpoints. While not strictly necessary, checkpointing is highly recommended for Managed Spot Training jobs due to the fact that Spot instances can be interrupted with short notice and using checkpoints to resume from the last interruption ensures you don't lose any progress made before the interruption.\n",
+    "\n",
+    "Feel free to toggle the `use_spot_instances` variable to see the effect of running the same job using regular (a.k.a. \"On Demand\") infrastructure.\n",
+    "\n",
+    "Note that `max_wait_time_in_seconds` can be set if and only if managed spot training is enabled and must be greater than or equal to `max_runtime_in_seconds`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "from sagemaker.train import ModelTrainer\n",
+    "from sagemaker.core.training.configs import (\n",
+    "    Compute,\n",
+    "    StoppingCondition,\n",
+    "    CheckpointConfig,\n",
+    "    OutputDataConfig,\n",
+    "    InputData,\n",
+    ")\n",
+    "\n",
+    "hyperparameters = {\n",
+    "    \"max_depth\": \"5\",\n",
+    "    \"eta\": \"0.2\",\n",
+    "    \"gamma\": \"4\",\n",
+    "    \"min_child_weight\": \"6\",\n",
+    "    \"subsample\": \"0.7\",\n",
+    "    \"objective\": \"reg:squarederror\",\n",
+    "    \"num_round\": \"50\",\n",
+    "    \"verbosity\": \"2\",\n",
+    "}\n",
+    "\n",
+    "instance_type = \"ml.m5.4xlarge\"\n",
+    "output_path = \"s3://{}/{}/{}/output\".format(bucket, prefix, \"abalone-xgb\")\n",
+    "content_type = \"libsvm\"\n",
+    "\n",
+    "job_name = \"DEMO-xgboost-spot-\" + time.strftime(\"%Y-%m-%d-%H-%M-%S\", time.gmtime())\n",
+    "print(\"Training job\", job_name)\n",
+    "\n",
+    "use_spot_instances = True\n",
+    "max_run = 3600\n",
+    "max_wait = 7200 if use_spot_instances else None\n",
+    "checkpoint_s3_uri = (\n",
+    "    \"s3://{}/{}/checkpoints/{}\".format(bucket, prefix, job_name) if use_spot_instances else None\n",
+    ")\n",
+    "print(\"Checkpoint path:\", checkpoint_s3_uri)\n",
+    "\n",
+    "# Managed spot training + stopping condition are expressed through structured v3 configs.\n",
+    "compute = Compute(\n",
+    "    instance_type=instance_type,\n",
+    "    instance_count=1,\n",
+    "    volume_size_in_gb=5,  # 5 GB\n",
+    "    enable_managed_spot_training=use_spot_instances,\n",
+    ")\n",
+    "stopping_condition = StoppingCondition(\n",
+    "    max_runtime_in_seconds=max_run,\n",
+    "    max_wait_time_in_seconds=max_wait,\n",
+    ")\n",
+    "checkpoint_config = (\n",
+    "    CheckpointConfig(s3_uri=checkpoint_s3_uri) if use_spot_instances else None\n",
+    ")\n",
+    "\n",
+    "model_trainer = ModelTrainer(\n",
+    "    training_image=container,\n",
+    "    role=role,\n",
+    "    sagemaker_session=sagemaker_session,\n",
+    "    hyperparameters=hyperparameters,\n",
+    "    compute=compute,\n",
+    "    stopping_condition=stopping_condition,\n",
+    "    checkpoint_config=checkpoint_config,\n",
+    "    output_data_config=OutputDataConfig(s3_output_path=output_path),\n",
+    "    base_job_name=job_name,\n",
+    ")\n",
+    "\n",
+    "train_input = InputData(\n",
+    "    channel_name=\"train\",\n",
+    "    data_source=\"s3://{}/{}/{}\".format(bucket, prefix, \"train\"),\n",
+    "    content_type=\"libsvm\",\n",
+    ")\n",
+    "model_trainer.train(input_data_config=[train_input])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Savings\n",
+    "Towards the end of the job you should see two lines of output printed:\n",
+    "\n",
+    "- `Training seconds: X` : This is the actual compute-time your training job spent\n",
+    "- `Billable seconds: Y` : This is the time you will be billed for after Spot discounting is applied.\n",
+    "\n",
+    "If you enabled managed spot training, then you should see a notable difference between `X` and `Y` signifying the cost savings you will get for having chosen Managed Spot Training. This should be reflected in an additional line:\n",
+    "- `Managed Spot Training savings: (1-Y/X)*100 %`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Train with Automatic Model Tuning ([HPO](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning.html)) <a id='AMT'></a> and Spot Training enabled \n",
+    "***\n",
+    "You could also train with Amazon SageMaker Automatic Model Tuning. AMT, also known as hyperparameter tuning, finds the best version of a model by running many training jobs on your dataset using the algorithm and ranges of hyperparameters that you specify. It then chooses the hyperparameter values that result in a model that performs the best, as measured by a metric that you choose. We will use the v3 `HyperparameterTuner` (from `sagemaker.train.tuner`) object to interact with Amazon SageMaker hyperparameter tuning APIs.\n",
+    "        \n",
+    "The code sample below shows you how to use the v3 `HyperparameterTuner` and a spot-enabled `ModelTrainer` together. Parameter ranges come from `sagemaker.core.parameter`.\n",
+    "***"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.core.parameter import ContinuousParameter, IntegerParameter\n",
+    "from sagemaker.core.common_utils import name_from_base\n",
+    "from sagemaker.train.tuner import HyperparameterTuner\n",
+    "\n",
+    "\n",
+    "# You can select from the hyperparameters supported by the model, and configure ranges of values to be searched for training the optimal model.(https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-define-ranges.html)\n",
+    "hyperparameter_ranges = {\n",
+    "    \"max_depth\": IntegerParameter(0, 10, scaling_type=\"Auto\"),\n",
+    "    \"num_round\": IntegerParameter(1, 4000, scaling_type=\"Auto\"),\n",
+    "    \"alpha\": ContinuousParameter(0, 2, scaling_type=\"Auto\"),\n",
+    "    \"subsample\": ContinuousParameter(0.5, 1, scaling_type=\"Auto\"),\n",
+    "    \"min_child_weight\": ContinuousParameter(0, 120, scaling_type=\"Auto\"),\n",
+    "    \"gamma\": ContinuousParameter(0, 5, scaling_type=\"Auto\"),\n",
+    "    \"eta\": ContinuousParameter(0.1, 0.5, scaling_type=\"Auto\"),\n",
+    "}\n",
+    "\n",
+    "# Increase the total number of training jobs run by AMT, for increased accuracy (and training time).\n",
+    "max_jobs = 6\n",
+    "# Change parallel training jobs run by AMT to reduce total training time, constrained by your account limits.\n",
+    "# if max_jobs=max_parallel_jobs then Bayesian search turns to Random.\n",
+    "max_parallel_jobs = 2\n",
+    "\n",
+    "hp_tuner = HyperparameterTuner(\n",
+    "    model_trainer,\n",
+    "    \"validation:rmse\",\n",
+    "    hyperparameter_ranges,\n",
+    "    max_jobs=max_jobs,\n",
+    "    max_parallel_jobs=max_parallel_jobs,\n",
+    "    objective_type=\"Minimize\",\n",
+    "    base_tuning_job_name=job_name,\n",
+    ")\n",
+    "\n",
+    "# Launch a SageMaker Tuning job to search for the best hyperparameters\n",
+    "# In this case, the tuner requires a `validation` channel to emit the validation:rmse metric.\n",
+    "# Since we only created a `train` channel, we re-use it for validation.\n",
+    "validation_input = InputData(\n",
+    "    channel_name=\"validation\",\n",
+    "    data_source=\"s3://{}/{}/{}\".format(bucket, prefix, \"train\"),\n",
+    "    content_type=\"libsvm\",\n",
+    ")\n",
+    "hp_tuner.tune(inputs=[train_input, validation_input])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Enabling checkpointing for script mode\n",
+    "\n",
+    "An additional mode of operation is to run customizable scripts as part of the training and inference jobs. See [this notebook](./xgboost_abalone_dist_script_mode.ipynb) for details on how to setup script mode. \n",
+    "\n",
+    "Here we highlight the specific changes that would enable checkpointing and use Spot instances. \n",
+    "\n",
+    "Checkpointing in script mode for SageMaker XGBoost can be performed using the convenience helpers in the `sagemaker_xgboost_container.checkpointing` module: \n",
+    "\n",
+    "- `checkpointing.train`: a convenience wrapper around `xgb.train` that loads any existing checkpoint, resumes from the last completed iteration, and registers a callback that saves a checkpoint every round. \n",
+    "\n",
+    "- `checkpointing.load_checkpoint` / `checkpointing.save_checkpoint`: the lower-level building blocks used by `checkpointing.train`. \n",
+    "\n",
+    "These read/write the checkpoint directory, which in the accompanying `abalone.py` script is set to `/opt/ml/checkpoints`. \n",
+    "\n",
+    "The relevant part of `abalone.py` looks like the following:\n",
+    "\n",
+    "---------\n",
+    "```\n",
+    "from sagemaker_xgboost_container import checkpointing\n",
+    "\n",
+    "CHECKPOINTS_DIR = '/opt/ml/checkpoints'   # default location for Checkpoints\n",
+    "train_args = dict(\n",
+    "    params=train_hp,\n",
+    "    dtrain=dtrain,\n",
+    "    evals=watchlist,\n",
+    "    num_boost_round=args.num_round,\n",
+    ")\n",
+    "bst = checkpointing.train(train_args, checkpoint_dir=CHECKPOINTS_DIR)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Using ModelTrainer for XGBoost script mode\n",
+    "\n",
+    "In v3 the framework-specific `sagemaker.xgboost.XGBoost` estimator is replaced by the generic `ModelTrainer`. We point it at the same XGBoost container image (retrieved via `image_uris.retrieve`, training scope) and supply our script through a `SourceCode` object (`entry_script=\"abalone.py\"`). We also pass the IAM role, the compute configuration, and the dictionary of hyperparameters that we want to pass to our script."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.core.training.configs import SourceCode\n",
+    "\n",
+    "job_name = \"DEMO-xgboost-regression-\" + time.strftime(\"%Y-%m-%d-%H-%M-%S\", time.gmtime())\n",
+    "print(\"Training job\", job_name)\n",
+    "checkpoint_s3_uri = (\n",
+    "    \"s3://{}/{}/checkpoints/{}\".format(bucket, prefix, job_name) if use_spot_instances else None\n",
+    ")\n",
+    "print(\"Checkpoint path:\", checkpoint_s3_uri)\n",
+    "\n",
+    "# The script-mode training image uses the same XGBoost framework version.\n",
+    "script_mode_image = image_uris.retrieve(\n",
+    "    \"xgboost\", region, \"1.7-1\", image_scope=\"training\"\n",
+    ")\n",
+    "\n",
+    "xgb_script_mode_trainer = ModelTrainer(\n",
+    "    training_image=script_mode_image,\n",
+    "    role=role,\n",
+    "    sagemaker_session=sagemaker_session,\n",
+    "    source_code=SourceCode(source_dir=\".\", entry_script=\"abalone.py\"),\n",
+    "    hyperparameters=hyperparameters,\n",
+    "    compute=Compute(\n",
+    "        instance_type=instance_type,\n",
+    "        instance_count=1,\n",
+    "        volume_size_in_gb=5,\n",
+    "        enable_managed_spot_training=use_spot_instances,\n",
+    "    ),\n",
+    "    stopping_condition=StoppingCondition(\n",
+    "        max_runtime_in_seconds=max_run,\n",
+    "        max_wait_time_in_seconds=max_wait,\n",
+    "    ),\n",
+    "    checkpoint_config=(\n",
+    "        CheckpointConfig(s3_uri=checkpoint_s3_uri) if use_spot_instances else None\n",
+    "    ),\n",
+    "    output_data_config=OutputDataConfig(\n",
+    "        s3_output_path=\"s3://{}/{}/{}/output\".format(bucket, prefix, \"xgboost-script-mode\")\n",
+    "    ),\n",
+    "    base_job_name=job_name,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Training is as simple as calling `train` on the `ModelTrainer`. This will start a SageMaker Training job that will download the data, invoke the entry point code (in the provided script file), and save any model artifacts that the script creates. In this case, the script requires a `train` and a `validation` channel. Since we only created a `train` channel, we re-use it for validation. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xgb_script_mode_trainer.train(input_data_config=[train_input, validation_input])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As previously stated, the `ModelTrainer` can also be passed to the v3 `HyperparameterTuner` object to interact with the Amazon SageMaker hyperparameter tuning APIs and create a Hyperparameter Tuning Job. Hyperparameters are automatically tuned which in most cases results in a more accurate model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Unlike the built-in algorithm mode (whose container publishes `validation:rmse` automatically), a script-mode tuning job runs a generic training image, so we tell the tuner how to read the objective metric from the training logs via `metric_definitions`. The regex matches the `validation-rmse:<value>` lines emitted by the XGBoost checkpointing evaluation callback in `abalone.py`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hp_tuner = HyperparameterTuner(\n",
+    "    xgb_script_mode_trainer,\n",
+    "    \"validation:rmse\",\n",
+    "    hyperparameter_ranges,\n",
+    "    metric_definitions=[\n",
+    "        {\"Name\": \"validation:rmse\", \"Regex\": \"validation-rmse:([0-9\\\\.]+)\"}\n",
+    "    ],\n",
+    "    max_jobs=max_jobs,\n",
+    "    max_parallel_jobs=max_parallel_jobs,\n",
+    "    objective_type=\"Minimize\",\n",
+    "    base_tuning_job_name=job_name,\n",
+    ")\n",
+    "\n",
+    "# Launch a SageMaker Tuning job to search for the best hyperparameters\n",
+    "# In this case, the tuner requires a `validation` channel to emit the validation:rmse metric.\n",
+    "# Since we only created a `train` channel, we re-use it for validation.\n",
+    "hp_tuner.tune(inputs=[train_input, validation_input])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Notebook CI Test Results\n",
+    "\n",
+    "This notebook was tested in multiple regions. The test results are as follows, except for us-west-2 which is shown at the top of the notebook.\n",
+    "\n",
+    "![This us-east-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-east-1/build_and_train_models|sm-managed_spot_training_xgboost|sm-managed_spot_training_xgboost.ipynb)\n",
+    "\n",
+    "![This us-east-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-east-2/build_and_train_models|sm-managed_spot_training_xgboost|sm-managed_spot_training_xgboost.ipynb)\n",
+    "\n",
+    "![This us-west-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-west-1/build_and_train_models|sm-managed_spot_training_xgboost|sm-managed_spot_training_xgboost.ipynb)\n",
+    "\n",
+    "![This ca-central-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ca-central-1/build_and_train_models|sm-managed_spot_training_xgboost|sm-managed_spot_training_xgboost.ipynb)\n",
+    "\n",
+    "![This sa-east-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/sa-east-1/build_and_train_models|sm-managed_spot_training_xgboost|sm-managed_spot_training_xgboost.ipynb)\n",
+    "\n",
+    "![This eu-west-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-1/build_and_train_models|sm-managed_spot_training_xgboost|sm-managed_spot_training_xgboost.ipynb)\n",
+    "\n",
+    "![This eu-west-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-2/build_and_train_models|sm-managed_spot_training_xgboost|sm-managed_spot_training_xgboost.ipynb)\n",
+    "\n",
+    "![This eu-west-3 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-3/build_and_train_models|sm-managed_spot_training_xgboost|sm-managed_spot_training_xgboost.ipynb)\n",
+    "\n",
+    "![This eu-central-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-central-1/build_and_train_models|sm-managed_spot_training_xgboost|sm-managed_spot_training_xgboost.ipynb)\n",
+    "\n",
+    "![This eu-north-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-north-1/build_and_train_models|sm-managed_spot_training_xgboost|sm-managed_spot_training_xgboost.ipynb)\n",
+    "\n",
+    "![This ap-southeast-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-southeast-1/build_and_train_models|sm-managed_spot_training_xgboost|sm-managed_spot_training_xgboost.ipynb)\n",
+    "\n",
+    "![This ap-southeast-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-southeast-2/build_and_train_models|sm-managed_spot_training_xgboost|sm-managed_spot_training_xgboost.ipynb)\n",
+    "\n",
+    "![This ap-northeast-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-northeast-1/build_and_train_models|sm-managed_spot_training_xgboost|sm-managed_spot_training_xgboost.ipynb)\n",
+    "\n",
+    "![This ap-northeast-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-northeast-2/build_and_train_models|sm-managed_spot_training_xgboost|sm-managed_spot_training_xgboost.ipynb)\n",
+    "\n",
+    "![This ap-south-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-south-1/build_and_train_models|sm-managed_spot_training_xgboost|sm-managed_spot_training_xgboost.ipynb)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "instance_type": "ml.t3.medium",
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/      build_and_train_models/sm-marketplace_build_model_package_for_listing/sm-marketplace_build_model_package_for_listing-v3.ipynb
+++ b/      build_and_train_models/sm-marketplace_build_model_package_for_listing/sm-marketplace_build_model_package_for_listing-v3.ipynb
@@ -1,0 +1,1299 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Package a machine learning model for listing on the AWS Marketplace"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "This notebook's CI test result for us-west-2 is as follows. CI test results in other regions can be found at the end of the notebook. \n",
+    "\n",
+    "![This us-west-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-west-2/build_and_train_models|sm-marketplace_build_model_package_for_listing|sm-marketplace_build_model_package_for_listing.ipynb)\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This sample notebook provides scripts you can use to package and verify your ML model for listing on AWS Marketplace. This sample notebook shows you the end-to-end process by building a sample ML model based on the Iris plant dataset."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following diagram provides an overview of the ML model packaging process. As you can see, In [Step 1](#step1) you will train a simple model, and you will store model artifacts into a joblib file. In [Step 2](#step2) you will learn how to author scoring logic that loads the ML model, performs inference, and returns the prediction. In [Step 3](#step3) you will learn how to package the ML model into a Docker Image. In [Step 4](#step4) you will push this Docker image into Amazon ECR. In [Step 5](#step5) you will learn how to package the ML model into a Model Package. In [Step 6](#step6) you will validate this ML model by deploying it with Amazon SageMaker. In [Step 7](#step7) you will learn about resources that guide you on how to list the ML model in AWS Marketplace.\n",
+    "\n",
+    "<img src=\"images/ml-model-publishing-workflow.png\"/>\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Pre-requisites** \n",
+    "1. Before you start building an ML model, you are strongly recommended watching this [video](https://www.youtube.com/watch?v=npilyL5xvV4) to understand the overall end-to-end ML model building and listing process.\n",
+    "2. You need to add the managed policy **[AmazonEC2ContainerRegistryFullAccess](https://docs.aws.amazon.com/AmazonECR/latest/userguide/security-iam-awsmanpol.html#security-iam-awsmanpol-AmazonEC2ContainerRegistryFullAccess)** to the role associated with your notebook instance.\n",
+    "3. In order to create listings on AWS Marketplace you will need to register an AWS account to be a seller account by following the [seller registration process](https://docs.aws.amazon.com/marketplace/latest/userguide/seller-registration-process.html). This guide assumes that the notebook is to be run in the registered seller account.\n",
+    "\n",
+    "**Note** - This example shows how to package a simple Python example which showcases a decision tree model built with the scikit-learn machine learning package. You are recommended to follow the notebook once and then customize it for your own ML model. \n",
+    "\n",
+    "**Table of contents**\n",
+    "1. [Step 1 - Build ML model](#step1): \n",
+    "2. [Step 2 - Implement scoring logic](#step2): \n",
+    "3. [Step 3 - Package model artifacts and scoring logic into a Docker image](#step3)\n",
+    "    1. [Step 3.1: Build Docker image to be included in the ML model](#step31)\n",
+    "    2. [Step 3.2 : Test Docker image](#step32)\n",
+    "4. [Step 4 - Push the Docker image into Amazon ECR](#step4): \n",
+    "5. [Step 5 - Create an ML Model Package](#step5): \n",
+    "6. [Step 6 - Validate model in Amazon SageMaker environment](#step6):\n",
+    "    1. [Step 6.1 Validate Real-time inference via Amazon SageMaker Endpoint](#step61)\n",
+    "    2. [Step 6.2 Validate batch inference via batch transform job](#step61)\n",
+    "7. [Step 7 - List ML model on AWS Marketplace](#step7):"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we import all of the libraries needed throughout the notebook to complete the model packaging process.  We also create the clients necessary to interact with the various services needed (e.g., ECR, SageMaker, and S3)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import base64\n",
+    "import boto3\n",
+    "import docker\n",
+    "import json\n",
+    "import pandas as pd\n",
+    "import requests\n",
+    "import socket\n",
+    "import time\n",
+    "from urllib.parse import urlparse\n",
+    "\n",
+    "# SageMaker Python SDK v3 (sagemaker-core). In v2 this notebook used\n",
+    "# `import sagemaker as sage` + `from sagemaker import get_execution_role, ModelPackage`.\n",
+    "# v3 replaces the monolithic package: the managed Session and get_execution_role\n",
+    "# live in sagemaker.core.helper.session_helper, and resources/shapes are used\n",
+    "# directly instead of the high-level ModelPackage/Model/Transformer classes.\n",
+    "from sagemaker.core.helper.session_helper import Session, get_execution_role\n",
+    "\n",
+    "# Training specific imports\n",
+    "from joblib import dump, load\n",
+    "from sklearn import tree\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "from sklearn import datasets\n",
+    "from src.scoring_logic import IrisLabel\n",
+    "\n",
+    "# Common variables\n",
+    "session = Session()\n",
+    "s3_bucket = session.default_bucket()\n",
+    "default_bucket_prefix = session.default_bucket_prefix\n",
+    "default_bucket_prefix_path = \"\"\n",
+    "\n",
+    "# If a default bucket prefix is specified, append it to the s3 path\n",
+    "if default_bucket_prefix:\n",
+    "    default_bucket_prefix_path = f\"/{default_bucket_prefix}\"\n",
+    "\n",
+    "region = session.boto_region_name\n",
+    "account_id = boto3.client(\"sts\").get_caller_identity().get(\"Account\")\n",
+    "role = get_execution_role()\n",
+    "\n",
+    "sagemaker = boto3.client(\"sagemaker\")\n",
+    "s3_client = session.boto_session.client(\"s3\")\n",
+    "ecr = boto3.client(\"ecr\")\n",
+    "sm_runtime = boto3.client(\"sagemaker-runtime\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The model name will be re-used through various parts of the packaging and publishing process."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define parameters\n",
+    "model_name = \"my-flower-detection-model\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### <a name=\"step1\"></a> Step 1: Build ML model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For the purpose of this sample, this section builds a simple classification model using the [Iris plants dataset](https://scikit-learn.org/stable/datasets/toy_dataset.html#iris-plants-dataset) and then serializes it using joblib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iris = pd.read_csv(\n",
+    "    f\"s3://sagemaker-example-files-prod-{region}/datasets/tabular/iris/iris.data\", header=None\n",
+    ")\n",
+    "\n",
+    "features = iris.iloc[:, 0:4]\n",
+    "label = iris.iloc[:, 4].apply(\n",
+    "    lambda x: IrisLabel[x.replace(\"Iris-\", \"\")].value\n",
+    ")  # Integer encode the labels\n",
+    "\n",
+    "classifier = tree.DecisionTreeClassifier(random_state=0)\n",
+    "classifier = classifier.fit(features, label)\n",
+    "\n",
+    "# Store the model\n",
+    "dump(classifier, \"src/model-artifacts.joblib\")\n",
+    "\n",
+    "# Show the model\n",
+    "plt.figure(figsize=[15.4, 14.0])\n",
+    "tree.plot_tree(classifier, filled=True)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### <a name=\"step2\"></a>Step 2: Implement scoring logic "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The supported input and output content types are left to the scoring logic. It is recommended to follow the [SageMaker standards](https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-inference.html) for request and response formats where possible to provide a consistent experience to end users. The sample scoring logic provided in this example follows this standard."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls src"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "scoring_logic.py contains all the necessary logic to take the HTTP requests that arrive via the SageMaker endpoint, translate them as needed to perform an inference, and return a properly formatted response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pygmentize src/scoring_logic.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Amazon SageMaker uses two URLs in the container:\n",
+    "\n",
+    "* `/ping` will receive `GET` requests from the infrastructure. Your program returns 200 if the container is up and accepting requests.\n",
+    "* `/invocations` is the endpoint that receives client inference `POST` requests. The format of the request and the response is up to the algorithm. If the client supplied `ContentType` and `Accept` headers, these will be passed in as well. For advanced usage like request tracing, `CustomAttributes` can be used (more [details](https://aws.amazon.com/blogs/machine-learning/amazon-sagemaker-runtime-now-supports-the-customattribute-header/)).  All other headers will be stripped off by the SageMaker Endpoint.\n",
+    "\n",
+    "The container will have the model files in the same place they were written during training:\n",
+    "\n",
+    "    /opt/ml\n",
+    "     -- model\n",
+    "        -- <model files>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Note on Inference pricing\n",
+    "\n",
+    "When the buyer runs your software by hosting an endpoint to perform real-time inference, you can choose to set a price per inference or per hour that the endpoint is active. Batch transform processes always use hourly pricing.\n",
+    "\n",
+    "With inference pricing, AWS Marketplace charges your buyer for each invocation of your endpoint with an HTTP response code of 2XX. However, in some cases, your software may process a batch of inferences in a single invocation. For an endpoint deployment, you can indicate a custom number of inferences that AWS Marketplace should charge the buyer for that single invocation. To do this, include a custom metering header in the HTTP response headers of your invocation, as in the following example.\n",
+    "\n",
+    "```\n",
+    "X-Amzn-Inference-Metering: {\"Dimension\": \"inference.count\", \"ConsumedUnits\": 3}\n",
+    "```\n",
+    "This example shows an invocation that charges the buyer for three inferences. You can find more information in the [documentation](https://docs.aws.amazon.com/marketplace/latest/userguide/machine-learning-pricing.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### <a name=\"step3\"></a>Step 3: Package model artifacts and scoring logic into a Docker Image"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Docker image"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The provided Dockerfile packages the model artifacts and serving logic as well as installing all the dependencies needed at inference time (flask, gunicorn, sklearn)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pygmentize src/Dockerfile"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this notebook, we are showing a minimal example for how to create an inference image for clarity. However, for models that use common machine learning frameworks such as Sklearn, TensorFlow, TensorFlow 2, PyTorch, and Apache MXNet, AWS provides [Deep Learning Containers](https://docs.aws.amazon.com/deep-learning-containers/latest/devguide/what-is-dlc.html) as well as [Scikit-learn and SparkML Containers](https://docs.aws.amazon.com/sagemaker/latest/dg/pre-built-docker-containers-scikit-learn-spark.html), which are a set of optimized Docker images which greatly simplify the setup necessary for model serving. These images should be used as base images when possible as they are performance optimized for CPU, GPU, and Inferentia. [Detailed instructions](https://docs.aws.amazon.com/sagemaker/latest/dg/pre-built-containers-frameworks-deep-learning.html) are available for using the Deep Learning Containers.\n",
+    "\n",
+    "Select the appropriate image (CPU/GPU/Inferentia/framework combination) and replace the ubuntu:18.04 base image when adapting this example notebook for your own model to take advantage of the prebuilt SageMaker containers. \n",
+    "\n",
+    "For additional performance optimization, [SageMaker Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html) provides the ability to automatically optimize an existing model implemented in any common machine learning framework for deployment on cloud instances (including Inferentia).  To take advantage of SageMaker Neo, follow the instructions for [compilation](https://docs.aws.amazon.com/sagemaker/latest/dg/neo-job-compilation.html) and [serving](https://docs.aws.amazon.com/sagemaker/latest/dg/neo-deployment-hosting-services-prerequisites.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Serving application"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`serve` is a minimal script for starting up an HTTP server to handle requests.  \n",
+    "\n",
+    "Here we use [gunicorn](https://gunicorn.org/) as it is appropriate for a production deployment of [Flask](https://flask.palletsprojects.com/) applications. For more complex deployments the prebuilt SageMaker containers include the [SageMaker Inference Toolkit](https://github.com/aws/sagemaker-inference-toolkit)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pygmentize -l bash src/serve"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How Amazon SageMaker runs your Docker container\n",
+    "\n",
+    "Amazon SageMaker runs your container with the argument `serve`. How your container processes this argument depends on the container:\n",
+    "\n",
+    "* In the example here, we don't define an `ENTRYPOINT` in the Dockerfile so Docker will run the command `train` at training time and `serve` at serving time. In this example, we define these as executable bash scripts, but they could be any program that we want to start in that environment.\n",
+    "* If you specify a program as an `ENTRYPOINT` in the Dockerfile, that program will be run at startup and the first argument will be `train` or `serve`. The program can then look at that argument and decide what to do.\n",
+    "* If you are building separate containers for training and hosting (or building only for one or the other), you can define a program as an `ENTRYPOINT` in the Dockerfile and ignore (or verify) the first argument passed in. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### <a name=\"step31\"></a>Step 3.1: Build Docker Image to be included in the ML model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "docker_client = docker.from_env()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Build for linux/amd64: SageMaker's standard hosting/transform fleet (e.g. ml.m4/m5)\n",
+    "# is x86_64, so the inference image must be amd64. This is required when building on\n",
+    "# an arm64 host (e.g. Apple Silicon); on an x86 build host it is a harmless no-op.\n",
+    "image, build_logs = docker_client.images.build(\n",
+    "    path=\"./src\", tag=model_name, platform=\"linux/amd64\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### <a name=\"step32\"></a>Step 3.2 : Run Docker container"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "port = 8080\n",
+    "SECONDS = 1000000000  # One second in nanoseconds\n",
+    "\n",
+    "container = docker_client.containers.run(\n",
+    "    image,\n",
+    "    detach=True,\n",
+    "    name=model_name,\n",
+    "    command=\"serve\",\n",
+    "    healthcheck={\n",
+    "        \"test\": f\"curl -f http://localhost:{port}/ping || exit 1\",\n",
+    "        \"interval\": 1 * SECONDS,  # One second\n",
+    "        \"timeout\": 1 * SECONDS,  # One second\n",
+    "    },\n",
+    "    ports={f\"{port}/tcp\": port},\n",
+    ")\n",
+    "\n",
+    "# Wait until our server is ready\n",
+    "while docker_client.api.inspect_container(container.name)[\"State\"][\"Health\"][\"Status\"] != \"healthy\":\n",
+    "    print(\"Waiting for server to become ready...\")\n",
+    "    time.sleep(1)\n",
+    "    container.reload()\n",
+    "    print(\n",
+    "        f\"Container is {docker_client.api.inspect_container(container.name)['State']['Health']['Status']}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Step 3.3: Perform inference on the container"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Test that we can send a single record in a request."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "container_invocation_url = f\"http://127.0.0.1:{port}/invocations\"\n",
+    "\n",
+    "r = requests.post(\n",
+    "    container_invocation_url,\n",
+    "    headers={\"Content-Type\": \"text/csv\"},\n",
+    "    data=\"5.1, 3.5, 1.4, 0.2\",  # setosa labeled record from training set\n",
+    ")\n",
+    "\n",
+    "print(r.json())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, try sending multiple records in a request."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Three records from the training set corresponding to setosa, versicolor, and virginica labels respectively\n",
+    "csv_input_data = \"\"\"\n",
+    "5.1, 3.5, 1.4, 0.2\n",
+    "6.5, 2.8, 4.6, 1.5\n",
+    "6.3, 2.9, 5.6, 1.8\n",
+    "\"\"\".strip()\n",
+    "\n",
+    "print(csv_input_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = requests.post(\n",
+    "    container_invocation_url, headers={\"Content-Type\": \"text/csv\"}, data=csv_input_data\n",
+    ")\n",
+    "\n",
+    "print(r.json())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, try sending different supported input content types."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### JSON input Content-Type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "json_input_data = json.dumps(\n",
+    "    {\n",
+    "        \"instances\": [\n",
+    "            {\"features\": [5.1, 3.5, 1.4, 0.2]},  # setosa labeled record from training set\n",
+    "            {\"features\": [6.5, 2.8, 4.6, 1.5]},  # versicolor\n",
+    "            {\"features\": [6.3, 2.9, 5.6, 1.8]},  # virginica\n",
+    "        ]\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = requests.post(\n",
+    "    container_invocation_url,\n",
+    "    headers={\"Content-Type\": \"application/json\"},\n",
+    "    data=json_input_data,\n",
+    ")\n",
+    "\n",
+    "print(r.json())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### JSON Lines input Content-Type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Three records from the training set corresponding to setosa, versicolor, and virginica labels respectively\n",
+    "jsonlines_input_data = \"\"\"\n",
+    "{\\\"features\\\": [5.1, 3.5, 1.4, 0.2]}\n",
+    "{\\\"features\\\": [6.5, 2.8, 4.6, 1.5]}\n",
+    "{\\\"features\\\": [6.3, 2.9, 5.6, 1.8]}\n",
+    "\"\"\".strip()\n",
+    "\n",
+    "print(jsonlines_input_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = requests.post(\n",
+    "    container_invocation_url,\n",
+    "    headers={\"Content-Type\": \"application/jsonlines\"},\n",
+    "    data=jsonlines_input_data,\n",
+    ")\n",
+    "\n",
+    "print(r.json())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### CSV output Content-Type"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Test the response types by setting the Accept header to the desired type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = requests.post(\n",
+    "    container_invocation_url,\n",
+    "    headers={\"Content-Type\": \"application/jsonlines\", \"Accept\": \"text/csv\"},\n",
+    "    data=jsonlines_input_data,\n",
+    ")\n",
+    "\n",
+    "print(r.text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### JSON Lines output Content-Type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = requests.post(\n",
+    "    container_invocation_url,\n",
+    "    headers={\n",
+    "        \"Content-Type\": \"application/jsonlines\",\n",
+    "        \"Accept\": \"application/jsonlines\",\n",
+    "    },\n",
+    "    data=jsonlines_input_data,\n",
+    ")\n",
+    "\n",
+    "print(r.text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note - If the container did not return the expected response, run the following command to see the logs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(container.logs().decode(\"utf-8\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Congratulations, now that you have successfully tested container locally you can remove the container."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "container.stop()\n",
+    "container.remove()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### <a name=\"step4\"></a>Step 4: Push the docker image into Amazon ECR"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that your docker image is ready, you are ready to push the docker image into the Amazon ECR repository. \n",
+    "\n",
+    "**NOTE:** The ECR repository must belong to the AWS account that is registered as a seller on the AWS Marketplace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "docker_image_arn = f\"{account_id}.dkr.ecr.{region}.amazonaws.com/{model_name}\"\n",
+    "docker_image_arn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following code shows how to build the container image and push the container image to ECR using the Docker python SDK. \n",
+    "\n",
+    "This code looks for an ECR repository in the account you're using and the current default region (if you're using an Amazon SageMaker notebook instance, this will be the region where the notebook instance was created). If the repository doesn't exist, the script will create it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "repo_exists = model_name in [\n",
+    "    repo[\"repositoryName\"] for repo in ecr.describe_repositories().get(\"repositories\")\n",
+    "]\n",
+    "\n",
+    "if not repo_exists:\n",
+    "    ecr.create_repository(repositoryName=model_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ecr_auth_data = ecr.get_authorization_token()[\"authorizationData\"][0]\n",
+    "username, password = (\n",
+    "    base64.b64decode(ecr_auth_data[\"authorizationToken\"]).decode(\"utf-8\").split(\":\")\n",
+    ")\n",
+    "\n",
+    "docker_client.api.tag(model_name, docker_image_arn, tag=\"latest\")\n",
+    "status = docker_client.api.push(\n",
+    "    docker_image_arn,\n",
+    "    tag=\"latest\",\n",
+    "    auth_config={\"username\": username, \"password\": password},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### <a name=\"step5\"></a>Step 5: Create an ML Model Package"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this section, we will see how you can package your artifacts (ECR image and the trained artifact from your previous training job) into a ModelPackage. Once you complete this, you can list your product as a pretrained model in the AWS Marketplace.\n",
+    "\n",
+    "**NOTE:** If your model can be deployed on multiple hardware types (CPU/GPU/Inferentia) then a ModelPackage must be created for each and added to the MP listing as different versions as, in general, the container image used will be different for each.  \n",
+    "\n",
+    "#### Model Package Definition\n",
+    "A Model Package is a reusable abstraction for model artifacts that packages all the ingredients necessary for inference. It consists of an inference specification that defines the inference image to use along with an optional model data location.\n",
+    "\n",
+    "The ModelPackage must be created in the AWS account that is registered to be a seller on the AWS Marketplace."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Step 5.1 Define parameters "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_description = \"This model accepts petal length, petal width, sepal length, sepal width and predicts whether flower is of type setosa, versicolor, or virginica\"\n",
+    "\n",
+    "supported_content_types = [\"text/csv\", \"application/json\", \"application/jsonlines\"]\n",
+    "supported_response_MIME_types = [\n",
+    "    \"application/json\",\n",
+    "    \"text/csv\",\n",
+    "    \"application/jsonlines\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A Model Package creation process requires you to specify following:\n",
+    "  1. Docker image\n",
+    "  2. Model artifacts\n",
+    "    - You can either package these inside the docker image, as we have done in this example, or provide them as a gzipped tarball.\n",
+    "  3. Validation specification \n",
+    "        \n",
+    "In order to provide confidence to sellers (and buyers) that the products work in Amazon SageMaker, before listing them on AWS Marketplace SageMaker needs to perform basic validations. The product can be listed in AWS Marketplace only if this validation process succeeds. This validation process uses the validation profile and sample data provided by you to create a transform job in your account using the Model to verify your inference image works with SageMaker."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, you need to identify the right instance-sizes for your ML models. You can do so by running performance tests on top of your ML Model.\n",
+    "A [sample notebook](https://github.com/aws-samples/aws-marketplace-machine-learning/blob/master/right_size_your_sagemaker_endpoints/Right-sizing%20your%20Amazon%20SageMaker%20Endpoints.ipynb) is available to identify minimum suggested instance types.\n",
+    "\n",
+    "**NOTE:** In addition to tuning, take into account the requirements of your model when identifying instance types.  If your model does not use GPU resources, then do not include GPU instance types.  Similarly, if your model does use GPU resources, but can only make use of a single GPU, do not include instance types that have multiple GPUs as it will lead to increased infrastructure charges for your customers with no performance benefit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "supported_realtime_inference_instance_types = [\"ml.m4.xlarge\"]\n",
+    "supported_batch_transform_instance_types = [\"ml.m4.xlarge\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validation_file_name = \"input.csv\"\n",
+    "validation_input_path = f\"s3://{s3_bucket}{default_bucket_prefix_path}/validation-input-csv/\"\n",
+    "validation_output_path = f\"s3://{s3_bucket}{default_bucket_prefix_path}/validation-output-csv/\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, we create sample data to be used in the validation stage of the ModelPackage creation and upload it to S3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "csv_line = \"5.1, 3.5, 1.4, 0.2\"\n",
+    "\n",
+    "with open(\"input.csv\", \"w\") as f:\n",
+    "    f.write(csv_line)\n",
+    "\n",
+    "key = \"validation-input-csv/input.csv\"\n",
+    "\n",
+    "# If a default bucket prefix is specified, append it to the s3 path\n",
+    "if default_bucket_prefix:\n",
+    "    key = f\"{default_bucket_prefix}/{key}\"\n",
+    "\n",
+    "s3_client.put_object(Bucket=s3_bucket, Key=key, Body=csv_line)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Step 5.2 Create Model Package "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NOTE (v3 SDK gap): CreateModelPackage is intentionally kept on the boto3\n",
+    "# client here. The typed sagemaker-core path `ModelPackage.create(...)` is\n",
+    "# currently unusable for this call because of a name collision in\n",
+    "# sagemaker.core.shapes: the package __init__ re-exports model_card_shapes after\n",
+    "# shapes, so `InferenceSpecification` resolves to the model-card variant\n",
+    "# (containers: List[ContainersItem]) which lacks the SupportedContentTypes /\n",
+    "# Supported*InstanceTypes / SupportedResponseMIMETypes fields required to register\n",
+    "# a Marketplace model package. resources.py binds the same shadowed type via\n",
+    "# `from sagemaker.core.shapes import *`, so those fields would be silently dropped.\n",
+    "# Until that is fixed, we call create_model_package via boto3 (which also matches\n",
+    "# the original v2 notebook), while the rest of the notebook uses sagemaker-core.\n",
+    "model_package = sagemaker.create_model_package(\n",
+    "    ModelPackageName=model_name,\n",
+    "    ModelPackageDescription=model_description,\n",
+    "    InferenceSpecification={\n",
+    "        \"Containers\": [\n",
+    "            {\n",
+    "                \"Image\": f\"{docker_image_arn}:latest\",\n",
+    "            }\n",
+    "        ],\n",
+    "        \"SupportedTransformInstanceTypes\": supported_batch_transform_instance_types,\n",
+    "        \"SupportedRealtimeInferenceInstanceTypes\": supported_realtime_inference_instance_types,\n",
+    "        \"SupportedContentTypes\": supported_content_types,\n",
+    "        \"SupportedResponseMIMETypes\": supported_response_MIME_types,\n",
+    "    },\n",
+    "    CertifyForMarketplace=True,  # Make sure to set this to True for Marketplace models!\n",
+    "    ValidationSpecification={\n",
+    "        \"ValidationRole\": role,\n",
+    "        \"ValidationProfiles\": [\n",
+    "            {\n",
+    "                \"ProfileName\": \"Validation-test\",\n",
+    "                \"TransformJobDefinition\": {\n",
+    "                    \"BatchStrategy\": \"SingleRecord\",\n",
+    "                    \"TransformInput\": {\n",
+    "                        \"DataSource\": {\n",
+    "                            \"S3DataSource\": {\n",
+    "                                \"S3DataType\": \"S3Prefix\",\n",
+    "                                \"S3Uri\": validation_input_path,\n",
+    "                            }\n",
+    "                        },\n",
+    "                        \"ContentType\": supported_content_types[0],\n",
+    "                    },\n",
+    "                    \"TransformOutput\": {\n",
+    "                        \"S3OutputPath\": validation_output_path,\n",
+    "                    },\n",
+    "                    \"TransformResources\": {\n",
+    "                        \"InstanceType\": supported_batch_transform_instance_types[0],\n",
+    "                        \"InstanceCount\": 1,\n",
+    "                    },\n",
+    "                },\n",
+    "            },\n",
+    "        ],\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# CreateModelPackage is boto3 (see gap note above). boto3 has no model-package\n",
+    "# waiter and v2's session.wait_for_model_package helper is not in v3, so poll\n",
+    "# describe_model_package until it leaves the Pending/InProgress state.\n",
+    "import time\n",
+    "\n",
+    "while True:\n",
+    "    status = sagemaker.describe_model_package(\n",
+    "        ModelPackageName=model_package[\"ModelPackageArn\"]\n",
+    "    )[\"ModelPackageStatus\"]\n",
+    "    print(f\"ModelPackage status: {status}\")\n",
+    "    if status not in (\"Pending\", \"InProgress\"):\n",
+    "        break\n",
+    "    time.sleep(30)\n",
+    "\n",
+    "assert status == \"Completed\", f\"Model package did not complete: {status}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once you have executed the preceding cell, open the [Model Packages console from Amazon SageMaker](https://console.aws.amazon.com/sagemaker/home?region=us-east-1#/model-packages/my-resources) and check if model creation succeeded. \n",
+    "\n",
+    "Choose the Model and then open the **Validation** tab to see the validation results."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### <a name=\"step6\"></a>Step 6: Validate model in Amazon SageMaker environment"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Create a deployable model from the model package."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# v3: the v2 high-level `ModelPackage(model_package_arn=...)` deployable model +\n",
+    "# `.deploy()` / `.transformer()` helpers are replaced by sagemaker-core resources.\n",
+    "# We create a core Model whose container references the model package ARN, then\n",
+    "# build an EndpointConfig + Endpoint from it (and reuse the same Model for the\n",
+    "# batch transform job below).\n",
+    "from sagemaker.core.resources import Model, EndpointConfig, Endpoint, TransformJob\n",
+    "from sagemaker.core.shapes import (\n",
+    "    ContainerDefinition,\n",
+    "    ProductionVariant,\n",
+    "    TransformInput,\n",
+    "    TransformDataSource,\n",
+    "    TransformS3DataSource,\n",
+    "    TransformOutput,\n",
+    "    TransformResources,\n",
+    ")\n",
+    "\n",
+    "model_name_deploy = f\"{model_name}-model\"\n",
+    "\n",
+    "model = Model.create(\n",
+    "    model_name=model_name_deploy,\n",
+    "    primary_container=ContainerDefinition(\n",
+    "        model_package_name=model_package[\"ModelPackageArn\"],\n",
+    "    ),\n",
+    "    execution_role_arn=role,\n",
+    "    region=region,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### <a name='step61'></a>Step 6.1 Validate Real-time inference via Amazon SageMaker Endpoint"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Deploy the SageMaker model to an endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# v3: `model.deploy(...)` -> EndpointConfig.create + Endpoint.create + wait_for_status.\n",
+    "endpoint_name = model_name\n",
+    "\n",
+    "EndpointConfig.create(\n",
+    "    endpoint_config_name=endpoint_name,\n",
+    "    production_variants=[\n",
+    "        ProductionVariant(\n",
+    "            variant_name=\"AllTraffic\",\n",
+    "            model_name=model_name_deploy,\n",
+    "            initial_instance_count=1,\n",
+    "            instance_type=supported_realtime_inference_instance_types[0],\n",
+    "            initial_variant_weight=1.0,\n",
+    "        )\n",
+    "    ],\n",
+    "    region=region,\n",
+    ")\n",
+    "\n",
+    "endpoint = Endpoint.create(\n",
+    "    endpoint_name=endpoint_name,\n",
+    "    endpoint_config_name=endpoint_name,\n",
+    "    region=region,\n",
+    ")\n",
+    "endpoint.wait_for_status(\"InService\")\n",
+    "endpoint.endpoint_name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "content_type = supported_content_types[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Example invocation via boto3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = sm_runtime.invoke_endpoint(\n",
+    "    EndpointName=endpoint.endpoint_name,\n",
+    "    ContentType=content_type,\n",
+    "    Accept=\"application/json\",\n",
+    "    Body=csv_input_data,\n",
+    ")\n",
+    "\n",
+    "json.load(response[\"Body\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Example invocation via the AWS CLI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Perform inference\n",
+    "!aws sagemaker-runtime invoke-endpoint \\\n",
+    "    --endpoint-name $endpoint.endpoint_name \\\n",
+    "    --body fileb://$validation_file_name \\\n",
+    "    --content-type $content_type \\\n",
+    "    --region $region \\\n",
+    "    out.out\n",
+    "    \n",
+    "    \n",
+    "# Print inference\n",
+    "!head out.out"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Clean up the endpoint and endpoint configuration created."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# v3: `sagemaker_session.delete_endpoint(...)` / `delete_endpoint_config(...)`\n",
+    "# -> core resource delete().\n",
+    "endpoint.delete()\n",
+    "EndpointConfig.get(endpoint_name, region=region).delete()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### <a name='step62'></a>Step 6.2 Validate batch inference via batch transform job "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Run a batch-transform job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# v3: `model.transformer(...)` + `transformer.transform(...)` + `.wait()`\n",
+    "# -> core TransformJob.create(...) + wait(). Reuses the same core Model created above.\n",
+    "transform_job_name = f\"{model_name}-transform\"\n",
+    "transform_output_path = f\"s3://{s3_bucket}{default_bucket_prefix_path}/batch-transform-output/\"\n",
+    "\n",
+    "transform_job = TransformJob.create(\n",
+    "    transform_job_name=transform_job_name,\n",
+    "    model_name=model_name_deploy,\n",
+    "    transform_input=TransformInput(\n",
+    "        data_source=TransformDataSource(\n",
+    "            s3_data_source=TransformS3DataSource(\n",
+    "                s3_data_type=\"S3Prefix\",\n",
+    "                s3_uri=validation_input_path,\n",
+    "            )\n",
+    "        ),\n",
+    "        content_type=content_type,\n",
+    "    ),\n",
+    "    transform_output=TransformOutput(\n",
+    "        s3_output_path=transform_output_path,\n",
+    "        accept=\"application/jsonlines\",\n",
+    "    ),\n",
+    "    transform_resources=TransformResources(\n",
+    "        instance_type=supported_batch_transform_instance_types[0],\n",
+    "        instance_count=1,\n",
+    "    ),\n",
+    "    region=region,\n",
+    ")\n",
+    "transform_job.wait()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Retrieve the results from S3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parsed_url = urlparse(transform_output_path)\n",
+    "file_key = f\"{parsed_url.path[1:].rstrip('/')}/{validation_file_name}.out\"\n",
+    "\n",
+    "# If a default bucket prefix is specified, append it to the s3 path\n",
+    "if default_bucket_prefix:\n",
+    "    file_key = f\"{default_bucket_prefix}/{file_key}\"\n",
+    "\n",
+    "response = s3_client.get_object(Bucket=s3_bucket, Key=file_key)\n",
+    "\n",
+    "print(response[\"Body\"].read().decode(\"utf-8\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Congratulations! You just verified that the batch transform job is working as expected. Since the model is not required, you can delete it. Note that you are deleting the deployable model. Not the model package."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# v3: `model.delete_model()` -> core Model.delete().\n",
+    "model.delete()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To publish the model to the AWS Marketplace, you will need to specify model package ARN. Copy the following Model Package ARN "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_package[\"ModelPackageArn\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### <a name=\"step7\"></a>Step 7: List ML Model on AWS Marketplace\n",
+    "\n",
+    "In the [Model Packages](https://console.aws.amazon.com/sagemaker/home?region=us-east-1#/model-packages/my-resources) section of the SageMaker console you'll find the entity you created in this notebook. If it was successfully created and validated, you should be able to select the entity and choose **Publish new ML Marketplace listing**.\n",
+    "\n",
+    "<img src=\"images/publish-to-marketplace-action.png\"/>\n",
+    "\n",
+    "You will be redirected to the [AWS Marketplace Management portal](https://aws.amazon.com/marketplace/management/ml-products/) where you will be able to build a listing.\n",
+    "\n",
+    "If your model targets multiple hardware types, remember to add each ModelPackage to the listing as separate versions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Creating a High-quality ML Model Listing\n",
+    "\n",
+    "Your AWS Marketplace model listing should appeal to both data scientists with deep expertise who are looking for an ML model because they don't have access to data they need to train an ML model from scratch and developers with little to no ML background who are looking to add powerful new features to their applications. \n",
+    "\n",
+    "You need to provide sample notebook and instructions your users can follow to interact with your model. [Sample notebook templates](https://github.com/aws/amazon-sagemaker-examples/tree/master/aws_marketplace/curating_aws_marketplace_listing_and_sample_notebook/ModelPackage/Sample_Notebook_Template) are available to assist in creating an effective sample notebook.\n",
+    "\n",
+    "To build an impressive listing, you need to stand out by providing information thoughtfully on your Marketplace listing. [Best practice recommendations](https://github.com/aws/amazon-sagemaker-examples/blob/master/aws_marketplace/curating_aws_marketplace_listing_and_sample_notebook/ModelPackage/curating_good_model_package_listing.md) are provided for curating your listing.\n",
+    "\n",
+    "\n",
+    "**Resources**\n",
+    "* [Publishing your product in AWS Marketplace](https://docs.aws.amazon.com/marketplace/latest/userguide/ml-publishing-your-product-in-aws-marketplace.html)\n",
+    "\n",
+    "Most importantly, once you have listed your listing in AWS Marketplace, do explore how you can spread the word about your cool new ML listing."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Notebook CI Test Results\n",
+    "\n",
+    "This notebook was tested in multiple regions. The test results are as follows, except for us-west-2 which is shown at the top of the notebook.\n",
+    "\n",
+    "![This us-east-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-east-1/build_and_train_models|sm-marketplace_build_model_package_for_listing|sm-marketplace_build_model_package_for_listing.ipynb)\n",
+    "\n",
+    "![This us-east-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-east-2/build_and_train_models|sm-marketplace_build_model_package_for_listing|sm-marketplace_build_model_package_for_listing.ipynb)\n",
+    "\n",
+    "![This us-west-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-west-1/build_and_train_models|sm-marketplace_build_model_package_for_listing|sm-marketplace_build_model_package_for_listing.ipynb)\n",
+    "\n",
+    "![This ca-central-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ca-central-1/build_and_train_models|sm-marketplace_build_model_package_for_listing|sm-marketplace_build_model_package_for_listing.ipynb)\n",
+    "\n",
+    "![This sa-east-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/sa-east-1/build_and_train_models|sm-marketplace_build_model_package_for_listing|sm-marketplace_build_model_package_for_listing.ipynb)\n",
+    "\n",
+    "![This eu-west-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-1/build_and_train_models|sm-marketplace_build_model_package_for_listing|sm-marketplace_build_model_package_for_listing.ipynb)\n",
+    "\n",
+    "![This eu-west-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-2/build_and_train_models|sm-marketplace_build_model_package_for_listing|sm-marketplace_build_model_package_for_listing.ipynb)\n",
+    "\n",
+    "![This eu-west-3 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-3/build_and_train_models|sm-marketplace_build_model_package_for_listing|sm-marketplace_build_model_package_for_listing.ipynb)\n",
+    "\n",
+    "![This eu-central-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-central-1/build_and_train_models|sm-marketplace_build_model_package_for_listing|sm-marketplace_build_model_package_for_listing.ipynb)\n",
+    "\n",
+    "![This eu-north-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-north-1/build_and_train_models|sm-marketplace_build_model_package_for_listing|sm-marketplace_build_model_package_for_listing.ipynb)\n",
+    "\n",
+    "![This ap-southeast-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-southeast-1/build_and_train_models|sm-marketplace_build_model_package_for_listing|sm-marketplace_build_model_package_for_listing.ipynb)\n",
+    "\n",
+    "![This ap-southeast-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-southeast-2/build_and_train_models|sm-marketplace_build_model_package_for_listing|sm-marketplace_build_model_package_for_listing.ipynb)\n",
+    "\n",
+    "![This ap-northeast-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-northeast-1/build_and_train_models|sm-marketplace_build_model_package_for_listing|sm-marketplace_build_model_package_for_listing.ipynb)\n",
+    "\n",
+    "![This ap-northeast-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-northeast-2/build_and_train_models|sm-marketplace_build_model_package_for_listing|sm-marketplace_build_model_package_for_listing.ipynb)\n",
+    "\n",
+    "![This ap-south-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-south-1/build_and_train_models|sm-marketplace_build_model_package_for_listing|sm-marketplace_build_model_package_for_listing.ipynb)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+  },
+  "kernelspec": {
+   "display_name": "conda_python3",
+   "language": "python",
+   "name": "conda_python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/      build_and_train_models/sm-marketplace_build_model_package_for_listing/src/Dockerfile
+++ b/      build_and_train_models/sm-marketplace_build_model_package_for_listing/src/Dockerfile
@@ -5,8 +5,13 @@ USER 0
 RUN apt-get update && apt-get install -y curl;
 USER 1000
 
-# Install flask server
-RUN pip install -U flask gunicorn;
+# Install flask server. Upgrade the scientific stack together so the serving
+# environment can unpickle the model artifact, which is trained/serialized by a
+# modern kernel (numpy 2.x). The stale base-image numpy (1.24) otherwise fails
+# with "No module named 'numpy._core'" when loading the joblib artifact. All of
+# numpy/scipy/pandas/scikit-learn are upgraded in a single resolve to keep their
+# compiled ABIs consistent (partial upgrades trigger "numpy.dtype size changed").
+RUN pip install -U flask gunicorn "numpy>=2.0,<3" "scipy>=1.13" "pandas>=2.2" "scikit-learn>=1.4" joblib;
 
 # Copy scoring logic and model artifacts into the docker image
 COPY scoring_logic.py /scoring_logic.py

--- a/      build_and_train_models/sm-marketplace_building_your_own_container_as_package/container/Dockerfile
+++ b/      build_and_train_models/sm-marketplace_building_your_own_container_as_package/container/Dockerfile
@@ -1,27 +1,21 @@
-# Build an image that can do training and inference in SageMaker
-# This is a Python 2 image that uses the nginx, gunicorn, flask stack
+# Build an image that can do training and inference in SageMaker.
+# This uses a Python 3 image with the nginx, gunicorn, flask stack
 # for serving inferences in a stable way.
 
-FROM ubuntu:18.04
+FROM python:3.10-slim-bullseye
 
-MAINTAINER Amazon AI <sage-learner@amazon.com>
+LABEL maintainer="Amazon AI <sage-learner@amazon.com>"
 
-
+# nginx + ca-certificates are needed for the serving stack. Python/pip come with the base image.
 RUN apt-get -y update && apt-get install -y --no-install-recommends \
-         wget \
-         python \
          nginx \
          ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Here we get all python packages.
-# There's substantial overlap between scipy and numpy that we eliminate by
-# linking them together. Likewise, pip leaves the install caches populated which uses
-# a significant amount of space. These optimizations save a fair amount of space in the
-# image, which reduces start up time.
-RUN wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py && \
-    pip install numpy scipy scikit-learn pandas flask gevent gunicorn && \
-        rm -rf /root/.cache
+# Install the Python packages needed by scikit-learn training and the flask serving stack.
+# pip leaves the install caches populated which uses a significant amount of space, so we
+# disable the cache to keep the image small and fast to start.
+RUN pip install --no-cache-dir numpy scipy scikit-learn pandas flask gevent gunicorn
 
 # Set some environment variables. PYTHONUNBUFFERED keeps Python from buffering our standard
 # output stream, which means that logs can be delivered to the user quickly. PYTHONDONTWRITEBYTECODE
@@ -35,4 +29,3 @@ ENV PATH="/opt/program:${PATH}"
 # Set up the program in the image
 COPY decision_trees /opt/program
 WORKDIR /opt/program
-

--- a/      build_and_train_models/sm-marketplace_building_your_own_container_as_package/container/decision_trees/predictor.py
+++ b/      build_and_train_models/sm-marketplace_building_your_own_container_as_package/container/decision_trees/predictor.py
@@ -12,7 +12,7 @@ import traceback
 
 import flask
 import pandas as pd
-import StringIO
+from io import StringIO
 
 prefix = "/opt/ml/"
 model_path = os.path.join(prefix, "model")
@@ -28,7 +28,7 @@ class ScoringService(object):
     def get_model(cls):
         """Get the model object for this instance, loading it if it's not already loaded."""
         if cls.model == None:
-            with open(os.path.join(model_path, "decision-tree-model.pkl"), "r") as inp:
+            with open(os.path.join(model_path, "decision-tree-model.pkl"), "rb") as inp:
                 cls.model = pickle.load(inp)
         return cls.model
 
@@ -68,7 +68,7 @@ def transformation():
     # Convert from CSV to pandas
     if flask.request.content_type == "text/csv":
         data = flask.request.data.decode("utf-8")
-        s = StringIO.StringIO(data)
+        s = StringIO(data)
         data = pd.read_csv(s, header=None)
     else:
         return flask.Response(
@@ -81,7 +81,7 @@ def transformation():
     predictions = ScoringService.predict(data)
 
     # Convert from numpy back to CSV
-    out = StringIO.StringIO()
+    out = StringIO()
     pd.DataFrame({"results": predictions}).to_csv(out, header=False, index=False)
     result = out.getvalue()
 

--- a/      build_and_train_models/sm-marketplace_building_your_own_container_as_package/container/decision_trees/train
+++ b/      build_and_train_models/sm-marketplace_building_your_own_container_as_package/container/decision_trees/train
@@ -50,8 +50,8 @@ def train():
         train_data = pd.concat(raw_data)
 
         # labels are in the first column
-        train_y = train_data.ix[:,0]
-        train_X = train_data.ix[:,1:]
+        train_y = train_data.iloc[:, 0]
+        train_X = train_data.iloc[:, 1:]
 
         # Here we only support a single hyperparameter. Note that hyperparameters are always passed in as
         # strings, so we need to do any necessary conversions.
@@ -68,7 +68,7 @@ def train():
         print('validation-accuracy: ' + str(validation_accuracy))
 
         # save the model
-        with open(os.path.join(model_path, 'decision-tree-model.pkl'), 'w') as out:
+        with open(os.path.join(model_path, 'decision-tree-model.pkl'), 'wb') as out:
             pickle.dump(clf, out)
         print('Training complete.')
     except Exception as e:

--- a/      build_and_train_models/sm-marketplace_building_your_own_container_as_package/sm-marketplace_building_your_own_container_as_package-v3.ipynb
+++ b/      build_and_train_models/sm-marketplace_building_your_own_container_as_package/sm-marketplace_building_your_own_container_as_package-v3.ipynb
@@ -1,0 +1,1530 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Building your own container as Algorithm / Model Package\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "This notebook's CI test result for us-west-2 is as follows. CI test results in other regions can be found at the end of the notebook. \n",
+    "\n",
+    "![This us-west-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-west-2/build_and_train_models|sm-marketplace_building_your_own_container_as_package|sm-marketplace_building_your_own_container_as_package.ipynb)\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "With Amazon SageMaker, you can package your own algorithms that can than be trained and deployed in the SageMaker environment. This notebook will guide you through an example that shows you how to build a Docker container for SageMaker and use it for training and inference.\n",
+    "\n",
+    "This is an extension of the [scikit-bring-your-own notebook](https://github.com/awslabs/amazon-sagemaker-examples/blob/master/advanced_functionality/scikit_bring_your_own/scikit_bring_your_own.ipynb). We append specific steps that help you create a new Algorithm / Model Package SageMaker entities, which can be sold on AWS Marketplace\n",
+    "\n",
+    "By packaging an algorithm in a container, you can bring almost any code to the Amazon SageMaker environment, regardless of programming language, environment, framework, or dependencies. \n",
+    "\n",
+    "1. [Building your own algorithm container](#Building-your-own-algorithm-container)\n",
+    "    1. [When should I build my own algorithm container?](#When-should-I-build-my-own-algorithm-container?)\n",
+    "    1. [Permissions](#Permissions)\n",
+    "    1. [The example](#The-example)\n",
+    "    1. [The presentation](#The-presentation)\n",
+    "1. [Part 1: Packaging and Uploading your Algorithm for use with Amazon SageMaker](#Part-1:-Packaging-and-Uploading-your-Algorithm-for-use-with-Amazon-SageMaker)\n",
+    "    1. [An overview of Docker](#An-overview-of-Docker)\n",
+    "    1. [How Amazon SageMaker runs your Docker container](#How-Amazon-SageMaker-runs-your-Docker-container)\n",
+    "      1. [Running your container during training](#Running-your-container-during-training)\n",
+    "        1. [The input](#The-input)\n",
+    "        1. [The output](#The-output)\n",
+    "      1. [Running your container during hosting](#Running-your-container-during-hosting)\n",
+    "    1. [The parts of the sample container](#The-parts-of-the-sample-container)\n",
+    "    1. [The Dockerfile](#The-Dockerfile)\n",
+    "    1. [Building and registering the container](#Building-and-registering-the-container)\n",
+    "    1. [Testing your algorithm on your local machine or on an Amazon SageMaker notebook instance](#Testing-your-algorithm-on-your-local-machine-or-on-an-Amazon-SageMaker-notebook-instance)\n",
+    "1. [Part 2: Training and Hosting your Algorithm in Amazon SageMaker](#Part-2:-Training-and-Hosting-your-Algorithm-in-Amazon-SageMaker)\n",
+    "    1. [Set up the environment](#Set-up-the-environment)\n",
+    "    1. [Create the session](#Create-the-session)\n",
+    "    1. [Upload the data for training](#Upload-the-data-for-training)\n",
+    "    1. [Create an estimator and fit the model](#Create-an-estimator-and-fit-the-model)\n",
+    "    1. [Run a Batch Transform Job](#Batch-Transform-Job)\n",
+    "    1. [Deploy the model](#Deploy-the-model)\n",
+    "    1. [Optional cleanup](#Cleanup-Endpoint)\n",
+    "1. [Part 3: Package your resources as an Amazon SageMaker Algorithm](#Part-3---Package-your-resources-as-an-Amazon-SageMaker-Algorithm)\n",
+    "    1. [Algorithm Definition](#Algorithm-Definition)\n",
+    "1. [Part 4: Package your resources as an Amazon SageMaker ModelPackage](#Part-4---Package-your-resources-as-an-Amazon-SageMaker-ModelPackage)\n",
+    "    1. [Model Package Definition](#Model-Package-Definition)\n",
+    "1. [Part 5: Package your resources as an Amazon SageMaker Algorithm for Fine-tuning Large Models](#part-5---package-your-resources-as-an-amazon-sagemaker-algorithm-for-fine-tuning-large-models)\n",
+    "1. [Debugging Creation Issues](#Debugging-Creation-Issues)\n",
+    "1. [List on AWS Marketplace](#List-on-AWS-Marketplace)\n",
+    "\n",
+    "## When should I build my own algorithm container?\n",
+    "\n",
+    "You may not need to create a container to bring your own code to Amazon SageMaker. When you are using a framework (such as Apache MXNet or TensorFlow) that has direct support in SageMaker, you can simply supply the Python code that implements your algorithm using the SDK entry points for that framework. This set of frameworks is continually expanding, so we recommend that you check the current list if your algorithm is written in a common machine learning environment.\n",
+    "\n",
+    "Even if there is direct SDK support for your environment or framework, you may find it more effective to build your own container. If the code that implements your algorithm is quite complex on its own or you need special additions to the framework, building your own container may be the right choice.\n",
+    "\n",
+    "If there isn't direct SDK support for your environment, don't worry. You'll see in this walk-through that building your own container is quite straightforward.\n",
+    "\n",
+    "## Permissions\n",
+    "\n",
+    "Running this notebook requires permissions in addition to the normal `SageMakerFullAccess` permissions. This is because we'll creating new repositories in Amazon ECR. The easiest way to add these permissions is simply to add the managed policy `AmazonEC2ContainerRegistryFullAccess` to the role that you used to start your notebook instance. There's no need to restart your notebook instance when you do this, the new permissions will be available immediately.\n",
+    "\n",
+    "## The example\n",
+    "\n",
+    "Here, we'll show how to package a simple Python example which showcases the [decision tree][] algorithm from the widely used [scikit-learn][] machine learning package. The example is purposefully fairly trivial since the point is to show the surrounding structure that you'll want to add to your own code so you can train and host it in Amazon SageMaker.\n",
+    "\n",
+    "The ideas shown here will work in any language or environment. You'll need to choose the right tools for your environment to serve HTTP requests for inference, but good HTTP environments are available in every language these days.\n",
+    "\n",
+    "In this example, we use a single image to support training and hosting. This is easy because it means that we only need to manage one image and we can set it up to do everything. Sometimes you'll want separate images for training and hosting because they have different requirements. Just separate the parts discussed below into separate Dockerfiles and build two images. Choosing whether to have a single image or two images is really a matter of which is more convenient for you to develop and manage.\n",
+    "\n",
+    "If you're only using Amazon SageMaker for training or hosting, but not both, there is no need to build the unused functionality into your container.\n",
+    "\n",
+    "[scikit-learn]: http://scikit-learn.org/stable/\n",
+    "[decision tree]: http://scikit-learn.org/stable/modules/tree.html\n",
+    "\n",
+    "## The presentation\n",
+    "\n",
+    "This presentation is divided into two parts: _building_ the container and _using_ the container."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Part 1: Packaging and Uploading your Algorithm for use with Amazon SageMaker\n",
+    "\n",
+    "### An overview of Docker\n",
+    "\n",
+    "If you're familiar with Docker already, you can skip ahead to the next section.\n",
+    "\n",
+    "For many data scientists, Docker containers are a new concept, but they are not difficult, as you'll see here. \n",
+    "\n",
+    "Docker provides a simple way to package arbitrary code into an _image_ that is totally self-contained. Once you have an image, you can use Docker to run a _container_ based on that image. Running a container is just like running a program on the machine except that the container creates a fully self-contained environment for the program to run. Containers are isolated from each other and from the host environment, so the way you set up your program is the way it runs, no matter where you run it.\n",
+    "\n",
+    "Docker is more powerful than environment managers like conda or virtualenv because (a) it is completely language independent and (b) it comprises your whole operating environment, including startup commands, environment variable, etc.\n",
+    "\n",
+    "In some ways, a Docker container is like a virtual machine, but it is much lighter weight. For example, a program running in a container can start in less than a second and many containers can run on the same physical machine or virtual machine instance.\n",
+    "\n",
+    "Docker uses a simple file called a `Dockerfile` to specify how the image is assembled. We'll see an example of that below. You can build your Docker images based on Docker images built by yourself or others, which can simplify things quite a bit.\n",
+    "\n",
+    "Docker has become very popular in the programming and devops communities for its flexibility and well-defined specification of the code to be run. It is the underpinning of many services built in the past few years, such as [Amazon ECS].\n",
+    "\n",
+    "Amazon SageMaker uses Docker to allow users to train and deploy arbitrary algorithms.\n",
+    "\n",
+    "In Amazon SageMaker, Docker containers are invoked in a certain way for training and a slightly different way for hosting. The following sections outline how to build containers for the SageMaker environment.\n",
+    "\n",
+    "Some helpful links:\n",
+    "\n",
+    "* [Docker home page](http://www.docker.com)\n",
+    "* [Getting started with Docker](https://docs.docker.com/get-started/)\n",
+    "* [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)\n",
+    "* [`docker run` reference](https://docs.docker.com/engine/reference/run/)\n",
+    "\n",
+    "[Amazon ECS]: https://aws.amazon.com/ecs/\n",
+    "\n",
+    "### How Amazon SageMaker runs your Docker container\n",
+    "\n",
+    "Because you can run the same image in training or hosting, Amazon SageMaker runs your container with the argument `train` or `serve`. How your container processes this argument depends on the container:\n",
+    "\n",
+    "* In the example here, we don't define an `ENTRYPOINT` in the Dockerfile so Docker will run the command `train` at training time and `serve` at serving time. In this example, we define these as executable Python scripts, but they could be any program that we want to start in that environment.\n",
+    "* If you specify a program as an `ENTRYPOINT` in the Dockerfile, that program will be run at startup and its first argument will be `train` or `serve`. The program can then look at that argument and decide what to do.\n",
+    "* If you are building separate containers for training and hosting (or building only for one or the other), you can define a program as an `ENTRYPOINT` in the Dockerfile and ignore (or verify) the first argument passed in. \n",
+    "\n",
+    "#### Running your container during training\n",
+    "\n",
+    "When Amazon SageMaker runs training, your `train` script is run just like a regular Python program. A number of files are laid out for your use, under the `/opt/ml` directory:\n",
+    "\n",
+    "    /opt/ml\n",
+    "    |-- input\n",
+    "    |   |-- config\n",
+    "    |   |   |-- hyperparameters.json\n",
+    "    |   |   `-- resourceConfig.json\n",
+    "    |   `-- data\n",
+    "    |       `-- <channel_name>\n",
+    "    |           `-- <input data>\n",
+    "    |-- model\n",
+    "    |   `-- <model files>\n",
+    "    `-- output\n",
+    "        `-- failure\n",
+    "\n",
+    "##### The input\n",
+    "\n",
+    "* `/opt/ml/input/config` contains information to control how your program runs. `hyperparameters.json` is a JSON-formatted dictionary of hyperparameter names to values. These values will always be strings, so you may need to convert them. `resourceConfig.json` is a JSON-formatted file that describes the network layout used for distributed training. Since scikit-learn doesn't support distributed training, we'll ignore it here.\n",
+    "* `/opt/ml/input/data/<channel_name>/` (for File mode) contains the input data for that channel. The channels are created based on the call to CreateTrainingJob but it's generally important that channels match what the algorithm expects. The files for each channel will be copied from S3 to this directory, preserving the tree structure indicated by the S3 key structure. \n",
+    "* `/opt/ml/input/data/<channel_name>_<epoch_number>` (for Pipe mode) is the pipe for a given epoch. Epochs start at zero and go up by one each time you read them. There is no limit to the number of epochs that you can run, but you must close each pipe before reading the next epoch.\n",
+    "\n",
+    "##### The output\n",
+    "\n",
+    "* `/opt/ml/model/` is the directory where you write the model that your algorithm generates. Your model can be in any format that you want. It can be a single file or a whole directory tree. SageMaker will package any files in this directory into a compressed tar archive file. This file will be available at the S3 location returned in the `DescribeTrainingJob` result.\n",
+    "* `/opt/ml/output` is a directory where the algorithm can write a file `failure` that describes why the job failed. The contents of this file will be returned in the `FailureReason` field of the `DescribeTrainingJob` result. For jobs that succeed, there is no reason to write this file as it will be ignored.\n",
+    "\n",
+    "#### Running your container during hosting\n",
+    "\n",
+    "Hosting has a very different model than training because hosting is reponding to inference requests that come in via HTTP. In this example, we use our recommended Python serving stack to provide robust and scalable serving of inference requests:\n",
+    "\n",
+    "![Request serving stack](images/stack.png)\n",
+    "\n",
+    "This stack is implemented in the sample code here and you can mostly just leave it alone. \n",
+    "\n",
+    "Amazon SageMaker uses two URLs in the container:\n",
+    "\n",
+    "* `/ping` will receive `GET` requests from the infrastructure. Your program returns 200 if the container is up and accepting requests.\n",
+    "* `/invocations` is the endpoint that receives client inference `POST` requests. The format of the request and the response is up to the algorithm. If the client supplied `ContentType` and `Accept` headers, these will be passed in as well. \n",
+    "\n",
+    "The container will have the model files in the same place they were written during training:\n",
+    "\n",
+    "    /opt/ml\n",
+    "    `-- model\n",
+    "        `-- <model files>\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The parts of the sample container\n",
+    "\n",
+    "In the `container` directory are all the components you need to package the sample algorithm for Amazon SageMager:\n",
+    "\n",
+    "    .\n",
+    "    |-- Dockerfile\n",
+    "    |-- build_and_push.sh\n",
+    "    `-- decision_trees\n",
+    "        |-- nginx.conf\n",
+    "        |-- predictor.py\n",
+    "        |-- serve\n",
+    "        |-- train\n",
+    "        `-- wsgi.py\n",
+    "\n",
+    "Let's discuss each of these in turn:\n",
+    "\n",
+    "* __`Dockerfile`__ describes how to build your Docker container image. More details below.\n",
+    "* __`build_and_push.sh`__ is a script that uses the Dockerfile to build your container images and then pushes it to ECR. We'll invoke the commands directly later in this notebook, but you can just copy and run the script for your own algorithms.\n",
+    "* __`decision_trees`__ is the directory which contains the files that will be installed in the container.\n",
+    "* __`local_test`__ is a directory that shows how to test your new container on any computer that can run Docker, including an Amazon SageMaker notebook instance. Using this method, you can quickly iterate using small datasets to eliminate any structural bugs before you use the container with Amazon SageMaker. We'll walk through local testing later in this notebook.\n",
+    "\n",
+    "In this simple application, we only install five files in the container. You may only need that many or, if you have many supporting routines, you may wish to install more. These five show the standard structure of our Python containers, although you are free to choose a different toolset and therefore could have a different layout. If you're writing in a different programming language, you'll certainly have a different layout depending on the frameworks and tools you choose.\n",
+    "\n",
+    "The files that we'll put in the container are:\n",
+    "\n",
+    "* __`nginx.conf`__ is the configuration file for the nginx front-end. Generally, you should be able to take this file as-is.\n",
+    "* __`predictor.py`__ is the program that actually implements the Flask web server and the decision tree predictions for this app. You'll want to customize the actual prediction parts to your application. Since this algorithm is simple, we do all the processing here in this file, but you may choose to have separate files for implementing your custom logic.\n",
+    "* __`serve`__ is the program started when the container is started for hosting. It simply launches the gunicorn server which runs multiple instances of the Flask app defined in `predictor.py`. You should be able to take this file as-is.\n",
+    "* __`train`__ is the program that is invoked when the container is run for training. You will modify this program to implement your training algorithm.\n",
+    "* __`wsgi.py`__ is a small wrapper used to invoke the Flask app. You should be able to take this file as-is.\n",
+    "\n",
+    "In summary, the two files you will probably want to change for your application are `train` and `predictor.py`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The Dockerfile\n",
+    "\n",
+    "The Dockerfile describes the image that we want to build. You can think of it as describing the complete operating system installation of the system that you want to run. A Docker container running is quite a bit lighter than a full operating system, however, because it takes advantage of Linux on the host machine for the basic operations. \n",
+    "\n",
+    "For the Python science stack, we will start from a standard Ubuntu installation and run the normal tools to install the things needed by scikit-learn. Finally, we add the code that implements our specific algorithm to the container and set up the right environment to run under.\n",
+    "\n",
+    "Along the way, we clean up extra space. This makes the container smaller and faster to start.\n",
+    "\n",
+    "Let's look at the Dockerfile for the example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cat container/Dockerfile"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Building and registering the container\n",
+    "\n",
+    "The following shell code shows how to build the container image using `docker build` and push the container image to ECR using `docker push`. This code is also available as the shell script `container/build-and-push.sh`, which you can run as `build-and-push.sh decision_trees_sample` to build the image `decision_trees_sample`. \n",
+    "\n",
+    "This code looks for an ECR repository in the account you're using and the current default region (if you're using an Amazon SageMaker notebook instance, this will be the region where the notebook instance was created). If the repository doesn't exist, the script will create it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sh\n",
+    "\n",
+    "# The name of our algorithm\n",
+    "algorithm_name=decision-trees-sample\n",
+    "\n",
+    "cd container\n",
+    "\n",
+    "chmod +x decision_trees/train\n",
+    "chmod +x decision_trees/serve\n",
+    "\n",
+    "account=$(aws sts get-caller-identity --query Account --output text)\n",
+    "\n",
+    "# Get the region defined in the current configuration (default to us-west-2 if none defined)\n",
+    "region=$(aws configure get region)\n",
+    "\n",
+    "fullname=\"${account}.dkr.ecr.${region}.amazonaws.com/${algorithm_name}:latest\"\n",
+    "\n",
+    "# If the repository doesn't exist in ECR, create it.\n",
+    "\n",
+    "aws ecr describe-repositories --repository-names \"${algorithm_name}\" > /dev/null 2>&1\n",
+    "\n",
+    "if [ $? -ne 0 ]\n",
+    "then\n",
+    "    aws ecr create-repository --repository-name \"${algorithm_name}\" > /dev/null\n",
+    "fi\n",
+    "\n",
+    "# Get the login command from ECR and execute it directly\n",
+    "$(aws ecr get-login --region ${region} --no-include-email)\n",
+    "\n",
+    "# Build the docker image locally with the image name and then push it to ECR\n",
+    "# with the full name.\n",
+    "\n",
+    "docker build  -t ${algorithm_name} .\n",
+    "docker tag ${algorithm_name} ${fullname}\n",
+    "\n",
+    "docker push ${fullname}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Testing your algorithm on your local machine or on an Amazon SageMaker notebook instance\n",
+    "\n",
+    "While you're first packaging an algorithm use with Amazon SageMaker, you probably want to test it yourself to make sure it's working right. In the directory `container/local_test`, there is a framework for doing this. It includes three shell scripts for running and using the container and a directory structure that mimics the one outlined above.\n",
+    "\n",
+    "The scripts are:\n",
+    "\n",
+    "* `train_local.sh`: Run this with the name of the image and it will run training on the local tree. You'll want to modify the directory `test_dir/input/data/...` to be set up with the correct channels and data for your algorithm. Also, you'll want to modify the file `input/config/hyperparameters.json` to have the hyperparameter settings that you want to test (as strings).\n",
+    "* `serve_local.sh`: Run this with the name of the image once you've trained the model and it should serve the model. It will run and wait for requests. Simply use the keyboard interrupt to stop it.\n",
+    "* `predict.sh`: Run this with the name of a payload file and (optionally) the HTTP content type you want. The content type will default to `text/csv`. For example, you can run `$ ./predict.sh payload.csv text/csv`.\n",
+    "\n",
+    "The directories as shipped are set up to test the decision trees sample algorithm presented here."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Part 2: Training, Batch Inference and Hosting your Algorithm in Amazon SageMaker\n",
+    "\n",
+    "Once you have your container packaged, you can use it to train and serve models. Let's do that with the algorithm we made above.\n",
+    "\n",
+    "### Set up the environment\n",
+    "\n",
+    "Here we specify a bucket to use and the role that will be used for working with Amazon SageMaker."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# S3 prefix\n",
+    "common_prefix = \"DEMO-scikit-byo-iris\"\n",
+    "training_input_prefix = common_prefix + \"/training-input-data\"\n",
+    "batch_inference_input_prefix = common_prefix + \"/batch-inference-input-data\"\n",
+    "\n",
+    "import os\n",
+    "\n",
+    "# V3: get_execution_role moved to sagemaker-core session helper.\n",
+    "from sagemaker.core.helper.session_helper import get_execution_role\n",
+    "\n",
+    "role = get_execution_role()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create the session\n",
+    "\n",
+    "The session remembers our connection parameters to Amazon SageMaker. We'll use it to perform all of our SageMaker operations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# V3: use the sagemaker-core Session helper instead of sagemaker.Session().\n",
+    "from sagemaker.core.helper.session_helper import Session\n",
+    "\n",
+    "sess = Session()\n",
+    "\n",
+    "default_bucket = sess.default_bucket()\n",
+    "default_bucket_prefix = sess.default_bucket_prefix\n",
+    "default_bucket_prefix_path = \"\"\n",
+    "\n",
+    "# If a default bucket prefix is specified, append it to the s3 path\n",
+    "if default_bucket_prefix:\n",
+    "    default_bucket_prefix_path = f\"/{default_bucket_prefix}\"\n",
+    "    common_prefix = f\"{default_bucket_prefix}/{common_prefix}\"\n",
+    "    training_input_prefix = f\"{default_bucket_prefix}/{training_input_prefix}\"\n",
+    "    batch_inference_input_prefix = f\"{default_bucket_prefix}/{batch_inference_input_prefix}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Upload the data for training\n",
+    "\n",
+    "When training large models with huge amounts of data, you'll typically use big data tools, like Amazon Athena, AWS Glue, or Amazon EMR, to create your data in S3. For the purposes of this example, we're using some the classic [Iris dataset](https://en.wikipedia.org/wiki/Iris_flower_data_set), which we have included. \n",
+    "\n",
+    "We can use use the tools provided by the Amazon SageMaker Python SDK to upload the data to a default bucket. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TRAINING_WORKDIR = \"data/training\"\n",
+    "\n",
+    "training_input = sess.upload_data(TRAINING_WORKDIR, key_prefix=training_input_prefix)\n",
+    "print(\"Training Data Location \" + training_input)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create an estimator and fit the model\n",
+    "\n",
+    "In order to use Amazon SageMaker to fit our algorithm, we'll create an `Estimator` that defines how to use the container to train. This includes the configuration we need to invoke SageMaker training:\n",
+    "\n",
+    "* The __container name__. This is constructed as in the shell commands above.\n",
+    "* The __role__. As defined above.\n",
+    "* The __instance count__ which is the number of machines to use for training.\n",
+    "* The __instance type__ which is the type of machine to use for training.\n",
+    "* The __output path__ determines where the model artifact will be written.\n",
+    "* The __session__ is the SageMaker session object that we defined above.\n",
+    "\n",
+    "Then we use fit() on the estimator to train against the data that we uploaded above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "account = sess.boto_session.client(\"sts\").get_caller_identity()[\"Account\"]\n",
+    "region = sess.boto_session.region_name\n",
+    "image = \"{}.dkr.ecr.{}.amazonaws.com/decision-trees-sample:latest\".format(account, region)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# V3: the V2 Estimator is replaced by ModelTrainer. For a bring-your-own custom\n",
+    "# container, pass the ECR image via `training_image`; compute/output are structured configs.\n",
+    "from sagemaker.train import ModelTrainer\n",
+    "from sagemaker.core.training.configs import Compute, OutputDataConfig, InputData\n",
+    "\n",
+    "tree = ModelTrainer(\n",
+    "    training_image=image,\n",
+    "    role=role,\n",
+    "    sagemaker_session=sess,\n",
+    "    compute=Compute(instance_type=\"ml.c4.2xlarge\", instance_count=1),\n",
+    "    output_data_config=OutputDataConfig(\n",
+    "        s3_output_path=\"s3://{}{}/output\".format(default_bucket, default_bucket_prefix_path)\n",
+    "    ),\n",
+    "    base_job_name=\"decision-trees-sample\",\n",
+    ")\n",
+    "\n",
+    "# The custom container expects a single channel named \"training\".\n",
+    "tree.train(\n",
+    "    input_data_config=[\n",
+    "        InputData(channel_name=\"training\", data_source=training_input)\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "# Grab the completed training job + its model artifact for downstream batch transform / hosting.\n",
+    "training_job = tree._latest_training_job\n",
+    "model_data = training_job.model_artifacts.s3_model_artifacts\n",
+    "print(\"Model artifact:\", model_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Batch Transform Job\n",
+    "\n",
+    "Now let's use the model built to run a batch inference job and verify it works.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Batch Transform Input Preparation\n",
+    "\n",
+    "The snippet below is removing the \"label\" column (column indexed at 0) and retaining the rest to be batch transform's input. \n",
+    "\n",
+    "NOTE: This is the same training data, which is a no-no from a statistical/ML science perspective. But the aim of this notebook is to demonstrate how things work end-to-end."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "## Remove first column that contains the label\n",
+    "shape = pd.read_csv(TRAINING_WORKDIR + \"/iris.csv\", header=None).drop([0], axis=1)\n",
+    "\n",
+    "TRANSFORM_WORKDIR = \"data/transform\"\n",
+    "shape.to_csv(TRANSFORM_WORKDIR + \"/batchtransform_test.csv\", index=False, header=False)\n",
+    "\n",
+    "transform_input = (\n",
+    "    sess.upload_data(TRANSFORM_WORKDIR, key_prefix=batch_inference_input_prefix)\n",
+    "    + \"/batchtransform_test.csv\"\n",
+    ")\n",
+    "print(\"Transform input uploaded to \" + transform_input)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run Batch Transform\n",
+    "\n",
+    "Now that our batch transform input is setup, we run the transformation job next"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# V3: batch transform is done via sagemaker-core resources. First register the trained\n",
+    "# artifact as a Model, then run a TransformJob against it.\n",
+    "import time\n",
+    "from sagemaker.core.resources import Model, TransformJob\n",
+    "from sagemaker.core.shapes import (\n",
+    "    ContainerDefinition,\n",
+    "    TransformInput,\n",
+    "    TransformOutput,\n",
+    "    TransformResources,\n",
+    "    TransformDataSource,\n",
+    "    TransformS3DataSource,\n",
+    ")\n",
+    "\n",
+    "suffix = time.strftime(\"%Y-%m-%d-%H-%M-%S\", time.gmtime())\n",
+    "transform_model_name = \"decision-trees-batch-\" + suffix\n",
+    "transform_job_name = \"decision-trees-transform-\" + suffix\n",
+    "transform_output_path = \"s3://{}{}/transform-output\".format(\n",
+    "    default_bucket, default_bucket_prefix_path\n",
+    ")\n",
+    "\n",
+    "# Same custom image is used for training and inference.\n",
+    "Model.create(\n",
+    "    model_name=transform_model_name,\n",
+    "    primary_container=ContainerDefinition(image=image, model_data_url=model_data),\n",
+    "    execution_role_arn=role,\n",
+    ")\n",
+    "\n",
+    "transform_job = TransformJob.create(\n",
+    "    transform_job_name=transform_job_name,\n",
+    "    model_name=transform_model_name,\n",
+    "    transform_input=TransformInput(\n",
+    "        data_source=TransformDataSource(\n",
+    "            s3_data_source=TransformS3DataSource(\n",
+    "                s3_data_type=\"S3Prefix\", s3_uri=transform_input\n",
+    "            )\n",
+    "        ),\n",
+    "        content_type=\"text/csv\",\n",
+    "        split_type=\"Line\",\n",
+    "    ),\n",
+    "    transform_output=TransformOutput(s3_output_path=transform_output_path, assemble_with=\"Line\"),\n",
+    "    transform_resources=TransformResources(instance_type=\"ml.m4.xlarge\", instance_count=1),\n",
+    ")\n",
+    "transform_job.wait()\n",
+    "\n",
+    "print(\"Batch Transform output saved to \" + transform_output_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Inspect the Batch Transform Output in S3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from urllib.parse import urlparse\n",
+    "\n",
+    "parsed_url = urlparse(transform_output_path)\n",
+    "bucket_name = parsed_url.netloc\n",
+    "file_key = \"{}/{}.out\".format(parsed_url.path[1:], \"batchtransform_test.csv\")\n",
+    "\n",
+    "s3_client = sess.boto_session.client(\"s3\")\n",
+    "\n",
+    "response = s3_client.get_object(Bucket=bucket_name, Key=file_key)\n",
+    "response_bytes = response[\"Body\"].read().decode(\"utf-8\")\n",
+    "print(response_bytes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Deploy the model\n",
+    "\n",
+    "Deploying the model to Amazon SageMaker hosting just requires a `deploy` call on the fitted model. This call takes an instance count, instance type, and optionally serializer and deserializer functions. These are used when the resulting predictor is created on the endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# V3: hosting is done with sagemaker-core resources (Model + EndpointConfig + Endpoint)\n",
+    "# instead of estimator.deploy(). The same custom image serves inference.\n",
+    "import time\n",
+    "from sagemaker.core.resources import Model, EndpointConfig, Endpoint\n",
+    "from sagemaker.core.shapes import ContainerDefinition, ProductionVariant\n",
+    "\n",
+    "deploy_suffix = time.strftime(\"%Y-%m-%d-%H-%M-%S\", time.gmtime())\n",
+    "model_name = \"decision-trees-model-\" + deploy_suffix\n",
+    "endpoint_config_name = \"decision-trees-epc-\" + deploy_suffix\n",
+    "endpoint_name = \"decision-trees-ep-\" + deploy_suffix\n",
+    "\n",
+    "Model.create(\n",
+    "    model_name=model_name,\n",
+    "    primary_container=ContainerDefinition(image=image, model_data_url=model_data),\n",
+    "    execution_role_arn=role,\n",
+    ")\n",
+    "\n",
+    "EndpointConfig.create(\n",
+    "    endpoint_config_name=endpoint_config_name,\n",
+    "    production_variants=[\n",
+    "        ProductionVariant(\n",
+    "            variant_name=\"AllTraffic\",\n",
+    "            model_name=model_name,\n",
+    "            initial_instance_count=1,\n",
+    "            instance_type=\"ml.m4.xlarge\",\n",
+    "            initial_variant_weight=1.0,\n",
+    "        )\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "predictor = Endpoint.create(\n",
+    "    endpoint_name=endpoint_name,\n",
+    "    endpoint_config_name=endpoint_config_name,\n",
+    ")\n",
+    "predictor.wait_for_status(\"InService\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Choose some data and use it for a prediction\n",
+    "\n",
+    "In order to do some predictions, we'll extract some of the data we used for training and do predictions against it. This is, of course, bad statistical practice, but a good way to see how the mechanism works."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shape = pd.read_csv(TRAINING_WORKDIR + \"/iris.csv\", header=None)\n",
+    "\n",
+    "import itertools\n",
+    "\n",
+    "a = [50 * i for i in range(3)]\n",
+    "b = [40 + i for i in range(10)]\n",
+    "indices = [i + j for i, j in itertools.product(a, b)]\n",
+    "\n",
+    "test_data = shape.iloc[indices[:-1]]\n",
+    "test_X = test_data.iloc[:, 1:]\n",
+    "test_y = test_data.iloc[:, 0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Prediction is as easy as calling predict with the predictor we got back from deploy and the data we want to do predictions with. The serializers take care of doing the data conversions for us."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# V3: invoke the endpoint via the core Endpoint resource. Serialize the feature rows to CSV\n",
+    "# (the same content type the custom container expects) and read the response body.\n",
+    "import io\n",
+    "\n",
+    "\n",
+    "def predict_csv(endpoint, values):\n",
+    "    buf = io.StringIO()\n",
+    "    for row in values:\n",
+    "        buf.write(\",\".join(str(v) for v in row) + \"\\n\")\n",
+    "    response = endpoint.invoke(\n",
+    "        body=buf.getvalue().encode(\"utf-8\"),\n",
+    "        content_type=\"text/csv\",\n",
+    "        accept=\"text/csv\",\n",
+    "    )\n",
+    "    payload = response.body.read()\n",
+    "    if isinstance(payload, bytes):\n",
+    "        payload = payload.decode(\"utf-8\")\n",
+    "    return payload\n",
+    "\n",
+    "\n",
+    "print(predict_csv(predictor, test_X.values))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Cleanup Endpoint\n",
+    "\n",
+    "When you're done with the endpoint, you'll want to clean it up."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# V3: clean up the hosted endpoint, its config, and the model.\n",
+    "predictor.delete()\n",
+    "EndpointConfig.get(endpoint_config_name).delete()\n",
+    "Model.get(model_name).delete()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Part 3 - Package your resources as an Amazon SageMaker Algorithm\n",
+    "(If you looking to sell a pretrained model (ModelPackage), please skip to Part 4. If you are looking to sell a large model (Algorithm), please skip to part 5.)\n",
+    "\n",
+    "Now that you have verified that the algorithm code works for training, live inference and batch inference in the above sections, you can start packaging it up as an Amazon SageMaker Algorithm."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "\n",
+    "smmp = boto3.client(\"sagemaker\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Algorithm Definition\n",
+    "\n",
+    "SageMaker Algorithm is comprised of 2 parts:\n",
+    "\n",
+    "1. A training image\n",
+    "2. An inference image (optional)\n",
+    "\n",
+    "The key requirement is that the training and inference images (if provided) remain compatible with each other. Specifically, the model artifacts generated by the code in training image should be readable and compatible with the code in inference image. \n",
+    "\n",
+    "You can reuse the same image to perform both training and inference or you can choose to separate them. \n",
+    "\n",
+    "\n",
+    "This sample notebook has already created a single algorithm image that perform both training and inference. This image has also been pushed to your ECR registry at {{image}}. You need to provide the following details as part of this algorithm specification:\n",
+    "\n",
+    "#### Training Specification\n",
+    "\n",
+    "You specify details pertinent to your training algorithm in this section.\n",
+    "\n",
+    "#### Supported Hyper-parameters\n",
+    "\n",
+    "This section captures the hyper-parameters your algorithm supports, their names, types, if they are required, default values, valid ranges etc. This serves both as documentation for buyers and is used by Amazon SageMaker to perform validations of buyer requests in the synchronous request path.\n",
+    "\n",
+    "Please Note: While this section is optional, we strongly recommend you provide comprehensive information here to leverage our validations and serve as documentation. Additionally, without this being specified, customers cannot leverage your algorithm for Hyper-parameter tuning.\n",
+    "\n",
+    "*** NOTE: The code below has hyper-parameters hard-coded in the json present in src/training_specification.py. Until we have better functionality to customize it, please update the json in that file appropriately***\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.training_specification import TrainingSpecification\n",
+    "from src.training_channels import TrainingChannels\n",
+    "from src.metric_definitions import MetricDefinitions\n",
+    "from src.tuning_objectives import TuningObjectives\n",
+    "import json\n",
+    "\n",
+    "training_specification = TrainingSpecification().get_training_specification_dict(\n",
+    "    ecr_image=image,\n",
+    "    supports_gpu=True,\n",
+    "    supported_channels=[\n",
+    "        TrainingChannels(\n",
+    "            \"training\",\n",
+    "            description=\"Input channel that provides training data\",\n",
+    "            supported_content_types=[\"text/csv\"],\n",
+    "        )\n",
+    "    ],\n",
+    "    supported_metrics=[MetricDefinitions(\"validation:accuracy\", \"validation-accuracy: (\\\\S+)\")],\n",
+    "    supported_tuning_job_objective_metrics=[TuningObjectives(\"Maximize\", \"validation:accuracy\")],\n",
+    ")\n",
+    "\n",
+    "print(json.dumps(training_specification, indent=2, sort_keys=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Inference Specification\n",
+    "\n",
+    "You specify details pertinent to your inference code in this section. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.inference_specification import InferenceSpecification\n",
+    "import json\n",
+    "\n",
+    "inference_specification = InferenceSpecification().get_inference_specification_dict(\n",
+    "    ecr_image=image,\n",
+    "    supports_gpu=True,\n",
+    "    supported_content_types=[\"text/csv\"],\n",
+    "    supported_mime_types=[\"text/csv\"],\n",
+    ")\n",
+    "\n",
+    "print(json.dumps(inference_specification, indent=4, sort_keys=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Validation Specification\n",
+    "\n",
+    "In order to provide confidence to the sellers (and buyers) that the products work in Amazon SageMaker before listing them on AWS Marketplace, SageMaker needs to perform basic validations. The product can be listed in AWS Marketplace only if this validation process succeeds. This validation process uses the validation profile and sample data provided by you to run the following validations:\n",
+    "\n",
+    "1. Create a training job in your account to verify your training image works with SageMaker.\n",
+    "2. Once the training job completes successfully, create a Model in your account using the algorithm's inference image and the model artifacts produced as part of the training job we ran. \n",
+    "3. Create a transform job in your account using the above Model to verify your inference image works with SageMaker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.algorithm_validation_specification import AlgorithmValidationSpecification\n",
+    "import json\n",
+    "\n",
+    "validation_specification = (\n",
+    "    AlgorithmValidationSpecification().get_algo_validation_specification_dict(\n",
+    "        validation_role=role,\n",
+    "        training_channel_name=\"training\",\n",
+    "        training_input=training_input,\n",
+    "        batch_transform_input=transform_input,\n",
+    "        content_type=\"text/csv\",\n",
+    "        instance_type=\"ml.c4.xlarge\",\n",
+    "        output_s3_location=\"s3://{}/{}\".format(default_bucket, common_prefix),\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "print(json.dumps(validation_specification, indent=4, sort_keys=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Putting it all together\n",
+    "\n",
+    "Now we put all the pieces together in the next cell and create an Amazon SageMaker Algorithm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import time\n",
+    "\n",
+    "algorithm_name = \"scikit-decision-trees-\" + str(round(time.time()))\n",
+    "\n",
+    "create_algorithm_input_dict = {\n",
+    "    \"AlgorithmName\": algorithm_name,\n",
+    "    \"AlgorithmDescription\": \"Decision trees using Scikit\",\n",
+    "    \"CertifyForMarketplace\": True,\n",
+    "}\n",
+    "create_algorithm_input_dict.update(training_specification)\n",
+    "create_algorithm_input_dict.update(inference_specification)\n",
+    "create_algorithm_input_dict.update(validation_specification)\n",
+    "\n",
+    "print(json.dumps(create_algorithm_input_dict, indent=4, sort_keys=True))\n",
+    "\n",
+    "print(\"Now creating an algorithm in SageMaker\")\n",
+    "\n",
+    "smmp.create_algorithm(**create_algorithm_input_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Describe the algorithm\n",
+    "\n",
+    "The next cell describes the Algorithm and waits until it reaches a terminal state (Completed or Failed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "import json\n",
+    "\n",
+    "while True:\n",
+    "    response = smmp.describe_algorithm(AlgorithmName=algorithm_name)\n",
+    "    status = response[\"AlgorithmStatus\"]\n",
+    "    print(status)\n",
+    "    if status == \"Completed\" or status == \"Failed\":\n",
+    "        print(response[\"AlgorithmStatusDetails\"])\n",
+    "        break\n",
+    "    time.sleep(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Part 4 - Package your resources as an Amazon SageMaker ModelPackage\n",
+    "\n",
+    "In this section, we will see how you can package your artifacts (ECR image and the trained artifact from your previous training job) into a ModelPackage. Once you complete this, you can list your product as a pretrained model in the AWS Marketplace.\n",
+    "\n",
+    "### Model Package Definition\n",
+    "A Model Package is a reusable model artifacts abstraction that packages all ingredients necessary for inference. It consists of an inference specification that defines the inference image to use along with an optional model weights location.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "smmp = boto3.client(\"sagemaker\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Inference Specification\n",
+    "\n",
+    "You specify details pertinent to your inference code in this section.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.inference_specification import InferenceSpecification\n",
+    "\n",
+    "import json\n",
+    "\n",
+    "modelpackage_inference_specification = InferenceSpecification().get_inference_specification_dict(\n",
+    "    ecr_image=image,\n",
+    "    supports_gpu=True,\n",
+    "    supported_content_types=[\"text/csv\"],\n",
+    "    supported_mime_types=[\"text/csv\"],\n",
+    ")\n",
+    "\n",
+    "# Specify the model data resulting from the previously completed training job\n",
+    "modelpackage_inference_specification[\"InferenceSpecification\"][\"Containers\"][0][\n",
+    "    \"ModelDataUrl\"\n",
+    "] = model_data\n",
+    "print(json.dumps(modelpackage_inference_specification, indent=4, sort_keys=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Validation Specification\n",
+    "\n",
+    "In order to provide confidence to the sellers (and buyers) that the products work in Amazon SageMaker before listing them on AWS Marketplace, SageMaker needs to perform basic validations. The product can be listed in the AWS Marketplace only if this validation process succeeds. This validation process uses the validation profile and sample data provided by you to run the following validations:\n",
+    "\n",
+    "* Create a transform job in your account using the above Model to verify your inference image works with SageMaker.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.modelpackage_validation_specification import ModelPackageValidationSpecification\n",
+    "import json\n",
+    "\n",
+    "modelpackage_validation_specification = (\n",
+    "    ModelPackageValidationSpecification().get_validation_specification_dict(\n",
+    "        validation_role=role,\n",
+    "        batch_transform_input=transform_input,\n",
+    "        content_type=\"text/csv\",\n",
+    "        instance_type=\"ml.c4.xlarge\",\n",
+    "        output_s3_location=\"s3://{}/{}\".format(default_bucket, common_prefix),\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "print(json.dumps(modelpackage_validation_specification, indent=4, sort_keys=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Putting it all together\n",
+    "\n",
+    "Now we put all the pieces together in the next cell and create an Amazon SageMaker Model Package."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import time\n",
+    "\n",
+    "model_package_name = \"scikit-iris-detector-\" + str(round(time.time()))\n",
+    "create_model_package_input_dict = {\n",
+    "    \"ModelPackageName\": model_package_name,\n",
+    "    \"ModelPackageDescription\": \"Model to detect 3 different types of irises (Setosa, Versicolour, and Virginica)\",\n",
+    "    \"CertifyForMarketplace\": True,\n",
+    "}\n",
+    "create_model_package_input_dict.update(modelpackage_inference_specification)\n",
+    "create_model_package_input_dict.update(modelpackage_validation_specification)\n",
+    "print(json.dumps(create_model_package_input_dict, indent=4, sort_keys=True))\n",
+    "\n",
+    "smmp.create_model_package(**create_model_package_input_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Describe the ModelPackage \n",
+    "\n",
+    "The next cell describes the ModelPackage and waits until it reaches a terminal state (Completed or Failed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "import json\n",
+    "\n",
+    "while True:\n",
+    "    response = smmp.describe_model_package(ModelPackageName=model_package_name)\n",
+    "    status = response[\"ModelPackageStatus\"]\n",
+    "    print(status)\n",
+    "    if status == \"Completed\" or status == \"Failed\":\n",
+    "        print(response[\"ModelPackageStatusDetails\"])\n",
+    "        break\n",
+    "    time.sleep(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Part 5 - Package your resources as an Amazon SageMaker Algorithm for Fine-tuning Large Models\n",
+    "(Use this notebook to see how to onboard machine learning models where the weights can be >= 100 GB. For example, if you are listing a large language model, follow these instructions.)\n",
+    "\n",
+    "Now that you have verified that the algorithm code works for training, live inference and batch inference in the above sections, you can start packaging it up as an Amazon SageMaker Algorithm."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create an Algorithm for Fine-tuning\n",
+    "\n",
+    "You can use the [create_algorithm API](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker/client/create_algorithm.html) to create fine-tuning algorithms. \n",
+    "\n",
+    "> Note: the new API field `AdditionalS3DataSource` under `TrainingSpecification` and `InferenceSpecification` that accept the base model weights from your S3 location. This allows you to provide larger sized model weights. \n",
+    "\n",
+    "**The Training and Inference containers also need to read the from the enviroment variable `SAGEMAKER_ADDITIONAL_S3_DATA_PATH` to access the pre-trained base model weights. This enviroment variable is the local path to the extracted artifacts in your container. You do not have the ability to customize the local path.**\n",
+    "\n",
+    "> As of now, Gzip is the only supported CompressionType. S3Object is the only supported S3DataType. S3Uri must end with `.tar.gz` suffix.\n",
+    "Under `ValidationSpecification` , `ValidationRole`,  `TrainingJobDefinition` are required. `TransfromJobDefinition` is optional.\n",
+    "\n",
+    "During Algorithm creation, a Training Job with `TrainingJobDefinition` setup will be run with `ValidationRole` to do basic validation on the training job container. If `TrainingJobDefinition` is provided in `ValidationSpecification`. During Algorithm creation,  Transform Job with `TransformJobDefinition` setup will be run with `ValidationRole` to do basic validation on the inference container. However, the transform inference Job run in this step will not have base weights downloaded to the container\n",
+    "\n",
+    "**Thus, only the inference container needs to exit successfully without base weights or real fine-tuning.**\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "\n",
+    "smmp = boto3.client(\"sagemaker\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Create the Algorithm using Boto3\n",
+    "\n",
+    "For an exhaustive list of parameters see the [CreateAlgorithm API](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateAlgorithm.html).\n",
+    "\n",
+    "The `AdditionalS3DataSource` artifacts are sent to your container. Your container can access them by reading the `SAGEMAKER_ADDITIONAL_S3_DATA_PATH` which contains the local path to the extracted artifacts. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NOTE (reference-only, not executed): fine-tuning large-model Algorithm creation template.\n",
+    "# This cell is illustrative boilerplate with <placeholder> values and is NOT meant to run.\n",
+    "# In V3 the sagemaker-core Session does not expose create_algorithm; use a boto3 SageMaker\n",
+    "# client (sess.boto_session.client(\"sagemaker\")) to call the CreateAlgorithm API directly.\n",
+    "#\n",
+    "# sagemaker_client = sess.boto_session.client(\"sagemaker\")\n",
+    "# response = sagemaker_client.create_algorithm(\n",
+    "#     AlgorithmName=\"<AlgorithmName>\",\n",
+    "#     AlgorithmDescription=\"<AlgorithmName>\",\n",
+    "#     TrainingSpecification={\n",
+    "#         \"TrainingImage\": \"<ImageURI>\",\n",
+    "#         # new field to pass inference base weights\n",
+    "#         \"AdditionalS3DataSource\": {\n",
+    "#             \"CompressionType\": \"Gzip\",\n",
+    "#             \"S3DataType\": \"S3Object\",\n",
+    "#             \"S3Uri\": \"<S3LocationOfBaseWeights>\",  # must end with .tar.gz suffix\n",
+    "#         },\n",
+    "#         \"SupportedTrainingInstanceTypes\": [\"<specify compatible instance type>\"],\n",
+    "#         \"SupportedHyperParameters\": [\n",
+    "#             {\n",
+    "#                 \"Name\": \"<Name>\",\n",
+    "#                 \"Description\": \"<Description>\",\n",
+    "#                 \"Type\": \"String\",  # Integer | Continuous | Categorical | FreeText\n",
+    "#                 \"IsTunable\": False,\n",
+    "#                 \"IsRequired\": False,\n",
+    "#             },\n",
+    "#         ],\n",
+    "#         \"SupportsDistributedTraining\": True,\n",
+    "#         \"TrainingChannels\": [\n",
+    "#             {\n",
+    "#                 \"Name\": \"<Name>\",\n",
+    "#                 \"Description\": \"<Description>\",\n",
+    "#                 \"IsRequired\": False,\n",
+    "#                 \"SupportedContentTypes\": [\"application/json\"],\n",
+    "#                 \"SupportedCompressionTypes\": [\"None\", \"Gzip\"],\n",
+    "#                 \"SupportedInputModes\": [\"Pipe\", \"File\"],\n",
+    "#             },\n",
+    "#         ],\n",
+    "#     },\n",
+    "#     InferenceSpecification={\n",
+    "#         \"Containers\": [  # Only Containers[0] can have AdditionalS3DataSource\n",
+    "#             {\n",
+    "#                 \"Image\": \"<ImageURI>\",\n",
+    "#                 \"AdditionalS3DataSource\": {\n",
+    "#                     \"CompressionType\": \"Gzip\",\n",
+    "#                     \"S3DataType\": \"S3Object\",\n",
+    "#                     \"S3Uri\": \"<S3LocationOfBaseWeights>\",  # must end with .tar.gz suffix\n",
+    "#                 },\n",
+    "#             }\n",
+    "#         ],\n",
+    "#         \"SupportedTransformInstanceTypes\": [\"ml.c5.xlarge\", \"<specify compatible instance type>\"],\n",
+    "#         \"SupportedRealtimeInferenceInstanceTypes\": [\"<specify compatible instance type>\"],\n",
+    "#         \"SupportedContentTypes\": [],\n",
+    "#         \"SupportedResponseMIMETypes\": [\"application/json\"],\n",
+    "#     },\n",
+    "#     ValidationSpecification={\n",
+    "#         \"ValidationRole\": \"<RoleARN>\",\n",
+    "#         \"ValidationProfiles\": [\n",
+    "#             {\n",
+    "#                 \"ProfileName\": \"<ProfileName>\",\n",
+    "#                 \"TrainingJobDefinition\": {\n",
+    "#                     \"TrainingInputMode\": \"File\",\n",
+    "#                     \"HyperParameters\": {\"num_epochs\": \"1\"},\n",
+    "#                     \"InputDataConfig\": [\n",
+    "#                         {\n",
+    "#                             \"ChannelName\": \"<ChannelName>\",\n",
+    "#                             \"DataSource\": {\n",
+    "#                                 \"S3DataSource\": {\n",
+    "#                                     \"S3DataType\": \"S3Prefix\",\n",
+    "#                                     \"S3Uri\": \"<S3DatasetLocation>\",\n",
+    "#                                     \"S3DataDistributionType\": \"FullyReplicated\",\n",
+    "#                                 }\n",
+    "#                             },\n",
+    "#                             \"CompressionType\": \"None\",\n",
+    "#                             \"RecordWrapperType\": \"None\",\n",
+    "#                         },\n",
+    "#                     ],\n",
+    "#                     \"OutputDataConfig\": {\"KmsKeyId\": \"\", \"S3OutputPath\": \"<S3OutputPath>\"},\n",
+    "#                     \"ResourceConfig\": {\n",
+    "#                         \"InstanceType\": \"ml.m5.xlarge\",\n",
+    "#                         \"InstanceCount\": 1,\n",
+    "#                         \"VolumeSizeInGB\": 10,\n",
+    "#                     },\n",
+    "#                     \"StoppingCondition\": {\"MaxRuntimeInSeconds\": 1800},\n",
+    "#                 },\n",
+    "#             }\n",
+    "#         ],\n",
+    "#     },\n",
+    "#     CertifyForMarketplace=True,\n",
+    "# )\n",
+    "print(\"Reference-only template cell; not executed.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Testing the Fine-tuning Algorithm \n",
+    "\n",
+    "Once the Algorithm is created, you can follow the steps below to test the algorithm. \n",
+    "> Note: that you can test it in the AWS account where the algorithm is created before listing it in the AWS Marketplace. \n",
+    "Also, after you create a preview listing in the AWS Marketplace, you can verify it again from test accounts you specify in the listing, by subscribing to the listing and then follow the same steps.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Create Fine-Tuning training Job\n",
+    "\n",
+    "Now you can use the Algorithm created for fine-tuning.\n",
+    "Specify the `AlgorithmName` under `AlgorithmSpecification` . Before training container starts, base weights file will be downloaded to training instances and extracted under the path indicated by environmental variable `SAGEMAKER_ADDITIONAL_S3_DATA_PATH`.\n",
+    "\n",
+    "For example, base weights are specified at `s3://fine-tuning-models/model.tar.gz and model.tar.gz` which contains files `data1` and `data2` in the `model.tar.gz`. These files will be available under `$SAGEMAKER_ADDITIONAL_S3_DATA_PATH/data1` and `$SAGEMAKER_ADDITIONAL_S3_DATA_PATH/data2` in the container.\n",
+    "\n",
+    "> Note: The `S3OutputPath` path will contain the fine-tuned weights in the end-user/customer's account. Make sure your Algorithm Training container does not output anything sensitive to both CloudWatch Logs (std_err/std_out in the container) or the fine-tuned model weights in S3 (artifacts saved in the container to `/opt/ml/model` during Training)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NOTE (reference-only, not executed): fine-tuning training job template.\n",
+    "# In V3, either call the boto3 SageMaker CreateTrainingJob API through\n",
+    "# sess.boto_session.client(\"sagemaker\").create_training_job(...), or use sagemaker-core\n",
+    "# TrainingJob.create(...) with an AlgorithmSpecification that references the algorithm name.\n",
+    "#\n",
+    "# sagemaker_client = sess.boto_session.client(\"sagemaker\")\n",
+    "# response = sagemaker_client.create_training_job(\n",
+    "#     TrainingJobName=\"<TrainingJobName>\",\n",
+    "#     RoleArn=\"<RoleArn>\",\n",
+    "#     AlgorithmSpecification={\n",
+    "#         \"AlgorithmName\": \"<AlgorithmName>\",  # fine-tuning algorithm name\n",
+    "#         \"TrainingInputMode\": \"File\",\n",
+    "#     },\n",
+    "#     InputDataConfig=[\n",
+    "#         {\n",
+    "#             \"ChannelName\": \"<ChannelName>\",\n",
+    "#             \"DataSource\": {\n",
+    "#                 \"S3DataSource\": {\n",
+    "#                     \"S3DataType\": \"S3Prefix\",\n",
+    "#                     \"S3Uri\": \"<S3DatasetLocation>\",\n",
+    "#                     \"S3DataDistributionType\": \"FullyReplicated\",\n",
+    "#                 }\n",
+    "#             },\n",
+    "#             \"CompressionType\": \"None\",\n",
+    "#             \"RecordWrapperType\": \"None\",\n",
+    "#         },\n",
+    "#     ],\n",
+    "#     OutputDataConfig={\n",
+    "#         \"S3OutputPath\": \"<S3OutputPath>\",\n",
+    "#         # CompressionType Gzip so the output weights can be used for creating a model package\n",
+    "#         \"CompressionType\": \"GZIP\",\n",
+    "#     },\n",
+    "#     ResourceConfig={\n",
+    "#         \"InstanceCount\": 1,\n",
+    "#         \"InstanceType\": \"ml.c4.xlarge\",\n",
+    "#         \"VolumeSizeInGB\": 40,\n",
+    "#     },\n",
+    "#     StoppingCondition={\"MaxRuntimeInSeconds\": 3600},\n",
+    "# )\n",
+    "print(\"Reference-only template cell; not executed.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once training is completed, the fine-tuned weights will be uploaded to `OutputDataConfig:S3OutputPath`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Create a Model Package\n",
+    "\n",
+    "To create a model package resource that you can use to create deployable models in Amazon SageMaker.\n",
+    "You can do the following:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NOTE (reference-only, not executed): create a ModelPackage from a fine-tuned algorithm.\n",
+    "# In V3, call the boto3 SageMaker CreateModelPackage API via\n",
+    "# sess.boto_session.client(\"sagemaker\").create_model_package(...).\n",
+    "#\n",
+    "# sagemaker_client = sess.boto_session.client(\"sagemaker\")\n",
+    "# model_package_name = \"string\"  # <= 63 characters\n",
+    "# create_model_pkg_rsp = sagemaker_client.create_model_package(\n",
+    "#     ModelPackageName=model_package_name,\n",
+    "#     SourceAlgorithmSpecification={\n",
+    "#         \"SourceAlgorithms\": [\n",
+    "#             {\n",
+    "#                 \"AlgorithmName\": \"<AlgorithmName>\",\n",
+    "#                 \"ModelDataUrl\": \"<S3LocationOfFineTunedModelWeightsFromTrainingJob>\",\n",
+    "#             }\n",
+    "#         ]\n",
+    "#     },\n",
+    "# )\n",
+    "# print(create_model_pkg_rsp)\n",
+    "# sagemaker_client.describe_model_package(ModelPackageName=model_package_name)\n",
+    "print(\"Reference-only template cell; not executed.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Create SageMaker Model entity and Deploy to SageMaker Hosting\n",
+    "\n",
+    "After the model package reaches a Completed status, you can use a model package to create a deployable model (SageMaker Model). You can then deploy this Model to am endpoint to get real-time inferences by creating a hosted endpoint (SageMaker Endpoint)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NOTE (reference-only, not executed): create a SageMaker Model / EndpointConfig / Endpoint\n",
+    "# from the model package. In V3 use the boto3 SageMaker client, or the sagemaker-core\n",
+    "# Model / EndpointConfig / Endpoint resources shown in Part 2.\n",
+    "#\n",
+    "# sagemaker_client = sess.boto_session.client(\"sagemaker\")\n",
+    "# create_model_rsp = sagemaker_client.create_model(\n",
+    "#     ModelName=model_package_name,\n",
+    "#     ExecutionRoleArn=\"<ExecutionRoleArn>\",\n",
+    "#     PrimaryContainer={\"ModelPackageName\": model_package_name},\n",
+    "#     EnableNetworkIsolation=True,\n",
+    "# )\n",
+    "# create_endpoint_config_rsp = sagemaker_client.create_endpoint_config(\n",
+    "#     EndpointConfigName=model_package_name,\n",
+    "#     ProductionVariants=[\n",
+    "#         {\n",
+    "#             \"VariantName\": \"<VariantName>\",\n",
+    "#             \"ModelName\": model_package_name,\n",
+    "#             \"InitialInstanceCount\": 1,\n",
+    "#             \"InstanceType\": \"ml.c5.xlarge\",\n",
+    "#             \"ContainerStartupHealthCheckTimeoutInSeconds\": 3600,\n",
+    "#             \"ModelDataDownloadTimeoutInSeconds\": 3600,\n",
+    "#         }\n",
+    "#     ],\n",
+    "# )\n",
+    "# create_endpoint_rsp = sagemaker_client.create_endpoint(\n",
+    "#     EndpointName=model_package_name, EndpointConfigName=model_package_name\n",
+    "# )\n",
+    "# sagemaker_client.describe_endpoint(EndpointName=model_package_name)\n",
+    "print(\"Reference-only template cell; not executed.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Invoke Endpoint for Inference\n",
+    "\n",
+    "After the endpoint reaches InService status, you can invoke the endpoint for inference:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NOTE (reference-only, not executed): invoke the fine-tuned endpoint for inference.\n",
+    "# In V3 use the boto3 sagemaker-runtime client, or the core Endpoint.invoke() shown in Part 2.\n",
+    "#\n",
+    "# sagemaker_runtime = sess.boto_session.client(\"sagemaker-runtime\")\n",
+    "# rsp = sagemaker_runtime.invoke_endpoint(\n",
+    "#     EndpointName=model_package_name,\n",
+    "#     Body=b\"<InferencePayload>\",\n",
+    "#     ContentType=\"text/csv\",  # any format your container supports\n",
+    "# )\n",
+    "# rsp[\"Body\"].read()\n",
+    "print(\"Reference-only template cell; not executed.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Debugging Creation Issues\n",
+    "\n",
+    "Entity creation typically never fails in the synchronous path. However, the validation process can fail for many reasons. If the above Algorithm creation fails, you can investigate the cause for the failure by looking at the \"AlgorithmStatusDetails\" field in the Algorithm object or \"ModelPackageStatusDetails\" field in the ModelPackage object. You can also look for the Training Jobs / Transform Jobs created in your account as part of our validation and inspect their logs for more hints on what went wrong. \n",
+    "\n",
+    "If all else fails, please contact AWS Customer Support for assistance!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "### List on AWS Marketplace\n",
+    "\n",
+    "Next, please go back to the Amazon SageMaker console, click on \"Algorithms\" (or \"Model Packages\") and you'll find the entity you created above. If it was successfully created and validated, you should be able to select the entity and \"Publish new ML Marketplace listing\" from SageMaker console.\n",
+    "\n",
+    "<img src=\"images/publish-to-marketplace-action.png\"/>\n",
+    "\n",
+    "\n",
+    "After creating and validating your fine-tuning Algorithms in Amazon SageMaker, you can list your products on AWS Marketplace. The listing process makes your products available for model consumers in the AWS Marketplace and the SageMaker console.\n",
+    "\n",
+    "Detailed steps can be found here: https://docs.aws.amazon.com/marketplace/latest/userguide/ml-publishing-your-product-in-aws-marketplace.html\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Notebook CI Test Results\n",
+    "\n",
+    "This notebook was tested in multiple regions. The test results are as follows, except for us-west-2 which is shown at the top of the notebook.\n",
+    "\n",
+    "![This us-east-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-east-1/build_and_train_models|sm-marketplace_building_your_own_container_as_package|sm-marketplace_building_your_own_container_as_package.ipynb)\n",
+    "\n",
+    "![This us-east-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-east-2/build_and_train_models|sm-marketplace_building_your_own_container_as_package|sm-marketplace_building_your_own_container_as_package.ipynb)\n",
+    "\n",
+    "![This us-west-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-west-1/build_and_train_models|sm-marketplace_building_your_own_container_as_package|sm-marketplace_building_your_own_container_as_package.ipynb)\n",
+    "\n",
+    "![This ca-central-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ca-central-1/build_and_train_models|sm-marketplace_building_your_own_container_as_package|sm-marketplace_building_your_own_container_as_package.ipynb)\n",
+    "\n",
+    "![This sa-east-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/sa-east-1/build_and_train_models|sm-marketplace_building_your_own_container_as_package|sm-marketplace_building_your_own_container_as_package.ipynb)\n",
+    "\n",
+    "![This eu-west-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-1/build_and_train_models|sm-marketplace_building_your_own_container_as_package|sm-marketplace_building_your_own_container_as_package.ipynb)\n",
+    "\n",
+    "![This eu-west-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-2/build_and_train_models|sm-marketplace_building_your_own_container_as_package|sm-marketplace_building_your_own_container_as_package.ipynb)\n",
+    "\n",
+    "![This eu-west-3 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-3/build_and_train_models|sm-marketplace_building_your_own_container_as_package|sm-marketplace_building_your_own_container_as_package.ipynb)\n",
+    "\n",
+    "![This eu-central-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-central-1/build_and_train_models|sm-marketplace_building_your_own_container_as_package|sm-marketplace_building_your_own_container_as_package.ipynb)\n",
+    "\n",
+    "![This eu-north-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-north-1/build_and_train_models|sm-marketplace_building_your_own_container_as_package|sm-marketplace_building_your_own_container_as_package.ipynb)\n",
+    "\n",
+    "![This ap-southeast-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-southeast-1/build_and_train_models|sm-marketplace_building_your_own_container_as_package|sm-marketplace_building_your_own_container_as_package.ipynb)\n",
+    "\n",
+    "![This ap-southeast-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-southeast-2/build_and_train_models|sm-marketplace_building_your_own_container_as_package|sm-marketplace_building_your_own_container_as_package.ipynb)\n",
+    "\n",
+    "![This ap-northeast-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-northeast-1/build_and_train_models|sm-marketplace_building_your_own_container_as_package|sm-marketplace_building_your_own_container_as_package.ipynb)\n",
+    "\n",
+    "![This ap-northeast-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-northeast-2/build_and_train_models|sm-marketplace_building_your_own_container_as_package|sm-marketplace_building_your_own_container_as_package.ipynb)\n",
+    "\n",
+    "![This ap-south-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-south-1/build_and_train_models|sm-marketplace_building_your_own_container_as_package|sm-marketplace_building_your_own_container_as_package.ipynb)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "conda_python3",
+   "language": "python",
+   "name": "conda_python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Migrate 9 example notebooks from SageMaker Python SDK V2 to V3

This PR adds V3 versions of 9 notebooks under `build_and_train_models/`. Each V3 notebook is added as a `-v3.ipynb` sibling next to the original V2 notebook (V2 files are left untouched for reference). The migrations replace the V2 `Estimator`/framework-estimator + `Predictor` workflow with the V3 `sagemaker-core` resource classes and, where a real training entry point is involved, `sagemaker.train.ModelTrainer`.

### What changed per notebook

| Notebook | What it demonstrates | Key V2 → V3 changes |
| --- | --- | --- |
| `sm-introduction_to_object2vec_sentence_similarity-v3.ipynb` | Object2Vec built-in algorithm (sentence-pair embeddings on SNLI + transfer-learning eval) | `Estimator` + `set_hyperparameters` + `.fit()`/`.deploy()` → `sagemaker.core.resources.TrainingJob` + `Model`/`EndpointConfig`/`Endpoint`; `estimator.attach` → second `TrainingJob.create`; raw boto3 HPO → `HyperParameterTuningJob.create` with V3 shapes; `sagemaker.analytics` → boto3 CloudWatch; session/role → `sagemaker.core.helper.session_helper` |
| `sm-jax_bring_your_own-v3.ipynb` | Bring-your-own-script JAX-on-TF training of 3 fashion-MNIST models, served on managed TF Serving | 3× `TensorFlow` estimator + `.fit()` → `ModelTrainer` + `SourceCode`/`Compute` + `image_uris.retrieve`; `.deploy()` → sagemaker-core `Model`/`EndpointConfig`/`Endpoint`; `predictor.predict` → `Endpoint.invoke` |
| `sm-jumpstart_private_model_hub_import-v3.ipynb` | Import a model into a private JumpStart hub and deploy it | `PyTorchModel.deploy()` → `image_uris.retrieve` + core `Model`/`EndpointConfig`/`Endpoint`; boto3 `invoke_endpoint` → `Endpoint.invoke`; Hub create/describe kept on boto3 (not on core Session) |
| `sm-jumpstart_private_model_hub_import_llama3-8B-v3.ipynb` | Gated JumpStart (Llama-3-8B) fine-tuning + private-hub import | Migrated to `ModelTrainer.from_jumpstart_config` / core resources. **Blocked from full e2e by a V3 SDK gap** (`ModelTrainer.from_jumpstart_config` drops `AcceptEula` on the auto-generated code channel for gated JumpStart models) |
| `sm-lightgbm_catboost_tabular_classification-v3.ipynb` | JumpStart LightGBM/CatBoost tabular classification with Automatic Model Tuning (HPO) | Generic `Estimator` → `ModelTrainer.from_jumpstart_config(JumpStartConfig)`; `sagemaker.tuner.HyperparameterTuner` → `sagemaker.train.tuner.HyperparameterTuner` + `tuner.tune`; parameter ranges → `sagemaker.core.parameter`; best-job deploy via core `Model`/`EndpointConfig`/`Endpoint` |
| `sm-linear_learner_mnist-v3.ipynb` | Linear Learner built-in algorithm (MNIST binary classifier) + HPO + hosting | `Estimator` + `.fit()` → core `TrainingJob.create`; `HyperparameterTuner` → `HyperParameterTuningJob.create` with V3 shapes; data path migrated recordIO-protobuf → CSV (V3 has no recordIO serializer); `predictor.predict` → `Endpoint.invoke` |
| `sm-managed_spot_training_xgboost-v3.ipynb` | Managed Spot Training for XGBoost (spot + checkpointing + HPO) | `Estimator(use_spot_instances/checkpoint_s3_uri)` + `.fit()` → `ModelTrainer` + `Compute(enable_managed_spot_training=True)` + `StoppingCondition` + `CheckpointConfig`; `sagemaker.xgboost.XGBoost` → `ModelTrainer(training_image, SourceCode)`; adds a real `abalone.py` entry script |
| `sm-marketplace_build_model_package_for_listing-v3.ipynb` | Package a BYO inference container as a Marketplace ModelPackage; validate via endpoint + batch transform | `ModelPackage(...).deploy()`/`.transformer()`/`.delete_model()` → core `Model`/`EndpointConfig`/`Endpoint`/`TransformJob`; `session.delete_endpoint` → core resource `delete()`. `create_model_package` kept on boto3 due to a V3 SDK gap (see below) |
| `sm-marketplace_building_your_own_container_as_package-v3.ipynb` | BYOC scikit decision-tree packaged as a Marketplace Algorithm + ModelPackage | `Estimator.fit` → `ModelTrainer(training_image=...)`; `tree.transformer().transform()` → core `Model`/`TransformJob`; `tree.deploy()` → core `Model`/`EndpointConfig`/`Endpoint`; container modernized Python 2 → Python 3 so it builds/serves |

### Common migration themes

- **Session/role:** `import sagemaker` + `sagemaker.Session()` / `sagemaker.get_execution_role()` → `from sagemaker.core.helper.session_helper import Session, get_execution_role`.
- **Image lookup:** `sagemaker.image_uris` → `sagemaker.core.image_uris`.
- **Training/deploy:** the V2 `Estimator`/framework-estimator `.fit()`/`.deploy()` flow is replaced either by `sagemaker-core` resource objects (`TrainingJob`, `Model`, `EndpointConfig`, `Endpoint`, `HyperParameterTuningJob`, `TransformJob`) for built-in algorithms, or by `sagemaker.train.ModelTrainer` (+ `SourceCode`/`Compute`/`InputData` configs) where a custom/framework training entry point is used.

### Known V3 SDK gaps surfaced by this PR

- **Gated JumpStart fine-tuning** (`sm-jumpstart_private_model_hub_import_llama3-8B-v3.ipynb`): `ModelTrainer.from_jumpstart_config` drops `AcceptEula` on the auto-generated code channel, so gated model fine-tuning cannot complete e2e.
- **Marketplace ModelPackage registration** (`sm-marketplace_build_model_package_for_listing-v3.ipynb`): `ModelPackage.create` is currently unusable for Marketplace registration because `sagemaker.core.shapes` re-exports `model_card_shapes` after `shapes`, so `InferenceSpecification` resolves to the model-card variant that lacks `SupportedContentTypes` / `Supported*InstanceTypes` / `SupportedResponseMIMETypes`. Worked around by calling `create_model_package` via boto3.

## Merge Checklist

_Put an `x` in the boxes that apply._

- [x] I have verified that my PR does not contain any new notebook/s which demonstrate a SageMaker functionality already showcased by another existing notebook in the repository
- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/default/CONTRIBUTING.md) doc and adhered to the guidelines regarding folder placement, notebook naming convention and example notebook best practices
- [x] I have updated the necessary documentation, including the README of the appropriate folder as well as the index.rst file
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [ ] I have linted my notebook(s) and code using `python3 -m black -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
