### PR TITLE
docs: Scope the RTD site to V3 and opt the V2 docs out of AI crawls

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -1,0 +1,18 @@
+{# Theme layout override for the V3 example notebooks build (the `default` branch). #}
+{# Overriding the "document" block places the scope note at the top of the main #}
+{# content area of EVERY page -- including theme-generated pages with no source #}
+{# file (genindex, search) that rst_prolog and nbsphinx_prolog cannot reach. The #}
+{# markup mirrors a Sphinx ".. note::" admonition so it picks up the theme's own #}
+{# admonition styling. #}
+{% extends "!layout.html" %}
+
+{% block document %}
+  <div class="admonition note">
+    <p class="admonition-title">Note</p>
+    <p>This site contains only the example notebooks built on SageMaker Python SDK v3,
+    which is what <code class="docutils literal notranslate"><span class="pre">pip install sagemaker</span></code> installs.
+    Notebooks built on the deprecated SDK 2.x are archived in the
+    <a class="reference external" href="https://sagemaker-examples.readthedocs.io/en/v2/">v2 example notebooks documentation</a>.</p>
+  </div>
+  {{ super() }}
+{% endblock %}

--- a/conf.py
+++ b/conf.py
@@ -39,7 +39,16 @@ nbsphinx_execute = "never"
 
 
 # Add any paths that contain templates here, relative to this directory.
+# The _templates/layout.html override injects a note at the top of every page
+# stating that this site holds only the SDK v3 example notebooks, and pointing at
+# the v2 build for the archived SDK 2.x notebooks.
 templates_path = ["_templates"]
+
+# Serve robots.txt at the docs site root. ReadTheDocs serves robots.txt only from
+# the default version, so it must live on this V3/default build (not the v2-archive
+# build). It opts the deprecated V2 notebooks (/en/v2/) out of AI-training crawls.
+# Sphinx copies files listed here verbatim into the build root.
+html_extra_path = ["robots.txt"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,105 @@
+# robots.txt -- served at the docs site root
+# (https://sagemaker-examples.readthedocs.io/robots.txt).
+#
+# This file MUST live on the DEFAULT ReadTheDocs version (the V3 / `default` build):
+# ReadTheDocs only serves robots.txt from the default version at the domain root.
+# A robots.txt shipped inside the non-default V2 build would land at
+# /en/v2/robots.txt, which crawlers never read, so it would have no effect.
+#
+# Purpose: opt the deprecated SDK 2.x example notebooks (/en/v2/) OUT of AI
+# training / data-collection crawls, so future model training sees the V3 examples
+# rather than the archived V2 ones. This is an ADVISORY signal: only compliant
+# crawlers honor it (well-behaved bots from major AI vendors do; abusive crawlers
+# ignore it).
+#
+# Search de-indexing of the V2 docs is handled SEPARATELY, on the v2-archive
+# branch, by a <meta name="robots" content="noindex"> tag injected into every
+# page's <head> via a _templates/layout.html theme override.
+#
+# IMPORTANT -- do NOT add a "User-agent: *  Disallow: /en/v2/" rule:
+#   robots.txt Disallow and the noindex meta tag are mutually exclusive on the same
+#   path. A path blocked here is never fetched, so a search crawler would never see
+#   the page's noindex meta and could keep a bare, snippet-less URL in its index.
+#   Generic search bots (Googlebot, Bingbot, ...) must stay ALLOWED so they can read
+#   the noindex tag and drop the V2 pages. Only AI-training / data-collection
+#   crawlers are blocked below.
+
+# --- OpenAI ---
+User-agent: GPTBot
+Disallow: /en/v2/
+
+User-agent: OAI-SearchBot
+Disallow: /en/v2/
+
+User-agent: ChatGPT-User
+Disallow: /en/v2/
+
+# --- Anthropic ---
+User-agent: ClaudeBot
+Disallow: /en/v2/
+
+User-agent: anthropic-ai
+Disallow: /en/v2/
+
+User-agent: Claude-Web
+Disallow: /en/v2/
+
+# --- Google (Gemini / Vertex AI training; distinct from Googlebot search) ---
+User-agent: Google-Extended
+Disallow: /en/v2/
+
+# --- Common Crawl (open dataset that feeds many LLM training corpora) ---
+User-agent: CCBot
+Disallow: /en/v2/
+
+# --- Meta (Llama training) ---
+User-agent: Meta-ExternalAgent
+Disallow: /en/v2/
+
+User-agent: meta-externalagent
+Disallow: /en/v2/
+
+User-agent: FacebookBot
+Disallow: /en/v2/
+
+# --- Amazon ---
+User-agent: Amazonbot
+Disallow: /en/v2/
+
+# --- Apple (Apple Intelligence training) ---
+User-agent: Applebot-Extended
+Disallow: /en/v2/
+
+# --- ByteDance ---
+User-agent: Bytespider
+Disallow: /en/v2/
+
+# --- Perplexity ---
+User-agent: PerplexityBot
+Disallow: /en/v2/
+
+# --- Cohere ---
+User-agent: cohere-ai
+Disallow: /en/v2/
+
+# --- Others (search-adjacent AI answer engines / data collectors) ---
+User-agent: Diffbot
+Disallow: /en/v2/
+
+User-agent: Omgilibot
+Disallow: /en/v2/
+
+User-agent: Omgili
+Disallow: /en/v2/
+
+User-agent: YouBot
+Disallow: /en/v2/
+
+User-agent: ImagesiftBot
+Disallow: /en/v2/
+
+User-agent: PetalBot
+Disallow: /en/v2/
+
+User-agent: Timpibot
+Disallow: /en/v2/


### PR DESCRIPTION
Add a note to the top of every page stating that this documentation covers only the example notebooks built on SageMaker Python SDK v3, and pointing readers at the v2 build for the archived SDK 2.x notebooks. The note is injected through a theme layout override rather than rst_prolog so that it also reaches theme-generated pages with no source file, such as the search and index pages.

Also add a robots.txt that asks AI training and data-collection crawlers not to fetch /en/v2/, so that future model training sees the V3 examples rather than the deprecated V2 ones. This file has to live on the default version because ReadTheDocs serves robots.txt only from the default version at the domain root.

Generic search crawlers are deliberately left allowed: a Disallow rule would stop them from ever fetching the V2 pages and therefore from seeing the noindex tag added on the v2-archive branch.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have verified that my PR does not contain any new notebook/s which demonstrate a SageMaker functionality already showcased by another existing notebook in the repository
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/default/CONTRIBUTING.md) doc and adhered to the guidelines regarding folder placement, notebook naming convention and example notebook best practices
- [ ] I have updated the necessary documentation, including the README of the appropriate folder as well as the index.rst file
- [ ] I have tested my notebook(s) and ensured it runs end-to-end
- [ ] I have linted my notebook(s) and code using `python3 -m black -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
