### PR TITLE
Add Notebook Test Engine GitHub Actions workflows (PR check + scheduled scan)

### DIFF
--- a/.github/workflows/notebook-scan.yml
+++ b/.github/workflows/notebook-scan.yml
@@ -19,7 +19,7 @@ name: Notebook Scan (scheduled)
 
 on:
   schedule:
-    - cron: '0 7 * * 1-5'   # 07:00 UTC Mon-Fri (matches the retired EventBridge rule)
+    - cron: '10 7 * * 1-5'   # 07:10 UTC Mon-Fri (off-the-hour to reduce GitHub schedule drop/delay risk)
   workflow_dispatch:         # manual / on-demand scan (also used for testing)
 
 permissions:

--- a/.github/workflows/notebook-scan.yml
+++ b/.github/workflows/notebook-scan.yml
@@ -1,0 +1,61 @@
+name: Notebook Scan (scheduled)
+
+# ---------------------------------------------------------------------------
+# Weekday scheduled full scan of the NotebookTestEngine example notebooks on real
+# SageMaker infrastructure. Replaces the old EventBridge weekday cron.
+#
+# Notes:
+#   - GitHub `schedule:` runs ONLY from the repository default branch, so this
+#     workflow lives on `default`. It scans the notebooks on the NotebookTestEngine
+#     branch via a secondary-source version override (that is where the engine's
+#     example set lives).
+#   - `schedule:` is best-effort (runs can be delayed or dropped). The engine's
+#     liveness alarm (MissedScheduledRun) remains the authoritative guard that a
+#     scan actually ran -- it reads the RunCompleted heartbeat this run emits.
+#   - full_scan lets the engine pick the day's rotation category; it exits 0 even
+#     on notebook failures (the Notebook CloudWatch alarm owns that signal), so no
+#     PR-style red check here.
+# ---------------------------------------------------------------------------
+
+on:
+  schedule:
+    - cron: '0 7 * * 1-5'   # 07:00 UTC Mon-Fri (matches the retired EventBridge rule)
+  workflow_dispatch:         # manual / on-demand scan (also used for testing)
+
+permissions:
+  id-token: write   # mint the GitHub OIDC token for AWS
+  contents: read
+
+jobs:
+  notebook-scan:
+    runs-on: ubuntu-latest
+    # A category scan can run long; 360 min is GitHub's hosted-job maximum.
+    timeout-minutes: 360
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.NOTEBOOK_TEST_ENGINE_ROLE_ARN }}
+          aws-region: us-west-2
+          role-duration-seconds: 28800
+
+      - name: Start CodeBuild full scan (NotebookTestEngine)
+        run: |
+          set -euo pipefail
+          PROJECT=notebook-test-engine
+
+          # Scan the NotebookTestEngine branch's notebooks (that is where the NTE
+          # example set lives). The old EventBridge rule scanned the source default
+          # branch with no override; the engine's notebooks now live on this branch,
+          # so pin the 'sdk' secondary source to it. TEST_MODE=full_scan -> the
+          # engine rotates through categories by weekday and owns its own alarm
+          # signal (no PR-style red check), so this job is fire-and-forget.
+          BUILD_ID=$(aws codebuild start-build \
+            --project-name "$PROJECT" \
+            --secondary-sources-version-override "[{\"sourceIdentifier\":\"sdk\",\"sourceVersion\":\"NotebookTestEngine\"}]" \
+            --environment-variables-override \
+              "name=TEST_MODE,value=full_scan,type=PLAINTEXT" \
+            --query 'build.id' --output text)
+
+          echo "Started scan build: $BUILD_ID"
+          echo "Console: https://us-west-2.console.aws.amazon.com/codesuite/codebuild/projects/${PROJECT}/build/${BUILD_ID//:/%3A}/log"

--- a/.github/workflows/notebook-scan.yml
+++ b/.github/workflows/notebook-scan.yml
@@ -2,19 +2,14 @@ name: Notebook Scan (scheduled)
 
 # ---------------------------------------------------------------------------
 # Weekday scheduled full scan of the NotebookTestEngine example notebooks on real
-# SageMaker infrastructure. Replaces the old EventBridge weekday cron.
+# SageMaker infrastructure.
 #
-# Notes:
-#   - GitHub `schedule:` runs ONLY from the repository default branch, so this
-#     workflow lives on `default`. It scans the notebooks on the NotebookTestEngine
-#     branch via a secondary-source version override (that is where the engine's
-#     example set lives).
-#   - `schedule:` is best-effort (runs can be delayed or dropped). The engine's
-#     liveness alarm (MissedScheduledRun) remains the authoritative guard that a
-#     scan actually ran -- it reads the RunCompleted heartbeat this run emits.
-#   - full_scan lets the engine pick the day's rotation category; it exits 0 even
-#     on notebook failures (the Notebook CloudWatch alarm owns that signal), so no
-#     PR-style red check here.
+#   - GitHub `schedule:` only runs from the repository default branch, so this
+#     workflow lives on `default` and scans the NotebookTestEngine branch's
+#     notebooks via the secondary-source version override below.
+#   - TEST_MODE=full_scan: the engine picks the day's rotation category and exits 0
+#     even on notebook failures (the Notebook CloudWatch alarm owns that signal),
+#     so this job is fire-and-forget -- no PR-style pass/fail reflection.
 # ---------------------------------------------------------------------------
 
 on:

--- a/.github/workflows/notebook-tests.yml
+++ b/.github/workflows/notebook-tests.yml
@@ -95,8 +95,13 @@ jobs:
           PROJECT=notebook-test-engine
 
           # Check out the PR head of the 'sdk' secondary source. refs/pull/<N>/head
-          # resolves in the BASE repo even for fork PRs; ^{<sha>} pins the exact commit.
-          SDK_VERSION="refs/pull/${PR_NUMBER}/head^{${PR_SHA}}"
+          # resolves in the BASE repo even for fork PRs. We deliberately do NOT pin
+          # with ^{<sha>}: CodeBuild's shallow fetch + a peeled SHA fails with
+          # "unable to read tree" for a re-pushed (synchronize) PR head. The plain
+          # ref checks out the ref tip reliably, and concurrency:cancel-in-progress
+          # (above) already guarantees only the newest commit's run survives, so the
+          # tip IS the commit under test.
+          SDK_VERSION="refs/pull/${PR_NUMBER}/head"
 
           BUILD_ID=$(aws codebuild start-build \
             --project-name "$PROJECT" \

--- a/.github/workflows/notebook-tests.yml
+++ b/.github/workflows/notebook-tests.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/github-script@v7
         id: collab-check
         with:
-          github-token: ${{ secrets.COLLAB_CHECK_TOKEN }}
+          github-token: ${{ secrets.COLLAB_CHECK_TOKEN || github.token }}
           result-encoding: string
           script: |
             try {

--- a/.github/workflows/notebook-tests.yml
+++ b/.github/workflows/notebook-tests.yml
@@ -1,0 +1,155 @@
+name: Notebook Tests
+
+# ---------------------------------------------------------------------------
+# Runs the changed SageMaker example notebooks on real SageMaker infrastructure
+# when a PR touches any notebook (**/*.ipynb) targeting the NotebookTestEngine
+# integration branch of aws/amazon-sagemaker-examples. Flow:
+#   1. Collaborator check -> collaborators auto-approve; fork / non-collaborator
+#      PRs are gated behind the manual-approval environment.
+#   2. Assume an AWS role via GitHub OIDC (no stored AWS keys) and start the
+#      `notebook-test-engine` CodeBuild project against this PR's notebooks.
+#   3. Poll the build to completion; this job's pass/fail IS the PR check, and a
+#      failing notebook is attached as a downloadable `failing-notebooks` artifact.
+# ---------------------------------------------------------------------------
+
+on:
+  pull_request_target:
+    branches:
+      - NotebookTestEngine
+    paths:
+      - '**/*.ipynb'
+
+# Only the newest commit of a PR runs; a new push cancels the older run.
+concurrency:
+  group: notebook-tests-${{ github.event.pull_request.number || github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write   # required to mint the GitHub OIDC token for AWS
+  contents: read
+
+jobs:
+  # 1) Collaborator? -> auto-approve. Otherwise -> manual-approval (gated below).
+  collab-check:
+    runs-on: ubuntu-latest
+    outputs:
+      approval-env: ${{ steps.collab-check.outputs.result }}
+    steps:
+      - name: Collaborator check
+        uses: actions/github-script@v7
+        id: collab-check
+        with:
+          github-token: ${{ secrets.COLLAB_CHECK_TOKEN }}
+          result-encoding: string
+          script: |
+            try {
+              const res = await github.rest.repos.checkCollaborator({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: "${{ github.event.pull_request.user.login }}",
+              });
+              return res.status == 204 ? "auto-approve" : "manual-approval";
+            } catch (error) {
+              return "manual-approval";
+            }
+
+  # 2) Non-collaborators block on the "manual-approval" environment's required
+  #    reviewers. Collaborators pass straight through the "auto-approve" env.
+  wait-for-approval:
+    runs-on: ubuntu-latest
+    needs: [collab-check]
+    environment: ${{ needs.collab-check.outputs.approval-env }}
+    steps:
+      - run: echo "Approved — starting notebook tests."
+
+  # 3) Assume the engine role via OIDC, start the build against the PR's notebooks,
+  #    and poll to completion. This job's result is the PR check.
+  notebook-tests:
+    runs-on: ubuntu-latest
+    needs: [wait-for-approval]
+    # GitHub hard-caps hosted jobs at 360 min (6h). The CodeBuild project can run up
+    # to 7h, but a pr_check build tests only the PR's changed notebooks and finishes
+    # well within this; 360 is the maximum GitHub allows for a hosted job.
+    timeout-minutes: 360
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.NOTEBOOK_TEST_ENGINE_ROLE_ARN }}
+          aws-region: us-west-2
+          # 8h session (matches the role's maxSessionDuration in the CDK stack) so the
+          # poll never expires mid-build. The GitHub job itself is capped at 360 min below.
+          role-duration-seconds: 28800
+
+      - name: Start CodeBuild and wait
+        id: build
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_REPO_FULL: ${{ github.event.pull_request.base.repo.full_name }}
+          PR_ARTIFACTS_BUCKET: notebook-test-engine-pr-674622101542-us-west-2
+        run: |
+          set -euo pipefail
+          PROJECT=notebook-test-engine
+
+          # Check out the PR head of the 'sdk' secondary source. refs/pull/<N>/head
+          # resolves in the BASE repo even for fork PRs; ^{<sha>} pins the exact commit.
+          SDK_VERSION="refs/pull/${PR_NUMBER}/head^{${PR_SHA}}"
+
+          BUILD_ID=$(aws codebuild start-build \
+            --project-name "$PROJECT" \
+            --secondary-sources-version-override "[{\"sourceIdentifier\":\"sdk\",\"sourceVersion\":\"${SDK_VERSION}\"}]" \
+            --environment-variables-override \
+              "name=TEST_MODE,value=pr_check,type=PLAINTEXT" \
+              "name=MAX_CONCURRENT,value=18,type=PLAINTEXT" \
+              "name=PR_NUMBER,value=${PR_NUMBER},type=PLAINTEXT" \
+              "name=PR_BRANCH,value=${PR_BRANCH},type=PLAINTEXT" \
+              "name=PR_REPO,value=${PR_REPO},type=PLAINTEXT" \
+              "name=PR_SHA,value=${PR_SHA},type=PLAINTEXT" \
+              "name=PR_REPO_FULL,value=${PR_REPO_FULL},type=PLAINTEXT" \
+            --query 'build.id' --output text)
+
+          echo "Started build: $BUILD_ID"
+          echo "Console: https://us-west-2.console.aws.amazon.com/codesuite/codebuild/projects/${PROJECT}/build/${BUILD_ID//:/%3A}/log"
+
+          # Poll until the build leaves IN_PROGRESS.
+          STATUS=IN_PROGRESS
+          while [ "$STATUS" = "IN_PROGRESS" ]; do
+            sleep 300
+            STATUS=$(aws codebuild batch-get-builds --ids "$BUILD_ID" \
+              --query 'builds[0].buildStatus' --output text 2>/dev/null || echo IN_PROGRESS)
+            echo "Build status: $STATUS"
+          done
+
+          echo "Final build status: $STATUS"
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+
+          # On any non-success, pull the engine-rendered failing-notebook HTML/ipynb
+          # (written under pr/<PR#>/<run_ts>/) so the next step can attach it to this run.
+          if [ "$STATUS" != "SUCCEEDED" ]; then
+            echo "Build did not succeed; fetching this run's failing-notebook artifacts..."
+            # Only the NEWEST run-timestamp folder -- not every historical render for
+            # this PR -- so the artifact holds just this run's notebook(s).
+            LATEST=$(aws s3 ls "s3://${PR_ARTIFACTS_BUCKET}/pr/${PR_NUMBER}/" 2>/dev/null | awk '{print $NF}' | grep '/$' | sort | tail -1 || true)
+            if [ -n "$LATEST" ]; then
+              aws s3 cp --recursive "s3://${PR_ARTIFACTS_BUCKET}/pr/${PR_NUMBER}/${LATEST}" pr-artifacts/ || true
+            fi
+          fi
+
+      - name: Upload failing notebook(s)
+        if: steps.build.outputs.status != 'SUCCEEDED'
+        uses: actions/upload-artifact@v4
+        with:
+          name: failing-notebooks
+          path: pr-artifacts/
+          if-no-files-found: ignore
+
+      - name: Reflect build result as the check
+        if: always()
+        run: |
+          echo "CodeBuild final status: ${{ steps.build.outputs.status }}"
+          # Anything other than SUCCEEDED (FAILED / FAULT / TIMED_OUT / STOPPED)
+          # fails this job -> red PR check.
+          [ "${{ steps.build.outputs.status }}" = "SUCCEEDED" ]

--- a/.github/workflows/notebook-tests.yml
+++ b/.github/workflows/notebook-tests.yml
@@ -95,12 +95,10 @@ jobs:
           PROJECT=notebook-test-engine
 
           # Check out the PR head of the 'sdk' secondary source. refs/pull/<N>/head
-          # resolves in the BASE repo even for fork PRs. We deliberately do NOT pin
-          # with ^{<sha>}: CodeBuild's shallow fetch + a peeled SHA fails with
-          # "unable to read tree" for a re-pushed (synchronize) PR head. The plain
-          # ref checks out the ref tip reliably, and concurrency:cancel-in-progress
-          # (above) already guarantees only the newest commit's run survives, so the
-          # tip IS the commit under test.
+          # resolves in the BASE repo even for fork PRs. Use the plain ref (not a
+          # ^{sha}-pinned commit) so CodeBuild checks out the ref tip;
+          # concurrency:cancel-in-progress (above) keeps only the newest commit's run,
+          # so the tip is the commit under test.
           SDK_VERSION="refs/pull/${PR_NUMBER}/head"
 
           BUILD_ID=$(aws codebuild start-build \


### PR DESCRIPTION
Adds the two GitHub Actions workflows that drive the Notebook Test Engine. They live on `default` because GitHub only evaluates `pull_request_target` and `schedule:` from the repository's default branch; both are **scoped to the `NotebookTestEngine` branch**, so they do not affect `default` or other branches.

- **`.github/workflows/notebook-tests.yml`** — PR check. On a PR into `NotebookTestEngine` touching `**/*.ipynb`: collaborator gate → assume an AWS role via GitHub OIDC → start the `notebook-test-engine` CodeBuild project in `pr_check` mode → poll; the job's pass/fail is the PR check, and a failing notebook is uploaded as a `failing-notebooks` artifact.
- **`.github/workflows/notebook-scan.yml`** — scheduled full scan. Weekday cron (07:10 UTC) + `workflow_dispatch` → OIDC → CodeBuild `full_scan` against the `NotebookTestEngine` branch. Fire-and-forget; CloudWatch alarms own the health signal.

No stored AWS keys — both use GitHub OIDC.

Prerequisites for these to run (repo settings): the `NOTEBOOK_TEST_ENGINE_ROLE_ARN` secret, and the `auto-approve` / `manual-approval` environments (required reviewers on `manual-approval`).
