### PR TITLE
docs: Mark the V2 example notebooks as deprecated and de-index them

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -1,0 +1,38 @@
+{# Theme layout override for the deprecated V2 example notebooks build. #}
+{#                                                                              #}
+{# 1. extrahead: injects <meta name="robots" content="noindex"> into every       #}
+{#    page's <head> so search engines drop these V2 pages from their results.    #}
+{#    No <link rel="canonical"> is emitted, and html_baseurl is intentionally    #}
+{#    NOT set: the V3 site has a different folder structure and none of the      #}
+{#    notebooks here has a same-path V3 counterpart, so a canonical would point  #}
+{#    at URLs that do not exist. noindex alone is the correct signal here, and   #}
+{#    noindex plus canonical on the same page are contradictory guidance.        #}
+{#                                                                              #}
+{#    Note that /en/v2/ is NOT disallowed in robots.txt (which lives on the      #}
+{#    default branch). That is deliberate and required: a disallowed page is     #}
+{#    never fetched, so a search crawler would never see the noindex below.      #}
+{#                                                                              #}
+{# 2. document: places the deprecation note at the top of the main content area  #}
+{#    of EVERY page -- including theme-generated pages with no source file       #}
+{#    (genindex, search) that rst_prolog and nbsphinx_prolog cannot reach. The   #}
+{#    markup mirrors a Sphinx ".. note::" admonition so it picks up the theme's  #}
+{#    own admonition styling.                                                   #}
+{% extends "!layout.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  <meta name="robots" content="noindex">
+{% endblock %}
+
+{% block document %}
+  <div class="admonition note">
+    <p class="admonition-title">Note</p>
+    <p>Version 2.x of the SageMaker Python SDK is on a deprecation path.
+    For the latest features and continued support, see the SageMaker Python SDK
+    <a class="reference external" href="https://sagemaker.readthedocs.io/en/stable/">V3 documentation</a>.</p>
+    <p>This site contains only the example notebooks built on SDK 2.x. For notebooks
+    built on SDK v3, see the
+    <a class="reference external" href="https://sagemaker-examples.readthedocs.io/en/latest/">v3 example notebooks documentation</a>.</p>
+  </div>
+  {{ super() }}
+{% endblock %}


### PR DESCRIPTION
Add a note to the top of every page stating that version 2.x of the SageMaker Python SDK is on a deprecation path, pointing at the V3 SDK documentation for current features, and pointing at the V3 example notebooks site for notebooks built on the current SDK.

Also emit <meta name="robots" content="noindex"> on every page so that search engines drop these archived V2 pages from their results and surface the V3 examples instead.

Both are injected through a theme layout override rather than rst_prolog so that they also reach theme-generated pages with no source file, such as the search and index pages.

No canonical link is emitted and html_baseurl is deliberately left unset: the V3 site uses a different folder structure and none of the notebooks archived here has a same-path counterpart there, so a canonical would point at URLs that do not exist.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have verified that my PR does not contain any new notebook/s which demonstrate a SageMaker functionality already showcased by another existing notebook in the repository
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/default/CONTRIBUTING.md) doc and adhered to the guidelines regarding folder placement, notebook naming convention and example notebook best practices
- [ ] I have updated the necessary documentation, including the README of the appropriate folder as well as the index.rst file
- [ ] I have tested my notebook(s) and ensured it runs end-to-end
- [ ] I have linted my notebook(s) and code using `python3 -m black -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
